### PR TITLE
Support building packets in w5100 packet memory.

### DIFF
--- a/libraries/Ethernet/Client.cpp
+++ b/libraries/Ethernet/Client.cpp
@@ -19,6 +19,12 @@ Client::Client(uint8_t sock) : _sock(sock) {
 Client::Client(uint8_t *ip, uint16_t port) : _ip(ip), _port(port), _sock(MAX_SOCK_NUM) {
 }
 
+uint8_t Client::connect(uint8_t* remote_ip, uint16_t remote_port) {
+    _ip = remote_ip;
+    _port = remote_port;
+    return connect();
+}
+
 uint8_t Client::connect() {
   if (_sock != MAX_SOCK_NUM)
     return 0;
@@ -50,7 +56,7 @@ uint8_t Client::connect() {
       return 0;
     }
   }
-
+  _offset = 0;
   return 1;
 }
 
@@ -67,6 +73,23 @@ void Client::write(const char *str) {
 void Client::write(const uint8_t *buf, size_t size) {
   if (_sock != MAX_SOCK_NUM)
     send(_sock, buf, size);
+}
+
+uint16_t Client::addData(uint8_t b) {
+    return addData(&b, 1);
+}
+
+uint16_t Client::addData(uint8_t *buf, uint16_t len)
+{
+  uint16_t bytes_written = bufferData(_sock, _offset, buf, len);
+  _offset += bytes_written;
+  return bytes_written;
+}
+
+uint16_t Client::finishSendPacket()
+{
+  _offset = 0;
+  return sendTCP(_sock);
 }
 
 int Client::available() {

--- a/libraries/Ethernet/Client.h
+++ b/libraries/Ethernet/Client.h
@@ -12,6 +12,7 @@ public:
 
   uint8_t status();
   uint8_t connect();
+  uint8_t connect(uint8_t *remote_ip, uint16_t remote_port);
   virtual void write(uint8_t);
   virtual void write(const char *str);
   virtual void write(const uint8_t *buf, size_t size);
@@ -26,6 +27,21 @@ public:
   uint8_t operator!=(int);
   operator bool();
 
+  // Add data to the packet about to be sent.  Only valid to call this after
+  // a call to connect or finishSendPacket.
+  // @param buf - data to append to the outgoing packet
+  // @param len - number of bytes to append from buf
+  // @return Number of bytes successfully appended
+  uint16_t addData(uint8_t *buf, uint16_t len);
+
+  // Add a single byte of data to the packet in progress
+  uint16_t addData(uint8_t b);
+
+  // Send the packet.  Only valid to call this after a call to connect()
+  // and at least one call to addData. Or finishSendPacket, and then more addData()
+  // @return 1 if successful, or 0 if there was an error
+  uint16_t finishSendPacket(); //send the packet
+
   friend class Server;
 
 private:
@@ -33,6 +49,7 @@ private:
   uint8_t _sock;
   uint8_t *_ip;
   uint16_t _port;
+  uint16_t _offset; // offset into the packet being sent (used in streaming API)
 };
 
 #endif

--- a/libraries/Ethernet/utility/socket.h
+++ b/libraries/Ethernet/utility/socket.h
@@ -16,5 +16,18 @@ extern uint16_t recvfrom(SOCKET s, uint8_t * buf, uint16_t len, uint8_t * addr, 
 
 extern uint16_t igmpsend(SOCKET s, const uint8_t * buf, uint16_t len);
 
+/*
+  @brief This function copies up to len bytes of data from buf into a UDP datagram to be
+  sent later by sendUDP.  Allows datagrams to be built up from a series of bufferData calls.
+  @return Number of bytes successfully buffered
+*/
+uint16_t bufferData(SOCKET s, uint16_t offset, const uint8_t* buf, uint16_t len);
+/*
+  @brief Send a TCP datagram built up from a sequence of connect() followed by one or more
+  calls to bufferData.
+  @return 1 if packet was successfully sent, or 0 if there was an error
+ */
+uint16_t sendTCP(SOCKET s);
+
 #endif
 /* _SOCKET_H_ */


### PR DESCRIPTION
This is a fix for http://code.google.com/p/arduino/issues/detail?id=563

It is based on work in the UDP library, even though that library no longer
contains support for prebuffering packets.
