### PR TITLE
Prevent infinite loops acquiring DHCP address with some servers

### DIFF
--- a/libraries/Ethernet/Dhcp.h
+++ b/libraries/Ethernet/Dhcp.h
@@ -143,6 +143,7 @@ private:
   
   void presend_DHCP();
   void send_DHCP_MESSAGE(uint8_t, uint16_t);
+  inline void chomp(uint8_t option_length_total, uint8_t read_length);
   
   uint8_t parseDHCPResponse(unsigned long responseTimeout, uint32_t& transactionId);
 public:


### PR DESCRIPTION
Compliance with RFC1533 is pretty important.

This prevents some infinite loops encountered when trying to parse DHCP
replies that contained, for instance, multiple dns servers.  Huawei B560 3g
wireless access points (at least) reply in such a (valid, legal) fashion.
