### PR TITLE
Recursive compilation

### DIFF
--- a/app/src/processing/app/debug/Compiler.java
+++ b/app/src/processing/app/debug/Compiler.java
@@ -137,6 +137,12 @@ public class Compiler implements MessageConsumer {
    // 2. compile the libraries, outputting .o files to: <buildPath>/<library>/
 
    sketch.setCompilingProgress(40);
+   
+   for (File libraryFolder : sketch.getImportedLibraries()) {
+       copyRecursively(avrBasePath, libraryFolder, buildPath, objectFiles, includePaths, boardPreferences);
+   }
+
+   /*
    for (File libraryFolder : sketch.getImportedLibraries()) {
      File outputFolder = new File(buildPath, libraryFolder.getName());
      File utilityFolder = new File(libraryFolder, "utility");
@@ -160,7 +166,8 @@ public class Compiler implements MessageConsumer {
      // other libraries should not see this library's utility/ folder
      includePaths.remove(includePaths.size() - 1);
    }
-
+	*/
+	
    // 3. compile the core, outputting .o files to <buildPath> and then
    // collecting them into the core.a library file.
 
@@ -250,7 +257,32 @@ public class Compiler implements MessageConsumer {
    
     return true;
   }
-
+  
+  
+  private void copyRecursively(String avrBasePath, File folder, String where, List<File> objectFiles, List includePaths, Map<String, String> boardPreferences) throws RunnerException {
+    File outputFolder = new File(where, folder.getName());
+	createFolder(outputFolder);
+	
+	//if (folder.isDirectory()){
+	  File[] subdirList = folder.listFiles();
+	  if (subdirList != null){ //if it contains folder
+	    for (File child : subdirList) {
+	      copyRecursively(avrBasePath, child, outputFolder.getAbsolutePath(), objectFiles, includePaths, boardPreferences);
+	    }
+	  }
+	//}
+	
+	includePaths.add(folder.getAbsolutePath());
+	
+	objectFiles.addAll(
+       compileFiles(avrBasePath, outputFolder.getAbsolutePath(), includePaths,
+               findFilesInFolder(folder, "S", false),
+               findFilesInFolder(folder, "c", false),
+               findFilesInFolder(folder, "cpp", false),
+               boardPreferences));
+	// other libraries should not see this library's utility/ folder
+     includePaths.remove(includePaths.size() - 1);
+  }
 
   private List<File> compileFiles(String avrBasePath,
                                   String buildPath, List<File> includePaths,

--- a/libraries/Ethernet/Dhcp.cpp
+++ b/libraries/Ethernet/Dhcp.cpp
@@ -1,7 +1,7 @@
 // DHCP Library v0.3 - April 25, 2009
 // Author: Jordan Terrell - blog.jordanterrell.com
 
-#include "w5100.h"
+#include "utility/w5100.h"
 
 #include <string.h>
 #include <stdlib.h>

--- a/libraries/Ethernet/Dns.cpp
+++ b/libraries/Ethernet/Dns.cpp
@@ -2,7 +2,7 @@
 // (c) Copyright 2009-2010 MCQN Ltd.
 // Released under Apache License, version 2.0
 
-#include "w5100.h"
+#include "utility/w5100.h"
 #include "EthernetUdp.h"
 #include "util.h"
 

--- a/libraries/Ethernet/Ethernet.cpp
+++ b/libraries/Ethernet/Ethernet.cpp
@@ -1,4 +1,4 @@
-#include "w5100.h"
+#include "utility/w5100.h"
 #include "Ethernet.h"
 #include "Dhcp.h"
 

--- a/libraries/Ethernet/EthernetClient.cpp
+++ b/libraries/Ethernet/EthernetClient.cpp
@@ -1,5 +1,5 @@
-#include "w5100.h"
-#include "socket.h"
+#include "utility/w5100.h"
+#include "utility/socket.h"
 
 extern "C" {
   #include "string.h"

--- a/libraries/Ethernet/EthernetServer.cpp
+++ b/libraries/Ethernet/EthernetServer.cpp
@@ -1,5 +1,5 @@
-#include "w5100.h"
-#include "socket.h"
+#include "utility/w5100.h"
+#include "utility/socket.h"
 extern "C" {
 #include "string.h"
 }

--- a/libraries/Ethernet/EthernetUdp.cpp
+++ b/libraries/Ethernet/EthernetUdp.cpp
@@ -26,8 +26,8 @@
  * bjoern@cs.stanford.edu 12/30/2008
  */
 
-#include "w5100.h"
-#include "socket.h"
+#include "utility/w5100.h"
+#include "utility/socket.h"
 #include "Ethernet.h"
 #include "Udp.h"
 #include "Dns.h"

--- a/libraries/WiFi/WiFiClient.cpp
+++ b/libraries/WiFi/WiFiClient.cpp
@@ -9,7 +9,7 @@ extern "C" {
 #include "WiFi.h"
 #include "WiFiClient.h"
 #include "WiFiServer.h"
-#include "server_drv.h"
+#include "utility/server_drv.h"
 
 
 uint16_t WiFiClient::_srcport = 1024;

--- a/libraries/WiFi/WiFiServer.cpp
+++ b/libraries/WiFi/WiFiServer.cpp
@@ -1,5 +1,5 @@
 #include <string.h>
-#include "server_drv.h"
+#include "utility/server_drv.h"
 
 extern "C" {
   #include "utility/debug.h"

--- a/libraries/WiFi/WiFiServer.h
+++ b/libraries/WiFi/WiFiServer.h
@@ -5,7 +5,7 @@ extern "C" {
   #include "utility/wl_definitions.h"
 }
 
-#include "Server.h"
+#include "utility/Server.h"
 
 class WiFiClient;
 

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -23,7 +23,7 @@ extern "C" {
   #include <stdlib.h>
   #include <string.h>
   #include <inttypes.h>
-  #include "twi.h"
+  #include "utility/twi.h"
 }
 
 #include "Wire.h"


### PR DESCRIPTION
With this patch, the special case of the "utility" folder in compilation is removed.
In fact now the IDE will be compliant to standard, and will copy recursively all file to compiled keeping the folder structure.
Also changed all library #include to be compliant with the standard.

Now you can import and export complex library and give a logical organization of your code's file.

TODO: The source in the sketch sub-folder will remain inaccessible from the IDE, I'll fix that soon with another patch
