### PR TITLE
Stream - virtual copy constructor added

### DIFF
--- a/hardware/arduino/cores/arduino/Stream.cpp
+++ b/hardware/arduino/cores/arduino/Stream.cpp
@@ -50,6 +50,15 @@ int Stream::timedPeek()
   return -1;     // -1 indicates timeout
 }
 
+// virtual copy constructor to allow child classes to use Stream as reference
+Stream& Stream::operator=(Stream const& src)
+{
+  // copy the timeout time
+  _timeout		= src._timeout;
+  // return a reference to this object
+  return *this;
+}
+
 // returns peek of the next digit in the stream or -1 if timeout
 // discards non-numeric characters
 int Stream::peekNextDigit()

--- a/hardware/arduino/cores/arduino/Stream.h
+++ b/hardware/arduino/cores/arduino/Stream.h
@@ -49,6 +49,7 @@ class Stream : public Print
     virtual int read() = 0;
     virtual int peek() = 0;
     virtual void flush() = 0;
+    virtual Stream& operator=(Stream const& src);
 
     Stream() {_timeout=1000;}
 


### PR DESCRIPTION
I've added a virtual copy constructor to Stream.h / .cpp, to give the user the ability to pass derived classes as reference. 

Tim