### PR TITLE
Added USBasp to programmers list

### DIFF
--- a/hardware/arduino/programmers.txt
+++ b/hardware/arduino/programmers.txt
@@ -18,3 +18,7 @@ arduinoisp.name=Arduino as ISP
 arduinoisp.communication=serial
 arduinoisp.protocol=stk500v1
 arduinoisp.speed=19200
+
+usbasp.name=USBasp
+usbasp.communication=usb
+usbasp.protocol=usbasp


### PR DESCRIPTION
USBasp has been an avrdude compatible programmer for quite a few time and hasn't been added to the list, although people in Issue 121 from Google Code asked for it.

I have tested it with 1.0 beta 4 in Windows 7 64bits and wrote the UNO/optiboot bootloader in a new ATmega328P and used the 'Upload using programmer' feature, both things worked flawlessly.
