### PR TITLE
Change "Uploading to I/O board..." to "Compiling and uploading to I/O board..."

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -2275,7 +2275,7 @@ public class Editor extends JFrame implements RunnerListener {
     //if (!handleExportCheckModified()) return;
     toolbar.activate(EditorToolbar.EXPORT);
     console.clear();
-    statusNotice("Uploading to I/O Board...");
+    statusNotice("Compiling and uploading to I/O Board...");
 
     new Thread(verbose ? exportAppHandler : exportHandler).start();
   }


### PR DESCRIPTION
Hi all,
I have seen people who were not sure that uploading included compiling, so they compiled first, then uploaded in two different steps. I have also seen people be unsure about what was happening, unsettled by the fact that "sometimes it takes longer" before it starts.
Both effects should be reduced by this tiny little change.

thanks for pulling,
Manuel
