### PR TITLE
User overridable `setup`, `loop` and `main` through `__attribute__((weak))`

### DIFF
--- a/hardware/arduino/cores/arduino/main.cpp
+++ b/hardware/arduino/cores/arduino/main.cpp
@@ -1,5 +1,9 @@
 #include <Arduino.h>
 
+extern "C" void setup(void) __attribute__((weak));
+extern "C" void loop(void) __attribute__((weak));
+
+__attribute__((weak))
 int main(void)
 {
 	init();
@@ -8,13 +12,12 @@ int main(void)
 	USBDevice.attach();
 #endif
 	
-	setup();
+	if (setup) setup();
     
 	for (;;) {
-		loop();
+		if (loop) loop();
 		if (serialEventRun) serialEventRun();
 	}
         
 	return 0;
 }
-


### PR DESCRIPTION
Following the same pattern as in the case of `serialEvent`, I've done the following:
- provide an empty implementation of the `setup` and `loop` functions;
- mark all three functions (`setup`, `loop` and `main`) as `__attribute__ ((weak))`
  so that the user is able to override them with customized versions;

See issue https://github.com/arduino/Arduino/issues/1138

(This is another variant of the pull request #1139)
