### PR TITLE
Make the bootloader build for atmega328

### DIFF
--- a/hardware/arduino/bootloaders/atmega/ATmegaBOOT_168.c
+++ b/hardware/arduino/bootloaders/atmega/ATmegaBOOT_168.c
@@ -580,7 +580,7 @@ int main(void)
 				/* if ((length.byte[0] & 0x01) == 0x01) length.word++;	//Even up an odd number of bytes */
 				if ((length.byte[0] & 0x01)) length.word++;	//Even up an odd number of bytes
 				cli();					//Disable interrupts, just to be sure
-#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega1281__)
+#if defined(EEPE)
 				while(bit_is_set(EECR,EEPE));			//Wait for previous EEPROM writes to complete
 #else
 				while(bit_is_set(EECR,EEWE));			//Wait for previous EEPROM writes to complete

--- a/hardware/arduino/bootloaders/atmega/Makefile
+++ b/hardware/arduino/bootloaders/atmega/Makefile
@@ -49,7 +49,7 @@ STK500-2 = $(STK500) -d$(MCU_TARGET) -ms -q -lCF -LCF -cUSB -I200kHz -s -wt
 
 
 OBJ        = $(PROGRAM).o
-OPTIMIZE   = -O2
+OPTIMIZE   = -Os
 
 DEFS       = 
 LIBS       =


### PR DESCRIPTION
By using this check rather than the ifdefs for the specific boards, the code should build well for more boards, currently the uno is broken, this is part one of the fix for that.
