### PR TITLE
328 notp

### DIFF
--- a/build/linux/dist/tools/avrdude.conf
+++ b/build/linux/dist/tools/avrdude.conf
@@ -9417,6 +9417,194 @@ part
 ;
 
 #------------------------------------------------------------
+# ATmega328
+#------------------------------------------------------------
+
+part
+    id			= "m328";
+    desc		= "ATMEGA328";
+    has_debugwire	= yes;
+    flash_instr		= 0xB6, 0x01, 0x11;
+    eeprom_instr	= 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
+			  0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
+			  0x99, 0xF9, 0xBB, 0xAF;
+    stk500_devcode	= 0x86;
+    # avr910_devcode	= 0x;
+    signature		= 0x1e 0x95 0x14;
+    pagel		= 0xd7;
+    bs2			= 0xc2;
+    chip_erase_delay	= 9000;
+    pgm_enable = "1 0 1 0 1 1 0 0 0 1 0 1 0 0 1 1",
+		 "x x x x x x x x x x x x x x x x";
+
+    chip_erase = "1 0 1 0 1 1 0 0 1 0 0 x x x x x",
+		 "x x x x x x x x x x x x x x x x";
+
+    timeout	= 200;
+    stabdelay	= 100;
+    cmdexedelay	= 25;
+    synchloops	= 32;
+    bytedelay	= 0;
+    pollindex	= 3;
+    pollvalue	= 0x53;
+    predelay	= 1;
+    postdelay	= 1;
+    pollmethod	= 1;
+
+    pp_controlstack =
+	0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+	0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+	0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+	0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay	= 100;
+    progmodedelay	= 0;
+    latchcycles		= 5;
+    togglevtg		= 1;
+    poweroffdelay	= 15;
+    resetdelayms	= 1;
+    resetdelayus	= 0;
+    hvleavestabdelay	= 15;
+    resetdelay		= 15;
+    chiperasepulsewidth	= 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    memory "eeprom"
+	paged		= no;
+	page_size	= 4;
+	size		= 1024;
+	min_write_delay = 3600;
+	max_write_delay = 3600;
+	readback_p1	= 0xff;
+	readback_p2	= 0xff;
+	read = " 1 0 1 0 0 0 0 0",
+	       " 0 0 0 x x x a9 a8",
+	       " a7 a6 a5 a4 a3 a2 a1 a0",
+	       " o o o o o o o o";
+
+	write = " 1 1 0 0 0 0 0 0",
+	      	" 0 0 0 x x x a9 a8",
+		" a7 a6 a5 a4 a3 a2 a1 a0",
+		" i i i i i i i i";
+
+	loadpage_lo = " 1 1 0 0 0 0 0 1",
+		      " 0 0 0 0 0 0 0 0",
+		      " 0 0 0 0 0 0 a1 a0",
+		      " i i i i i i i i";
+
+	writepage = " 1 1 0 0 0 0 1 0",
+		    " 0 0 x x x x a9 a8",
+		    " a7 a6 a5 a4 a3 a2 0 0",
+		    " x x x x x x x x";
+
+	mode		= 0x41;
+	delay		= 20;
+	blocksize	= 4;
+	readsize	= 256;
+    ;
+
+    memory "flash"
+	paged		= yes;
+	size		= 32768;
+	page_size	= 128;
+	num_pages	= 256;
+	min_write_delay = 4500;
+	max_write_delay = 4500;
+	readback_p1	= 0xff;
+	readback_p2	= 0xff;
+	read_lo = " 0 0 1 0 0 0 0 0",
+		  " 0 0 a13 a12 a11 a10 a9 a8",
+		  " a7 a6 a5 a4 a3 a2 a1 a0",
+		  " o o o o o o o o";
+
+	read_hi = " 0 0 1 0 1 0 0 0",
+		  " 0 0 a13 a12 a11 a10 a9 a8",
+		  " a7 a6 a5 a4 a3 a2 a1 a0",
+		  " o o o o o o o o";
+
+	loadpage_lo = " 0 1 0 0 0 0 0 0",
+		      " 0 0 0 x x x x x",
+		      " x x a5 a4 a3 a2 a1 a0",
+		      " i i i i i i i i";
+
+	loadpage_hi = " 0 1 0 0 1 0 0 0",
+		      " 0 0 0 x x x x x",
+		      " x x a5 a4 a3 a2 a1 a0",
+		      " i i i i i i i i";
+
+	writepage = " 0 1 0 0 1 1 0 0",
+		    " 0 0 a13 a12 a11 a10 a9 a8",
+		    " a7 a6 x x x x x x",
+		    " x x x x x x x x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 128;
+	readsize	= 256;
+
+    ;
+
+    memory "lfuse"
+	size = 1;
+	min_write_delay = 4500;
+	max_write_delay = 4500;
+	read = "0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0",
+	       "x x x x x x x x o o o o o o o o";
+
+	write = "1 0 1 0 1 1 0 0 1 0 1 0 0 0 0 0",
+	      	"x x x x x x x x i i i i i i i i";
+    ;
+
+    memory "hfuse"
+	size = 1;
+	min_write_delay = 4500;
+	max_write_delay = 4500;
+	read = "0 1 0 1 1 0 0 0 0 0 0 0 1 0 0 0",
+	       "x x x x x x x x o o o o o o o o";
+
+	write = "1 0 1 0 1 1 0 0 1 0 1 0 1 0 0 0",
+	      	"x x x x x x x x i i i i i i i i";
+    ;
+
+    memory "efuse"
+	size = 1;
+	min_write_delay = 4500;
+	max_write_delay = 4500;
+	read = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
+	       "x x x x x x x x x x x x x o o o";
+
+	write = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
+	      	"x x x x x x x x x x x x x i i i";
+    ;
+
+    memory "lock"
+	size = 1;
+	min_write_delay = 4500;
+	max_write_delay = 4500;
+	read = "0 1 0 1 1 0 0 0 0 0 0 0 0 0 0 0",
+	       "x x x x x x x x x x o o o o o o";
+
+	write = "1 0 1 0 1 1 0 0 1 1 1 x x x x x",
+	      	"x x x x x x x x 1 1 i i i i i i";
+    ;
+
+    memory "calibration"
+	size = 1;
+	read = "0 0 1 1 1 0 0 0 0 0 0 x x x x x",
+	       "0 0 0 0 0 0 0 0 o o o o o o o o";
+    ;
+
+    memory "signature"
+	size = 3;
+	read = "0 0 1 1 0 0 0 0 0 0 0 x x x x x",
+	       "x x x x x x a1 a0 o o o o o o o o";
+    ;
+;
+
+#------------------------------------------------------------
 # ATtiny2313
 #------------------------------------------------------------
 

--- a/hardware/arduino/boards.txt
+++ b/hardware/arduino/boards.txt
@@ -501,3 +501,24 @@ atmega8.build.mcu=atmega8
 atmega8.build.f_cpu=16000000L
 atmega8.build.core=arduino
 atmega8.build.variant=standard
+
+##############################################################
+
+nanode.name=Nanode or Shrimp with 328 (not 328p)
+
+nanode.upload.protocol=arduino
+nanode.upload.maximum_size=30720
+nanode.upload.speed=57600
+
+nanode.bootloader.low_fuses=0xFF
+nanode.bootloader.high_fuses=0xDA
+nanode.bootloader.extended_fuses=0x05
+nanode.bootloader.path=atmega
+nanode.bootloader.file=ATmegaBOOT_168_atmega328_notp.hex
+nanode.bootloader.unlock_bits=0x3F
+nanode.bootloader.lock_bits=0x0F
+
+nanode.build.mcu=atmega328
+nanode.build.f_cpu=16000000L
+nanode.build.core=arduino
+nanode.build.variant=standard

--- a/hardware/arduino/bootloaders/atmega/ATmegaBOOT_168.c
+++ b/hardware/arduino/bootloaders/atmega/ATmegaBOOT_168.c
@@ -75,7 +75,7 @@
 
 /* the current avr-libc eeprom functions do not support the ATmega168 */
 /* own eeprom write/read functions are used instead */
-#if !defined(__AVR_ATmega168__) || !defined(__AVR_ATmega328P__)
+#if !defined(__AVR_ATmega168__) || !defined(__AVR_ATmega328P__) || !defined(__AVR_ATmega328__)
 #include <avr/eeprom.h>
 #endif
 
@@ -202,6 +202,11 @@
 #elif defined __AVR_ATmega328P__
 #define SIG2	0x95
 #define SIG3	0x0F
+#define PAGE_SIZE	0x40U	//64 words
+
+#elif defined __AVR_ATmega328__
+#define SIG2	0x95
+#define SIG3	0x14
 #define PAGE_SIZE	0x40U	//64 words
 
 #elif defined __AVR_ATmega162__
@@ -369,7 +374,7 @@ int main(void)
 	UBRRHI = (F_CPU/(BAUD_RATE*16L)-1) >> 8;
 	UCSRA = 0x00;
 	UCSRB = _BV(TXEN)|_BV(RXEN);	
-#elif defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__)
+#elif defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__) || defined (__AVR_ATmega328__)
 
 #ifdef DOUBLE_SPEED
 	UCSR0A = (1<<U2X0); //Double speed mode USART0
@@ -558,7 +563,7 @@ int main(void)
 			if (flags.eeprom) {		                //Write to EEPROM one byte at a time
 				address.word <<= 1;
 				for(w=0;w<length.word;w++) {
-#if defined(__AVR_ATmega168__)  || defined(__AVR_ATmega328P__)
+#if defined(__AVR_ATmega168__)  || defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328__)
 					while(EECR & (1<<EEPE));
 					EEAR = (uint16_t)(void *)address.word;
 					EEDR = buff[w];
@@ -679,7 +684,7 @@ int main(void)
 					 "rjmp	write_page	\n\t"
 					 "block_done:		\n\t"
 					 "clr	__zero_reg__	\n\t"	//restore zero register
-#if defined __AVR_ATmega168__  || __AVR_ATmega328P__ || __AVR_ATmega128__ || __AVR_ATmega1280__ || __AVR_ATmega1281__ 
+#if defined __AVR_ATmega168__  || __AVR_ATmega328P__ || __AVR_ATmega328__ || __AVR_ATmega128__ || __AVR_ATmega1280__ || __AVR_ATmega1281__ 
 					 : "=m" (SPMCSR) : "M" (PAGE_SIZE) : "r0","r16","r17","r24","r25","r28","r29","r30","r31"
 #else
 					 : "=m" (SPMCR) : "M" (PAGE_SIZE) : "r0","r16","r17","r24","r25","r28","r29","r30","r31"
@@ -712,7 +717,7 @@ int main(void)
 			putch(0x14);
 			for (w=0;w < length.word;w++) {		        // Can handle odd and even lengths okay
 				if (flags.eeprom) {	                        // Byte access EEPROM read
-#if defined(__AVR_ATmega168__)  || defined(__AVR_ATmega328P__)
+#if defined(__AVR_ATmega168__)  || defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328__)
 					while(EECR & (1<<EEPE));
 					EEAR = (uint16_t)(void *)address.word;
 					EECR |= (1<<EERE);
@@ -865,6 +870,7 @@ int main(void)
 
 			} /* end of monitor functions */
 
+
 		}
 		}
 	}
@@ -928,7 +934,7 @@ void putch(char ch)
 		while (!(UCSR1A & _BV(UDRE1)));
 		UDR1 = ch;
 	}
-#elif defined(__AVR_ATmega168__)  || defined(__AVR_ATmega328P__)
+#elif defined(__AVR_ATmega168__)  || defined(__AVR_ATmega328P__) || defined (__AVR_ATmega328__)
 	while (!(UCSR0A & _BV(UDRE0)));
 	UDR0 = ch;
 #else
@@ -966,7 +972,7 @@ char getch(void)
 		return UDR1;
 	}
 	return 0;
-#elif defined(__AVR_ATmega168__)  || defined(__AVR_ATmega328P__)
+#elif defined(__AVR_ATmega168__)  || defined(__AVR_ATmega328P__) || defined (__AVR_ATmega328__)
 	uint32_t count = 0;
 	while(!(UCSR0A & _BV(RXC0))){
 		/* 20060803 DojoCorp:: Addon coming from the previous Bootloader*/               
@@ -1003,7 +1009,7 @@ void getNch(uint8_t count)
 			while(!(UCSR1A & _BV(RXC1)));
 			UDR1;
 		}
-#elif defined(__AVR_ATmega168__)  || defined(__AVR_ATmega328P__)
+#elif defined(__AVR_ATmega168__)  || defined(__AVR_ATmega328P__) || defined (__AVR_ATmega328__)
 		getch();
 #else
 		/* m8,16,32,169,8515,8535,163 */

--- a/hardware/arduino/bootloaders/atmega/ATmegaBOOT_168.c
+++ b/hardware/arduino/bootloaders/atmega/ATmegaBOOT_168.c
@@ -580,7 +580,7 @@ int main(void)
 				/* if ((length.byte[0] & 0x01) == 0x01) length.word++;	//Even up an odd number of bytes */
 				if ((length.byte[0] & 0x01)) length.word++;	//Even up an odd number of bytes
 				cli();					//Disable interrupts, just to be sure
-#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega1281__)
+#if defined(EEPE)
 				while(bit_is_set(EECR,EEPE));			//Wait for previous EEPROM writes to complete
 #else
 				while(bit_is_set(EECR,EEWE));			//Wait for previous EEPROM writes to complete

--- a/hardware/arduino/bootloaders/atmega/Makefile
+++ b/hardware/arduino/bootloaders/atmega/Makefile
@@ -49,7 +49,7 @@ STK500-2 = $(STK500) -d$(MCU_TARGET) -ms -q -lCF -LCF -cUSB -I200kHz -s -wt
 
 
 OBJ        = $(PROGRAM).o
-OPTIMIZE   = -O2
+OPTIMIZE   = -Os
 
 DEFS       = 
 LIBS       =

--- a/hardware/arduino/bootloaders/atmega/Makefile
+++ b/hardware/arduino/bootloaders/atmega/Makefile
@@ -166,6 +166,21 @@ atmega328_isp: LFUSE = FF
 atmega328_isp: EFUSE = 05
 atmega328_isp: isp
 
+atmega328_notp: TARGET = atmega328_notp
+atmega328_notp: MCU_TARGET = atmega328
+atmega328_notp: CFLAGS += '-DMAX_TIME_COUNT=F_CPU>>4' '-DNUM_LED_FLASHES=1' -DBAUD_RATE=57600
+atmega328_notp: AVR_FREQ = 16000000L 
+atmega328_notp: LDSECTION  = --section-start=.text=0x7800
+atmega328_notp: $(PROGRAM)_atmega328_notp.hex
+
+atmega328_notp_isp: atmega328_notp
+atmega328_notp_isp: TARGET = atmega328
+atmega328_notp_isp: MCU_TARGET = atmega328
+atmega328_notp_isp: HFUSE = DA
+atmega328_notp_isp: LFUSE = FF
+atmega328_notp_isp: EFUSE = 05
+atmega328_notp_isp: isp
+
 atmega328_pro8: TARGET = atmega328_pro_8MHz
 atmega328_pro8: MCU_TARGET = atmega328p
 atmega328_pro8: CFLAGS += '-DMAX_TIME_COUNT=F_CPU>>4' '-DNUM_LED_FLASHES=1' -DBAUD_RATE=57600 -DDOUBLE_SPEED

--- a/hardware/arduino/bootloaders/bt/ATmegaBOOT_168.c
+++ b/hardware/arduino/bootloaders/bt/ATmegaBOOT_168.c
@@ -79,7 +79,7 @@
 
 /* the current avr-libc eeprom functions do not support the ATmega168 */
 /* own eeprom write/read functions are used instead */
-#if !defined(__AVR_ATmega168__) || !defined(__AVR_ATmega328P__)
+#if !defined(__AVR_ATmega168__) || !defined(__AVR_ATmega328P__) || !defined(__AVR_ATmega328__)
 #include <avr/eeprom.h>
 #endif
 
@@ -192,6 +192,11 @@
 #elif defined __AVR_ATmega328P__
 #define SIG2	0x95
 #define SIG3	0x0F
+#define PAGE_SIZE	0x40U	//64 words
+
+#elif defined __AVR_ATmega328__
+#define SIG2	0x95
+#define SIG3	0x14
 #define PAGE_SIZE	0x40U	//64 words
 
 #elif defined __AVR_ATmega162__
@@ -335,7 +340,7 @@ int main(void)
     UBRRHI = (F_CPU/(BAUD_RATE*16L)-1) >> 8;
     UCSRA = 0x00;
     UCSRB = _BV(TXEN)|_BV(RXEN);	
-#elif defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__)
+#elif defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328__)
 
 	UBRR0H = ((F_CPU / 16 + BAUD_RATE / 2) / BAUD_RATE - 1) >> 8;
 	UBRR0L = ((F_CPU / 16 + BAUD_RATE / 2) / BAUD_RATE - 1);
@@ -557,7 +562,7 @@ putch(0x0D);
 	    if (getch() == ' ') {
 		if (flags.eeprom) {		                //Write to EEPROM one byte at a time
 		    for(w=0;w<length.word;w++) {
-#if defined(__AVR_ATmega168__)  || defined(__AVR_ATmega328P__)
+#if defined(__AVR_ATmega168__)  || defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328__)
 			while(EECR & (1<<EEPE));
 			EEAR = (uint16_t)(void *)address.word;
 			EEDR = buff[w];
@@ -675,7 +680,7 @@ putch(0x0D);
 				 "rjmp	write_page	\n\t"
 				 "block_done:		\n\t"
 				 "clr	__zero_reg__	\n\t"	//restore zero register
-#if defined __AVR_ATmega168__  || __AVR_ATmega328P__
+#if defined __AVR_ATmega168__  || __AVR_ATmega328P__ || __AVR_ATmega_328__
 				 : "=m" (SPMCSR) : "M" (PAGE_SIZE) : "r0","r16","r17","r24","r25","r28","r29","r30","r31"
 #else
 				 : "=m" (SPMCR) : "M" (PAGE_SIZE) : "r0","r16","r17","r24","r25","r28","r29","r30","r31"
@@ -707,7 +712,7 @@ putch(0x0D);
 		putch(0x14);
 		for (w=0;w < length.word;w++) {		        // Can handle odd and even lengths okay
 		    if (flags.eeprom) {	                        // Byte access EEPROM read
-#if defined __AVR_ATmega168__  || __AVR_ATmega328P__
+#if defined __AVR_ATmega168__  || __AVR_ATmega328P__ || __AVR_ATmega328__
 			while(EECR & (1<<EEPE));
 			EEAR = (uint16_t)(void *)address.word;
 			EECR |= (1<<EERE);
@@ -921,7 +926,7 @@ void putch(char ch)
 	while (!(UCSR1A & _BV(UDRE1)));
 	UDR1 = ch;
     }
-#elif defined (__AVR_ATmega168__) || defined(__AVR_ATmega328P__)
+#elif defined (__AVR_ATmega168__) || defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328__)
     while (!(UCSR0A & _BV(UDRE0)));
     UDR0 = ch;
 #else
@@ -944,7 +949,7 @@ char getch(void)
 	return UDR1;
     }
     return 0;
-#elif defined (__AVR_ATmega168__) || defined(__AVR_ATmega328P__)
+#elif defined (__AVR_ATmega168__) || defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328__)
     uint32_t count = 0;
     while(!(UCSR0A & _BV(RXC0))){
     	/* 20060803 DojoCorp:: Addon coming from the previous Bootloader*/               
@@ -982,7 +987,7 @@ void getNch(uint8_t count)
 	    while(!(UCSR1A & _BV(RXC1)));
 	    UDR1;
 	}
-#elif (defined __AVR_ATmega168__) || defined(__AVR_ATmega328P__)
+#elif (defined __AVR_ATmega168__) || defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328__)
 	while(!(UCSR0A & _BV(RXC0)));
 	UDR0;
 #else

--- a/hardware/arduino/bootloaders/optiboot/optiboot.c
+++ b/hardware/arduino/bootloaders/optiboot/optiboot.c
@@ -231,7 +231,7 @@ void appStart() __attribute__ ((naked));
 #if defined(__AVR_ATmega168__)
 #define RAMSTART (0x100)
 #define NRWWSTART (0x3800)
-#elif defined(__AVR_ATmega328P__)
+#elif defined(__AVR_ATmega328P__) || defined (__AVR_ATmega328__)
 #define RAMSTART (0x100)
 #define NRWWSTART (0x7000)
 #elif defined (__AVR_ATmega644P__)

--- a/hardware/arduino/bootloaders/optiboot/pin_defs.h
+++ b/hardware/arduino/bootloaders/optiboot/pin_defs.h
@@ -1,4 +1,4 @@
-#if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__) || defined(__AVR_ATmega88) || defined(__AVR_ATmega8__) || defined(__AVR_ATmega88__)
+#if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328__) || defined(__AVR_ATmega88) || defined(__AVR_ATmega8__) || defined(__AVR_ATmega88__)
 /* Onboard LED is connected to pin PB5 in Arduino NG, Diecimila, and Duemilanove */ 
 #define LED_DDR     DDRB
 #define LED_PORT    PORTB

--- a/hardware/arduino/bootloaders/stk500v2/avrinterruptnames.h
+++ b/hardware/arduino/bootloaders/stk500v2/avrinterruptnames.h
@@ -270,8 +270,8 @@
 
 
 //**************************************************************************************************
-#if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__)
-#pragma mark __AVR_ATmega168__ / __AVR_ATmega328P__
+#if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328__)
+#pragma mark __AVR_ATmega168__ / __AVR_ATmega328P__ / __AVR_ATmega328__
 
 #define	_INTERRUPT_NAMES_DEFINED_
 

--- a/libraries/Firmata/Boards.h
+++ b/libraries/Firmata/Boards.h
@@ -129,7 +129,7 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #endif
 
 // Arduino Duemilanove, Diecimila, and NG
-#if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__)
+#if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328__)
 #if defined(NUM_ANALOG_INPUTS) && NUM_ANALOG_INPUTS == 6
 #define TOTAL_ANALOG_PINS       6
 #define TOTAL_PINS              20 // 14 digital + 6 analog


### PR DESCRIPTION
Add support for the 328 chip (different from the 328p) that the nanode and shrimp use.  If you decide to pull the fix from the defines branch first (pull request about to come), let me know and I'll fix this one to not conflict.