### PR TITLE
Allow use of unpatched rxtx

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -963,6 +963,7 @@ public class Editor extends JFrame implements RunnerListener {
       }
       if ( SerialPorts != null ) {
         System.setProperty("gnu.io.rxtx.SerialPorts", SerialPorts);
+        serialScanned = true;
       }
     }
 


### PR DESCRIPTION
Following on from the discussion in http://code.google.com/p/arduino/issues/detail?id=193, this change overrides the serial devices used by rxtx without having to provide a patched version.
