### PR TITLE
Fixdefines

### DIFF
--- a/hardware/arduino/bootloaders/atmega/ATmegaBOOT_168.c
+++ b/hardware/arduino/bootloaders/atmega/ATmegaBOOT_168.c
@@ -541,6 +541,7 @@ int main(void)
 		} else {
 			getNch(3);
 			byte_response(0x00);
+
 		}
 	}
 
@@ -679,7 +680,7 @@ int main(void)
 					 "rjmp	write_page	\n\t"
 					 "block_done:		\n\t"
 					 "clr	__zero_reg__	\n\t"	//restore zero register
-#if defined __AVR_ATmega168__  || __AVR_ATmega328P__ || __AVR_ATmega128__ || __AVR_ATmega1280__ || __AVR_ATmega1281__ 
+#if defined (__AVR_ATmega168__)  || defined (__AVR_ATmega328P__) || defined (__AVR_ATmega128__) || defined (__AVR_ATmega1280__) || defined (__AVR_ATmega1281__) 
 					 : "=m" (SPMCSR) : "M" (PAGE_SIZE) : "r0","r16","r17","r24","r25","r28","r29","r30","r31"
 #else
 					 : "=m" (SPMCR) : "M" (PAGE_SIZE) : "r0","r16","r17","r24","r25","r28","r29","r30","r31"

--- a/hardware/arduino/bootloaders/atmega/ATmegaBOOT_168.c
+++ b/hardware/arduino/bootloaders/atmega/ATmegaBOOT_168.c
@@ -580,7 +580,7 @@ int main(void)
 				/* if ((length.byte[0] & 0x01) == 0x01) length.word++;	//Even up an odd number of bytes */
 				if ((length.byte[0] & 0x01)) length.word++;	//Even up an odd number of bytes
 				cli();					//Disable interrupts, just to be sure
-#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega1281__)
+#if defined(EEPE)
 				while(bit_is_set(EECR,EEPE));			//Wait for previous EEPROM writes to complete
 #else
 				while(bit_is_set(EECR,EEWE));			//Wait for previous EEPROM writes to complete

--- a/hardware/arduino/bootloaders/atmega/Makefile
+++ b/hardware/arduino/bootloaders/atmega/Makefile
@@ -49,7 +49,7 @@ STK500-2 = $(STK500) -d$(MCU_TARGET) -ms -q -lCF -LCF -cUSB -I200kHz -s -wt
 
 
 OBJ        = $(PROGRAM).o
-OPTIMIZE   = -O2
+OPTIMIZE   = -Os
 
 DEFS       = 
 LIBS       =

--- a/hardware/arduino/bootloaders/bt/ATmegaBOOT_168.c
+++ b/hardware/arduino/bootloaders/bt/ATmegaBOOT_168.c
@@ -675,7 +675,7 @@ putch(0x0D);
 				 "rjmp	write_page	\n\t"
 				 "block_done:		\n\t"
 				 "clr	__zero_reg__	\n\t"	//restore zero register
-#if defined __AVR_ATmega168__  || __AVR_ATmega328P__
+#if defined(__AVR_ATmega168__)  || defined(__AVR_ATmega328P__)
 				 : "=m" (SPMCSR) : "M" (PAGE_SIZE) : "r0","r16","r17","r24","r25","r28","r29","r30","r31"
 #else
 				 : "=m" (SPMCR) : "M" (PAGE_SIZE) : "r0","r16","r17","r24","r25","r28","r29","r30","r31"
@@ -707,7 +707,7 @@ putch(0x0D);
 		putch(0x14);
 		for (w=0;w < length.word;w++) {		        // Can handle odd and even lengths okay
 		    if (flags.eeprom) {	                        // Byte access EEPROM read
-#if defined __AVR_ATmega168__  || __AVR_ATmega328P__
+#if defined(__AVR_ATmega168__)  || defined(__AVR_ATmega328P__)
 			while(EECR & (1<<EEPE));
 			EEAR = (uint16_t)(void *)address.word;
 			EECR |= (1<<EERE);


### PR DESCRIPTION
Multiple locations in the source are #if defined(blah) || blah2 || blah3 instead of #if defined(blah) || defined(blah2) ||  defined(blah3)

This branch fixes a few of them.