### PR TITLE
EthernetClient: Fix for CLOSE_WAIT Bug

### DIFF
--- a/libraries/Ethernet/EthernetClient.cpp
+++ b/libraries/Ethernet/EthernetClient.cpp
@@ -41,7 +41,7 @@ int EthernetClient::connect(IPAddress ip, uint16_t port) {
 
   for (int i = 0; i < MAX_SOCK_NUM; i++) {
     uint8_t s = W5100.readSnSR(i);
-    if (s == SnSR::CLOSED || s == SnSR::FIN_WAIT) {
+    if (s == SnSR::CLOSED || s == SnSR::FIN_WAIT || s == SnSR::CLOSE_WAIT) {
       _sock = i;
       break;
     }


### PR DESCRIPTION
This is a fix for an EthernetClient bug, as per the following thread http://forum.freetronics.com/viewtopic.php?t=176. I haven't seen that PULL request anywhere and from what I can tell, the discovery of the error is a recent one.

Kudos to mr-russ for finding a fix.
