### PR TITLE
Correct implementation of gcc specific internal functions

### DIFF
--- a/hardware/arduino/cores/arduino/abi.cpp
+++ b/hardware/arduino/cores/arduino/abi.cpp
@@ -1,0 +1,61 @@
+#include <abi.h>
+#include <stdint.h>
+// TODO Uncomment this once you have libstdc++
+//#include <exception>
+
+#include <avr/io.h>
+#include <avr/interrupt.h>
+
+namespace {
+// guard is an integer type big enough to hold flag and a mutex. 
+// By default gcc uses long long int and avr ABI does not change it
+// So we have 32 or 64 bits available. Actually, we need 16.
+
+inline char& flag_part(__guard *g) {
+    return *(reinterpret_cast<char*>(g));
+}
+
+inline uint8_t& sreg_part(__guard *g) {
+    return *(reinterpret_cast<uint8_t*>(g) + sizeof(char));
+}
+}
+
+int __cxa_guard_acquire(__guard *g) {
+    uint8_t oldSREG = SREG;
+    cli();
+    // Initialization of static variable has to be done with blocked interrupts
+    // because if this function is called from interrupt and sees that somebody
+    // else is already doing initialization it MUST wait until initializations
+    // is complete. That's impossible.
+    // If you don't want this overhead compile with -fno-threadsafe-statics
+    if (flag_part(g)) {
+        SREG = oldSREG;
+        return false;
+    } else {
+        sreg_part(g) = oldSREG;
+        return true;
+    }
+}
+
+void __cxa_guard_release (__guard *g) {
+    flag_part(g) = 1;
+    SREG = sreg_part(g);
+}
+
+void __cxa_guard_abort (__guard *g) {
+    SREG = sreg_part(g);
+}
+
+void __cxa_pure_virtual(void) {
+    // We might want to write some diagnostics to uart in this case
+    // TODO Uncomment this once you have libstdc++
+    //std::terminate();
+    abort();
+}
+
+void __cxa_deleted_virtual(void) {
+    // We might want to write some diagnostics to uart in this case
+    // TODO Uncomment this once you have libstdc++
+    //std::terminate();
+    abort();
+}

--- a/hardware/arduino/cores/arduino/abi.h
+++ b/hardware/arduino/cores/arduino/abi.h
@@ -1,0 +1,19 @@
+/* Header to define cxx abi parts missing from avrlibc */
+
+#ifndef ABI_H_INCLUDED
+#define ABI_H_INCLUDED
+
+#include <stdlib.h>
+
+__extension__ typedef int __guard __attribute__((mode (__DI__)));
+
+extern "C" {
+int __cxa_guard_acquire(__guard *);
+void __cxa_guard_release (__guard *);
+void __cxa_guard_abort (__guard *); 
+
+void __cxa_pure_virtual(void) __attribute__ ((__noreturn__));
+void __cxa_deleted_virtual(void) __attribute__ ((__noreturn__));
+}
+
+#endif

--- a/hardware/arduino/cores/arduino/new.cpp
+++ b/hardware/arduino/cores/arduino/new.cpp
@@ -9,10 +9,3 @@ void operator delete(void * ptr)
 {
   free(ptr);
 } 
-
-int __cxa_guard_acquire(__guard *g) {return !*(char *)(g);};
-void __cxa_guard_release (__guard *g) {*(char *)g = 1;};
-void __cxa_guard_abort (__guard *) {}; 
-
-void __cxa_pure_virtual(void) {};
-

--- a/hardware/arduino/cores/arduino/new.h
+++ b/hardware/arduino/cores/arduino/new.h
@@ -10,13 +10,5 @@
 void * operator new(size_t size);
 void operator delete(void * ptr); 
 
-__extension__ typedef int __guard __attribute__((mode (__DI__)));
-
-extern "C" int __cxa_guard_acquire(__guard *);
-extern "C" void __cxa_guard_release (__guard *);
-extern "C" void __cxa_guard_abort (__guard *); 
-
-extern "C" void __cxa_pure_virtual(void);
-
 #endif
 


### PR DESCRIPTION
This patch add correct implementation for:

``` C++
int __cxa_guard_acquire(__guard *);
void __cxa_guard_release (__guard *);
void __cxa_guard_abort (__guard *); 
void __cxa_pure_virtual(void) __attribute__ ((__noreturn__));
void __cxa_deleted_virtual(void) __attribute__ ((__noreturn__));
```

Current implementations in arduino are just stubs that can lead to undefined behavior if one of that functions is used. __cxa_guard_acquire, __cxa_guard_release and __cxa_guard_abort are needed for thread safe initialization of static variables (in case if they can't be initialized at compile time). If you don't need thread safety just turn it of with -fno-threadsafe-statics. Buf if you provide it, provide correct implementation, not a stub.

__cxa_pure_virtual  and __cxa_deleted_virtual are called if thing went really wrong and they must not return. They must terminate the program because it is already broken.
