### PR TITLE
Adding the "dont_erase" option to board preferences

### DIFF
--- a/app/src/processing/app/debug/AvrdudeUploader.java
+++ b/app/src/processing/app/debug/AvrdudeUploader.java
@@ -80,7 +80,9 @@ public class AvrdudeUploader extends Uploader  {
       "-P" + (Base.isWindows() ? "\\\\.\\" : "") + Preferences.get("serial.port"));
     commandDownloader.add(
       "-b" + Integer.parseInt(boardPreferences.get("upload.speed")));
-    commandDownloader.add("-D"); // don't erase
+    if (!boardPreferences.containsKey("upload.dont_erase")
+        || boardPreferences.get("upload.dont_erase").toLowerCase().equals("false"))
+	commandDownloader.add("-D"); // don't erase
     if (!Preferences.getBoolean("upload.verify")) commandDownloader.add("-V"); // disable verify
     commandDownloader.add("-Uflash:w:" + buildPath + File.separator + className + ".hex:i");
 

--- a/app/src/processing/app/debug/AvrdudeUploader.java
+++ b/app/src/processing/app/debug/AvrdudeUploader.java
@@ -81,7 +81,7 @@ public class AvrdudeUploader extends Uploader  {
     commandDownloader.add(
       "-b" + Integer.parseInt(boardPreferences.get("upload.speed")));
     if (!boardPreferences.containsKey("upload.dont_erase")
-        || boardPreferences.get("upload.dont_erase").toLowerCase().equals("false"))
+        || boardPreferences.get("upload.dont_erase").toLowerCase().equals("true"))
 	commandDownloader.add("-D"); // don't erase
     if (!Preferences.getBoolean("upload.verify")) commandDownloader.add("-V"); // disable verify
     commandDownloader.add("-Uflash:w:" + buildPath + File.separator + className + ".hex:i");


### PR DESCRIPTION
Some AVR require to be erased before uploading a new program. But
the Arduino IDE always pass the '-D' (dont erase) option to avrdude.

This patch allow to disable this feature on a per-board basis.