### PR TITLE
Misleading comment :)

### DIFF
--- a/libraries/LiquidCrystal/LiquidCrystal.cpp
+++ b/libraries/LiquidCrystal/LiquidCrystal.cpp
@@ -122,7 +122,7 @@ void LiquidCrystal::begin(uint8_t cols, uint8_t lines, uint8_t dotsize) {
     write4bits(0x03); 
     delayMicroseconds(150);
 
-    // finally, set to 8-bit interface
+    // finally, set to 4-bit interface
     write4bits(0x02); 
   } else {
     // this is according to the hitachi HD44780 datasheet


### PR DESCRIPTION
This commit is a minor correction for a misleading comment in the LCD library. It said initializing "8-bit" when it was really initializing "4-bit" mode. got me a little confused when i tried to port to a project i am doing on atmega48

Cheers!
