### PR TITLE
Lcd oop extensions

### DIFF
--- a/libraries/LiquidCrystal/LiquidCrystal.cpp
+++ b/libraries/LiquidCrystal/LiquidCrystal.cpp
@@ -78,19 +78,17 @@ void LiquidCrystal::init(uint8_t fourbitmode, uint8_t rs, uint8_t rw, uint8_t en
     _displayfunction = LCD_4BITMODE | LCD_1LINE | LCD_5x8DOTS;
   else 
     _displayfunction = LCD_8BITMODE | LCD_1LINE | LCD_5x8DOTS;
-  
-  begin(16, 1);  
 }
 
-void LiquidCrystal::begin(uint8_t cols, uint8_t lines, uint8_t dotsize) {
-  if (lines > 1) {
+void LiquidCrystal::begin(uint8_t cols, uint8_t rows, uint8_t dotsize) {
+  if (rows > 1) {
     _displayfunction |= LCD_2LINE;
   }
-  _numlines = lines;
-  _currline = 0;
+  _numcols = cols;
+  _numrows = rows;
 
   // for some 1 line displays you can select a 10 pixel high font
-  if ((dotsize != 0) && (lines == 1)) {
+  if ((dotsize != 0) && (rows == 1)) {
     _displayfunction |= LCD_5x10DOTS;
   }
 
@@ -151,7 +149,7 @@ void LiquidCrystal::begin(uint8_t cols, uint8_t lines, uint8_t dotsize) {
   clear();
 
   // Initialize to default text direction (for romance languages)
-  _displaymode = LCD_ENTRYLEFT | LCD_ENTRYSHIFTDECREMENT;
+  _displaymode = LCD_ENTRYLEFT | LCD_ENTRYSHIFTDISABLE;
   // set the entry mode
   command(LCD_ENTRYMODESET | _displaymode);
 
@@ -172,9 +170,9 @@ void LiquidCrystal::home()
 
 void LiquidCrystal::setCursor(uint8_t col, uint8_t row)
 {
-  int row_offsets[] = { 0x00, 0x40, 0x14, 0x54 };
-  if ( row >= _numlines ) {
-    row = _numlines-1;    // we count rows starting w/0
+  int row_offsets[] = { 0x00, 0x40, _numcols, 0x40 + _numcols };
+  if ( row >= _numrows ) {
+    row = _numrows - 1;    // we count rows starting w/0
   }
   
   command(LCD_SETDDRAMADDR | (col + row_offsets[row]));
@@ -230,15 +228,15 @@ void LiquidCrystal::rightToLeft(void) {
   command(LCD_ENTRYMODESET | _displaymode);
 }
 
-// This will 'right justify' text from the cursor
+// This will move the text on write, looks like a fixed cursor
 void LiquidCrystal::autoscroll(void) {
-  _displaymode |= LCD_ENTRYSHIFTINCREMENT;
+  _displaymode |= LCD_ENTRYSHIFTENABLE;
   command(LCD_ENTRYMODESET | _displaymode);
 }
 
-// This will 'left justify' text from the cursor
+// This will fix the text and moves the cursor on write
 void LiquidCrystal::noAutoscroll(void) {
-  _displaymode &= ~LCD_ENTRYSHIFTINCREMENT;
+  _displaymode &= ~LCD_ENTRYSHIFTENABLE;
   command(LCD_ENTRYMODESET | _displaymode);
 }
 

--- a/libraries/LiquidCrystal/LiquidCrystal.cpp
+++ b/libraries/LiquidCrystal/LiquidCrystal.cpp
@@ -24,6 +24,11 @@
 // can't assume that its in that state when a sketch starts (and the
 // LiquidCrystal constructor is called).
 
+LiquidCrystal::LiquidCrystal()
+{
+  // Not used but makes C++ happy when inherited
+}
+
 LiquidCrystal::LiquidCrystal(uint8_t rs, uint8_t rw, uint8_t enable,
 			     uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
 			     uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7)

--- a/libraries/LiquidCrystal/LiquidCrystal.h
+++ b/libraries/LiquidCrystal/LiquidCrystal.h
@@ -51,9 +51,9 @@ public:
 		uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
 		uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7);
   LiquidCrystal(uint8_t rs, uint8_t rw, uint8_t enable,
-		uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3);
+		uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7);
   LiquidCrystal(uint8_t rs, uint8_t enable,
-		uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3);
+		uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7);
 
   void init(uint8_t fourbitmode, uint8_t rs, uint8_t rw, uint8_t enable,
 	    uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
@@ -82,14 +82,13 @@ public:
   virtual size_t write(uint8_t);
   virtual void command(uint8_t);
   
+  inline LiquidCrystal& operator() (uint8_t x, uint8_t y) { setCursor(x,y); return *this;};  //use along w Streaming.h to support: lcd(col,line)<<"a="<<a;
   using Print::write;
 protected:
   LiquidCrystal();
 
   virtual void send(uint8_t, uint8_t);
-  virtual void write4bits(uint8_t);
-  virtual void write8bits(uint8_t);
-  virtual void pulseEnable();
+  virtual void writebits(uint8_t, uint8_t);
 
   uint8_t _rs_pin; // LOW: command.  HIGH: character.
   uint8_t _rw_pin; // LOW: write to LCD.  HIGH: read from LCD.
@@ -99,7 +98,7 @@ protected:
   uint8_t _displayfunction;
   uint8_t _displaycontrol;
   uint8_t _displaymode;
-
+  
   uint8_t _numcols;
   uint8_t _numrows;
 };

--- a/libraries/LiquidCrystal/LiquidCrystal.h
+++ b/libraries/LiquidCrystal/LiquidCrystal.h
@@ -59,7 +59,7 @@ public:
 	    uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
 	    uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7);
     
-  void begin(uint8_t cols, uint8_t rows, uint8_t charsize = LCD_5x8DOTS);
+  virtual void begin(uint8_t cols, uint8_t rows, uint8_t charsize = LCD_5x8DOTS);
 
   void clear();
   void home();
@@ -80,14 +80,16 @@ public:
   void createChar(uint8_t, uint8_t[]);
   void setCursor(uint8_t, uint8_t); 
   virtual size_t write(uint8_t);
-  void command(uint8_t);
+  virtual void command(uint8_t);
   
   using Print::write;
-private:
-  void send(uint8_t, uint8_t);
-  void write4bits(uint8_t);
-  void write8bits(uint8_t);
-  void pulseEnable();
+protected:
+  LiquidCrystal();
+
+  virtual void send(uint8_t, uint8_t);
+  virtual void write4bits(uint8_t);
+  virtual void write8bits(uint8_t);
+  virtual void pulseEnable();
 
   uint8_t _rs_pin; // LOW: command.  HIGH: character.
   uint8_t _rw_pin; // LOW: write to LCD.  HIGH: read from LCD.

--- a/libraries/LiquidCrystal/LiquidCrystal.h
+++ b/libraries/LiquidCrystal/LiquidCrystal.h
@@ -17,8 +17,8 @@
 // flags for display entry mode
 #define LCD_ENTRYRIGHT 0x00
 #define LCD_ENTRYLEFT 0x02
-#define LCD_ENTRYSHIFTINCREMENT 0x01
-#define LCD_ENTRYSHIFTDECREMENT 0x00
+#define LCD_ENTRYSHIFTENABLE 0x01
+#define LCD_ENTRYSHIFTDISABLE 0x00
 
 // flags for display on/off control
 #define LCD_DISPLAYON 0x04
@@ -98,9 +98,8 @@ private:
   uint8_t _displaycontrol;
   uint8_t _displaymode;
 
-  uint8_t _initialized;
-
-  uint8_t _numlines,_currline;
+  uint8_t _numcols;
+  uint8_t _numrows;
 };
 
 #endif

--- a/libraries/LiquidCrystal/examples/CustomCharacter/CustomCharacter.ino
+++ b/libraries/LiquidCrystal/examples/CustomCharacter/CustomCharacter.ino
@@ -97,6 +97,9 @@ byte armsUp[8] = {
   0b01010
 };
 void setup() {
+  // set up the lcd's number of columns and rows:
+  lcd.begin(16, 2);
+
   // create a new character
   lcd.createChar(0, heart);
   // create a new character
@@ -108,8 +111,6 @@ void setup() {
   // create a new character
   lcd.createChar(4, armsUp);  
 
-  // set up the lcd's number of columns and rows: 
-  lcd.begin(16, 2);
   // Print a message to the lcd.
   lcd.print("I "); 
   lcd.write(0);


### PR DESCRIPTION
This Version of the Liquid Crystal Library can be inherited from other classes.
A possible usage is outlined in http://github.com/manfredjonsson/LiquidCrystalAddons

Because of the many changes, each commit contains one step of the improvements.

Commit 1: Fixes
- Remove unneeded variables.
- Make setCursor work for 16x2 and 16x4 displays.
- I consider LCD_ENTRYSHIFTINCREMENT etc to be a missnomer. Use ...ENABLE and 
  ...DISABLE instead. 
- Different variable names were used in definition and declaration of begin().
  Use the name "row" instead of "line" in all places to have a consistent 
  wording.
- Remove the begin() call from init() because some transport may not be 
  initialized in a global constructor (Some versions of the Wire (I2C) 
  library don't work when their begin() method is called inside a constructor 
  of a global object).

Commit 2: Minimal set of changes for inheritance
- Move functions and variables from private to protected.
- Add the virtual keyword to all functions which may need an override in an
  derived class.

Commit 3: Make it smaller
- Use the "-1" trick from rw for the data lines too. This enables the use of 
  one writebits() function instead of two. Pay attention to the fact that 
  pinMode is still in writebits(), this slows down each write to the LCD but 
  code is smaller compared to an additional initialization loop.
- Use the 4 upper bits of a byte in writebits() instead of the 4 lower bits 
  for 4 bit writes. Leads to an almost identical initialization for 4 and 8 
  bit mode. 
- Use the same code in 4 and 8 bit mode to force display to 8 bit mode and use 
  a loop instead of three distinct calls to writebits().
