### PR TITLE
Don't set TWSTO in tw_stop for slave transactions. This fixes non-working

### DIFF
--- a/libraries/Wire/utility/twi.c
+++ b/libraries/Wire/utility/twi.c
@@ -315,6 +315,21 @@ void twi_stop(void)
 }
 
 /* 
+ * Function twi_stop_slv
+ * Desc     relinquishes bus master status
+ * Input    none
+ * Output   none
+ */
+void twi_stop_slv(void)
+{
+  // send stop condition
+  TWCR = _BV(TWEN) | _BV(TWIE) | _BV(TWEA) | _BV(TWINT);
+
+  // update twi state
+  twi_state = TWI_READY;
+}
+
+/* 
  * Function twi_releaseBus
  * Desc     releases bus control
  * Input    none
@@ -414,7 +429,7 @@ SIGNAL(TWI_vect)
         twi_rxBuffer[twi_rxBufferIndex] = '\0';
       }
       // sends ack and stops interface for clock stretching
-      twi_stop();
+      twi_stop_slv();
       // callback to user defined callback
       twi_onSlaveReceive(twi_rxBuffer, twi_rxBufferIndex);
       // since we submit rx buffer to "wire" library, we can reset it

--- a/libraries/Wire/utility/twi.h
+++ b/libraries/Wire/utility/twi.h
@@ -47,6 +47,7 @@
   void twi_attachSlaveTxEvent( void (*)(void) );
   void twi_reply(uint8_t);
   void twi_stop(void);
+  void twi_stop_slv(void);
   void twi_releaseBus(void);
 
 #endif


### PR DESCRIPTION
Don't set TWSTO in tw_stop for slave transactions. This fixes non-working repeated-start sequences.