### PR TITLE
pass correct language option to gcc when compiling assembler files

### DIFF
--- a/app/src/processing/app/debug/Compiler.java
+++ b/app/src/processing/app/debug/Compiler.java
@@ -547,7 +547,7 @@ public class Compiler implements MessageConsumer {
       avrBasePath + "avr-gcc",
       "-c", // compile, don't link
       "-g", // include debugging info (so errors include line numbers)
-      "-assembler-with-cpp",
+      "-xassembler-with-cpp",
       "-mmcu=" + boardPreferences.get("build.mcu"),
       "-DF_CPU=" + boardPreferences.get("build.f_cpu"),      
       "-DARDUINO=" + Base.REVISION,


### PR DESCRIPTION
At the moment, the arduino GUI fails to compile assembler files in libraries due to a wrong command line option. this patch fixes that.
