### PR TITLE
Wire library support for TWI General Call

### DIFF
--- a/libraries/SoftwareSerial/SoftwareSerial.h
+++ b/libraries/SoftwareSerial/SoftwareSerial.h
@@ -47,7 +47,8 @@ http://arduiniana.org.
 class SoftwareSerial : public Stream
 {
 private:
-  // per object data
+  // per object data	
+  uint8_t _sharedRxTx;
   uint8_t _receivePin;
   uint8_t _receiveBitMask;
   volatile uint8_t *_receivePortRegister;

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -40,8 +40,9 @@ class TwoWire : public Stream
     static uint8_t transmitting;
     static void (*user_onRequest)(void);
     static void (*user_onReceive)(int);
+	static void (*user_onGcallReceive)(int);
     static void onRequestService(void);
-    static void onReceiveService(uint8_t*, int);
+    static void onReceiveService(uint8_t*, int,uint8_t);
   public:
     TwoWire();
     void begin();
@@ -59,6 +60,7 @@ class TwoWire : public Stream
     virtual int peek(void);
 	virtual void flush(void);
     void onReceive( void (*)(int) );
+	void onReceive( void (*)(int), void (*)(int) );
     void onRequest( void (*)(void) );
   
     using Print::write;

--- a/libraries/Wire/examples/general_call_master/general_call_master.ino
+++ b/libraries/Wire/examples/general_call_master/general_call_master.ino
@@ -1,0 +1,69 @@
+/*
+  * Author: Ed Baafi 
+  * Date: 11/11/11 
+  *
+  * This example demonstrates the TWI (I2C) "General Call" capabilities.
+  *
+  * General call is like a broadcast that can be received by many listeners at the same same. This
+  * is useful when you don't know the address of the device you want to talk to or it can be used as
+  * a sort of interrupt over the TWI (I2C). For more info on General Call, please see the I2C specs.
+  *
+  * The Wire library now supports General Call by adding a second receive callback to Wire.onReceive()
+  * This second callback will be called whenever a message is received over the general call address.  
+  *
+  * This code is for the master device. Instructions are in comments for the slave device code.
+  *  
+  */
+
+#include <Wire.h>
+
+//button to send a general call message (connect button between pin10 and ground)
+#define GENERAL_CALL_ADDR_BUTTON 10
+//button to send a normal i2c message (connect button between pin 9 and ground)
+#define SLAVE_ADDR_BUTTON 9
+
+#define SLAVE_ADDRESS 0x9
+#define GENERAL_CALL_ADDR 0x0
+
+//store state of slave message button 
+boolean slave_btn_state = HIGH;
+//store state of general call message button
+boolean general_call_btn_state = HIGH;
+
+void setup() {
+  Serial.begin(9600);
+  
+  //setup general call button as input with internal pullup
+  pinMode(GENERAL_CALL_ADDR_BUTTON, INPUT);
+  digitalWrite(GENERAL_CALL_ADDR_BUTTON, HIGH);
+  
+  //setup normal i2c send button as input with internal pullup
+  pinMode(SLAVE_ADDR_BUTTON, INPUT);
+  digitalWrite(SLAVE_ADDR_BUTTON, HIGH);
+  
+  //setup TWI as master
+  Wire.begin();
+  
+}
+
+void loop() {
+  //if general call button state changes, send new state over message to general call address
+  if (digitalRead(GENERAL_CALL_ADDR_BUTTON) != general_call_btn_state){
+    general_call_btn_state = !general_call_btn_state;
+    Wire.beginTransmission(GENERAL_CALL_ADDR);
+    Wire.write(general_call_btn_state);
+    Wire.endTransmission();
+    delay(100);
+  }
+  
+  //if slave address send button changes state, send new state over message to slave address
+  if (digitalRead(SLAVE_ADDR_BUTTON) != slave_btn_state){
+    slave_btn_state = !slave_btn_state;
+    Wire.beginTransmission(SLAVE_ADDRESS);
+    Wire.write(slave_btn_state);
+    Wire.endTransmission();
+    //we need a small delay or we'll crash the Wire library - TODO - fix it
+    delay(100);
+  }
+  
+}

--- a/libraries/Wire/examples/general_call_slave/general_call_slave.ino
+++ b/libraries/Wire/examples/general_call_slave/general_call_slave.ino
@@ -1,0 +1,84 @@
+/*
+  * Author: Ed Baafi 
+  * Date: 11/11/11 
+  *
+  * This example demonstrates the TWI (I2C) "General Call" capabilities.
+  *
+  * General call is like a broadcast that can be received by many listeners at the same same. This
+  * is useful when you don't know the address of the device you want to talk to or it can be used as
+  * a sort of interrupt over the TWI (I2C). For more info on General Call, please see the I2C specs.
+  *
+  * The Wire library now supports General Call by adding a second receive callback to Wire.onReceive()
+  * This second callback will be called whenever a message is received over the general call address.  
+  *
+  * 1) This code is for the slave device.  Connect the slave device (through usb) to your PC and open  
+  *  up the serial monitor (set it to 9600 bps).  You can optionally connect two LEDs to pins 12 and 11
+  *
+  * 2) On the master device, connect a button between pin10 and ground and another between pin9 
+  *  and ground.  The pin10 button will send its state to the general call address (can be picked up by 
+  *  any attached slave device) and the pin9 button will sent through to a specific slave address. 
+  * 
+  * 3) Connect the SCL and SDA lines from the slave to the master.  For UNO boards SDA is on analog pin
+  *  4 and SCL is on analog pin 5.
+  *
+  * 4) Pressing one button will send a message to general call and the other will send a message through 
+  *  the slave's address.  Want to go further, add a second slave device and/or use the LEDs to see which
+  *  address is being sent to.
+  */
+  
+#include <Wire.h>
+
+//led to tie to the master's general call i2c button
+#define GENERAL_CALL_RECV_LED 12
+//led to tie to the master's normal i2c button
+#define RECV_LED 11
+
+#define MY_ADDRESS 0x9
+
+void setup() {
+  Serial.begin(9600);
+ 
+  //set general call led pin as output and set low (turn off)
+  pinMode(GENERAL_CALL_RECV_LED, OUTPUT);
+  digitalWrite(GENERAL_CALL_RECV_LED, LOW);
+  
+  //set slave receive led pin as output and set low (turn off)
+  pinMode(RECV_LED, OUTPUT);
+  digitalWrite(RECV_LED, LOW);
+  
+  //setup TWI as slave and set address
+  Wire.begin(MY_ADDRESS);
+  
+  //setup first callback to fire when data is received on MY_ADDRESS
+  //and the second when a data is received on the general call address (0x0)
+  //if you omit the second callback, general call wil not be enabled in the Wire library
+  Wire.onReceive(receiveCallback,generalCallreceiveCallback);
+  
+}
+
+void loop() {
+   //do nothing - wait for callbacks to fire
+}
+
+void receiveCallback(int howMany){
+     //print data sent to MY_ADDRESS to the serial monitor
+     Serial.print("\nRECIEIVED BYTE FROM SLAVE ADDRESS: ");
+     while (Wire.available() > 0 && howMany > 0){
+        boolean b = Wire.read();
+        Serial.print(b, DEC);
+        digitalWrite(RECV_LED, !b);
+        howMany--;
+     }
+}
+
+void generalCallreceiveCallback(int howMany){
+      //print data sent to the general call address to the serial monitor
+      Serial.print("\nRECEIVED BYTE FROM GENERAL CALL ADDRESS: "); 
+      while (Wire.available() > 0 && howMany > 0){
+        boolean b = Wire.read();
+        Serial.print(b, DEC);
+        digitalWrite(GENERAL_CALL_RECV_LED, !b);
+        howMany--;
+      } 
+}
+

--- a/libraries/Wire/utility/twi.h
+++ b/libraries/Wire/utility/twi.h
@@ -40,10 +40,11 @@
   
   void twi_init(void);
   void twi_setAddress(uint8_t);
+  void twi_enableGenCall(void);
   uint8_t twi_readFrom(uint8_t, uint8_t*, uint8_t);
   uint8_t twi_writeTo(uint8_t, uint8_t*, uint8_t, uint8_t);
   uint8_t twi_transmit(const uint8_t*, uint8_t);
-  void twi_attachSlaveRxEvent( void (*)(uint8_t*, int) );
+  void twi_attachSlaveRxEvent( void (*)(uint8_t*, int, uint8_t) );
   void twi_attachSlaveTxEvent( void (*)(void) );
   void twi_reply(uint8_t);
   void twi_stop(void);


### PR DESCRIPTION
This patch adds TWI (I2C) "General Call" capabilities to the Wire library

General call is like a broadcast that can be received by many listeners at the same same. This is useful when you don't know the address of the device you want to talk to or it can be used as a sort of interrupt over the TWI. While it was possible to enable general call from an Arduino user program simply by setting the TWGCE bit in the TWAR, it was not possible to determine which address the data came from. 

TwoWire::onReceive is overridden to add an optional second callback which will be called whenever data is received over the general call address.  

This patch addresses issue 120 (http://code.google.com/p/arduino/issues/detail?id=120) and its use is reasonably well documented in the example code.  

Thanks,
Ed
