### PR TITLE
Changed language ISO code to match Norwegian (Norsk bokmål).

### DIFF
--- a/app/src/processing/app/Preferences.java
+++ b/app/src/processing/app/Preferences.java
@@ -138,7 +138,7 @@ public class Preferences {
                         "lv",
                         "lt",
                         "mr",
-                        "no",
+                        "no_nb",
                         "fa",
                         "pl",
                         "pt_br",


### PR DESCRIPTION
The language code used in Preferences.java does not match the norwegian translation.
