### PR TITLE
Added support for interrupt on INT2 and INT3 on the Leonardo

### DIFF
--- a/hardware/arduino/cores/arduino/WInterrupts.c
+++ b/hardware/arduino/cores/arduino/WInterrupts.c
@@ -59,6 +59,14 @@ void attachInterrupt(uint8_t interruptNum, void (*userFunc)(void), int mode) {
 		EICRA = (EICRA & ~((1<<ISC10) | (1<<ISC11))) | (mode << ISC10);
 		EIMSK |= (1<<INT1);
 		break;	
+    case 2:
+        EICRA = (EICRA & ~((1<<ISC20) | (1<<ISC21))) | (mode << ISC20);
+        EIMSK |= (1<<INT2);
+        break;
+    case 3:
+        EICRA = (EICRA & ~((1<<ISC30) | (1<<ISC31))) | (mode << ISC30);
+        EIMSK |= (1<<INT3);
+        break;
 #elif defined(EICRA) && defined(EICRB) && defined(EIMSK)
     case 2:
       EICRA = (EICRA & ~((1 << ISC00) | (1 << ISC01))) | (mode << ISC00);
@@ -147,12 +155,18 @@ void detachInterrupt(uint8_t interruptNum) {
     // ATmega8.  There, INT0 is 6 and INT1 is 7.)
     switch (interruptNum) {
 #if defined(__AVR_ATmega32U4__)
-	case 0:
-		EIMSK &= ~(1<<INT0);
-		break;
-	case 1:
-		EIMSK &= ~(1<<INT1);
-		break;		
+    case 0:
+        EIMSK &= ~(1<<INT0);
+        break;
+    case 1:
+        EIMSK &= ~(1<<INT1);
+        break;
+    case 2:
+        EIMSK &= ~(1<<INT2);
+        break;
+    case 3:
+        EIMSK &= ~(1<<INT3);
+        break;		
 #elif defined(EICRA) && defined(EICRB) && defined(EIMSK)
     case 2:
       EIMSK &= ~(1 << INT0);
@@ -224,6 +238,16 @@ SIGNAL(INT0_vect) {
 SIGNAL(INT1_vect) {
 	if(intFunc[EXTERNAL_INT_1])
 		intFunc[EXTERNAL_INT_1]();
+}
+
+SIGNAL(INT2_vect) {
+    if(intFunc[EXTERNAL_INT_2])
+		intFunc[EXTERNAL_INT_2]();
+}
+
+SIGNAL(INT3_vect) {
+    if(intFunc[EXTERNAL_INT_3])
+		intFunc[EXTERNAL_INT_3]();
 }
 
 #elif defined(EICRA) && defined(EICRB)

--- a/hardware/arduino/cores/arduino/wiring_private.h
+++ b/hardware/arduino/cores/arduino/wiring_private.h
@@ -56,6 +56,8 @@ extern "C"{
 #define EXTERNAL_NUM_INTERRUPTS 8
 #elif defined(__AVR_ATmega1284P__) 
 #define EXTERNAL_NUM_INTERRUPTS 3
+#elif defined(__AVR_ATmega32U4__)
+#define EXTERNAL_NUM_INTERRUPTS 4
 #else
 #define EXTERNAL_NUM_INTERRUPTS 2
 #endif


### PR DESCRIPTION
You might also  want to update the following page: http://arduino.cc/it/Reference/AttachInterrupt, so people know that they can't use external interrupt 2 and 3 and the Serial1 class at the same time.
Also a small text about the location of the interrupt pins might be useful for beginners.
