### PR TITLE
Appdir with spaces on linux resulting in 'Error: Could not find or load main class processing.app.Base'

### DIFF
--- a/build/linux/dist/arduino
+++ b/build/linux/dist/arduino
@@ -1,8 +1,8 @@
 #!/bin/sh
  
-APPDIR="$(dirname -- $(readlink -f -- "${0}") )"
+APPDIR=$(dirname -- "$(readlink -f -- "${0}")" )
 
-cd $APPDIR
+cd "$APPDIR"
  
 for LIB in \
     java/lib/rt.jar \


### PR DESCRIPTION
The arduino script can now handle an appdir with spaces (e.g. /home/user/Arduino IDE).
Without that fix I got a really strange error: 'Error: Could not find or load main class processing.app.Base' and the IDE refused to start.
