### PR TITLE
Fixed nullpointer exception in case of missing bootloader.path param

### DIFF
--- a/app/src/processing/app/debug/AvrdudeUploader.java
+++ b/app/src/processing/app/debug/AvrdudeUploader.java
@@ -85,7 +85,7 @@ public class AvrdudeUploader extends Uploader  {
     // this wait a moment for the bootloader to enumerate. On Windows, also must
     // deal with the fact that the COM port number changes from bootloader to
     // sketch.
-    if (boardPreferences.get("bootloader.path").equals("caterina")) {
+    if (boardPreferences.get("bootloader.path") != null && boardPreferences.get("bootloader.path").equals("caterina")) {
       String caterinaUploadPort = null;
       try {
         // Toggle 1200 bps on selected serial port to force board reset.
@@ -178,7 +178,7 @@ public class AvrdudeUploader extends Uploader  {
 	// port reconnects (or timeout after a few seconds if the sketch port never comes back).
 	// Doing this saves users from accidentally opening Serial Monitor on the soon-to-be-orphaned
 	// bootloader port.
-    if (true == avrdudeResult && boardPreferences.get("bootloader.path").equals("caterina")) {
+    if (true == avrdudeResult && boardPreferences.get("bootloader.path") != null && boardPreferences.get("bootloader.path").equals("caterina")) {
     	try {
     		Thread.sleep(500);
     	} catch (InterruptedException ex) { } 


### PR DESCRIPTION
...n boards.txt

Pre-1.0.1 it was not necessary to have a bootloader.path param in
boards.txt under the respective board type. This patch helps keeping
compatibility with older settings and avoid dummy param settings.
