### PR TITLE
Extend Stream to provide remove(count) and peek(offset)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+app/bin/
+app/pde.jar
+build/.DS_Store
+build/macosx/work/
+core/bin/
+core/core.jar

--- a/hardware/arduino/cores/arduino/HardwareSerial.cpp
+++ b/hardware/arduino/cores/arduino/HardwareSerial.cpp
@@ -37,12 +37,6 @@
 // using a ring buffer (I think), in which rx_buffer_head is the index of the
 // location to which to write the next incoming character and rx_buffer_tail
 // is the index of the location from which to read.
-#if (RAMEND < 1000)
-  #define RX_BUFFER_SIZE 32
-#else
-  #define RX_BUFFER_SIZE 128
-#endif
-
 struct ring_buffer
 {
   unsigned char buffer[RX_BUFFER_SIZE];
@@ -236,11 +230,25 @@ int HardwareSerial::available(void)
 
 int HardwareSerial::peek(void)
 {
+    return peek(0);
+}
+
+int HardwareSerial::peek(uint8_t offset)
+{
   if (_rx_buffer->head == _rx_buffer->tail) {
     return -1;
   } else {
-    return _rx_buffer->buffer[_rx_buffer->tail];
+    return _rx_buffer->buffer[(_rx_buffer->tail + offset) % RX_BUFFER_SIZE];
   }
+}
+
+/**
+    Removes count number of bytes from the buffer.
+**/
+void HardwareSerial::remove(uint8_t count) {
+    if (_rx_buffer->head != _rx_buffer->tail) {
+        _rx_buffer->tail = (_rx_buffer->tail + count) % RX_BUFFER_SIZE;
+    }
 }
 
 int HardwareSerial::read(void)

--- a/hardware/arduino/cores/arduino/HardwareSerial.h
+++ b/hardware/arduino/cores/arduino/HardwareSerial.h
@@ -26,6 +26,16 @@
 
 #include "Stream.h"
 
+// Define constants and variables for buffering incoming serial data.  We're
+// using a ring buffer (I think), in which rx_buffer_head is the index of the
+// location to which to write the next incoming character and rx_buffer_tail
+// is the index of the location from which to read.
+#if (RAMEND < 1000)
+  #define RX_BUFFER_SIZE 32
+#else
+  #define RX_BUFFER_SIZE 128
+#endif
+
 struct ring_buffer;
 
 class HardwareSerial : public Stream
@@ -52,6 +62,8 @@ class HardwareSerial : public Stream
     void end();
     virtual int available(void);
     virtual int peek(void);
+    virtual int peek(uint8_t);
+    virtual void remove(uint8_t);
     virtual int read(void);
     virtual void flush(void);
     virtual void write(uint8_t);

--- a/hardware/arduino/cores/arduino/HardwareSerial.h
+++ b/hardware/arduino/cores/arduino/HardwareSerial.h
@@ -60,13 +60,16 @@ class HardwareSerial : public Stream
       uint8_t rxen, uint8_t txen, uint8_t rxcie, uint8_t udre, uint8_t u2x);
     void begin(long);
     void end();
-    virtual int available(void);
-    virtual int peek(void);
-    virtual int peek(uint8_t);
-    virtual void remove(uint8_t);
-    virtual int read(void);
-    virtual void flush(void);
-    virtual void write(uint8_t);
+    
+    // @todo I think these only need to be declared virtual if HWSerial's going to be extended
+    int available(void);
+    int peek(void);
+    int peek(uint8_t);
+    void remove(uint8_t);
+    int read(void);
+    void flush(void);
+    void write(uint8_t);
+    
     using Print::write; // pull in write(str) and write(buf, size) from Print
 };
 

--- a/hardware/arduino/cores/arduino/Stream.h
+++ b/hardware/arduino/cores/arduino/Stream.h
@@ -44,7 +44,7 @@ class Stream : public Print
      *
      * Default implementation for classes without a buffer.
      */
-    int peek(uint8_t offset) {
+    virtual int peek(uint8_t offset) {
       return (offset == 0) ? peek() : -1;
     }
     
@@ -53,7 +53,7 @@ class Stream : public Print
      *
      * Inefficient default implementation.
      */
-    void remove(uint8_t count) {
+    virtual void remove(uint8_t count) {
       for (uint8_t i = 0; i < count; i++) {
         read();
       }

--- a/hardware/arduino/cores/arduino/Stream.h
+++ b/hardware/arduino/cores/arduino/Stream.h
@@ -28,8 +28,36 @@ class Stream : public Print
   public:
     virtual int available() = 0;
     virtual int read() = 0;
+    
+    /*
+     * Return the next byte waiting to be read.
+     */
     virtual int peek() = 0;
+    
+    /*
+     * Forces output to the underlying device.
+     */
     virtual void flush() = 0;
+    
+    /*
+     * Return the byte offset places from the beginning of the buffer.
+     *
+     * Default implementation for classes without a buffer.
+     */
+    int peek(uint8_t offset) {
+      return (offset == 0) ? peek() : -1;
+    }
+    
+    /*
+     * Remove count bytes from the buffer.
+     *
+     * Inefficient default implementation.
+     */
+    void remove(uint8_t count) {
+      for (uint8_t i = 0; i < count; i++) {
+        read();
+      }
+    }
 };
 
 #endif


### PR DESCRIPTION
I needed to extend HardwareSerial to get more access to the internal buffer; for my project, it was wasteful to have two statically-allocated buffers for incoming serial data, but I needed to be able read arbitrary bytes of the receive buffer.  This is the result.  The comments on the individual commits should make it pretty clear what was done. :-)
