### PR TITLE
Enhancements in SoftwareSerial lib

### DIFF
--- a/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -376,15 +376,13 @@ void SoftwareSerial::setRX(uint8_t rx)
 // Public methods
 //
 
-bool SoftwareSerial::begin(long speed)
+void SoftwareSerial::begin(long speed)
 {
   _rx_delay_centering = _rx_delay_intrabit = _rx_delay_stopbit = _tx_delay = 0;
 
-  long baud = 0;
-
   for (unsigned i=0; i<sizeof(table)/sizeof(table[0]); ++i)
   {
-    baud = pgm_read_dword(&table[i].baud);
+    long baud = pgm_read_dword(&table[i].baud);
     if (baud == speed)
     {
       _rx_delay_centering = pgm_read_word(&table[i].rx_delay_centering);
@@ -394,7 +392,6 @@ bool SoftwareSerial::begin(long speed)
       break;
     }
   }
-  if (baud != speed) return false;
 
   // Set up RX interrupts, but only if we have a valid RX baud rate
   if (_rx_delay_stopbit)
@@ -413,8 +410,6 @@ bool SoftwareSerial::begin(long speed)
 #endif
 
   listen();
-
-  return true;
 }
 
 void SoftwareSerial::end()

--- a/libraries/SoftwareSerial/SoftwareSerial.h
+++ b/libraries/SoftwareSerial/SoftwareSerial.h
@@ -82,7 +82,7 @@ public:
   // public methods
   SoftwareSerial(uint8_t receivePin, uint8_t transmitPin, bool inverse_logic = false);
   ~SoftwareSerial();
-  bool begin(long speed);
+  void begin(long speed);
   bool listen();
   void end();
   bool isListening() { return this == active_object; }


### PR DESCRIPTION
I tried to use SotfwareSerial to communicate with a device at 600 Baud. Unfortunately, i did not succeed. And after spending some time to figure out the failure, i noticed that 
- the 600 Baud speed was simply not supported  (no delays in DELAY_TABLE) 
- begin(long speed) was returning normally even if speed was not supported.

So, i have added a 600 Baud line in DELAY_TABLE for each CPU frequency. This has been fully tested for 16 MHz. I have also changed the return type of begin(long speed) from void to bool in order to notify  unsupported speeds.
