### PR TITLE
Patch SD library to allow re-initialization after power down

### DIFF
--- a/libraries/SD/SD.cpp
+++ b/libraries/SD/SD.cpp
@@ -340,6 +340,13 @@ boolean SDClass::begin(uint8_t csPin) {
     Return true if initialization succeeds, false otherwise.
 
    */
+
+  /* before trying to initialize the card, close the root if open */
+  /* this fixes a bug when we turn off the SD card to save power  */
+  if (root.isOpen())
+    if (!root.close())
+      return false;
+
   return card.init(SPI_HALF_SPEED, csPin) &&
          volume.init(card) &&
          root.openRoot(volume);


### PR DESCRIPTION
This is a patch of the SD library to allow the SD card to be re-initialized after having been powered off.

This patch fixes issue [1103](http://code.google.com/p/arduino/issues/detail?id=1103&start=400).

The problem was that the root directory is still marked as open and thus its initialization fails. The fix changes SD.init to first check if the root dir is open, and if so, closes it.
