### PR TITLE
Fix for issue 866 -- Fix F() macro uncompilable

### DIFF
--- a/hardware/arduino/cores/arduino/WString.h
+++ b/hardware/arduino/cores/arduino/WString.h
@@ -35,7 +35,7 @@
 //     -std=c++0x
 
 class __FlashStringHelper;
-#define F(string_literal) (reinterpret_cast<__FlashStringHelper *>(PSTR(string_literal)))
+#define F(string_literal) (reinterpret_cast<const __FlashStringHelper *>(PSTR(string_literal)))
 
 // An inherited class for holding the result of a concatenation.  These
 // result objects are assumed to be writable by subsequent concatenations.


### PR DESCRIPTION
Fix issue 866 by adding a const qualifier to what the F macro casts to.
Issue 866 makes the F() macro uncompilable on many systems, and should be fixed as  soon as possible.
