### PR TITLE
Fix for Issue 933: Memory leak in Ethernet.cpp (allocating DHCP object)

### DIFF
--- a/libraries/Ethernet/Dhcp.cpp
+++ b/libraries/Ethernet/Dhcp.cpp
@@ -43,6 +43,7 @@ int DhcpClass::request_DHCP_lease(){
     _dhcpTransactionId = random(1UL, 2000UL);
     _dhcpInitialTransactionId = _dhcpTransactionId;
 
+    _dhcpUdpSocket.stop();
     if (_dhcpUdpSocket.begin(DHCP_CLIENT_PORT) == 0)
     {
       // Couldn't get a socket

--- a/libraries/Ethernet/Ethernet.cpp
+++ b/libraries/Ethernet/Ethernet.cpp
@@ -10,7 +10,8 @@ uint16_t EthernetClass::_server_port[MAX_SOCK_NUM] = {
 
 int EthernetClass::begin(uint8_t *mac_address)
 {
-  _dhcp = new DhcpClass();
+  static DhcpClass s_dhcp;
+  _dhcp = &s_dhcp;
 
 
   // Initialise the basic info


### PR DESCRIPTION
- Fixes memory leak when calling Ethernet.begin() multiple times
- Ensure the UDP socket is closed before trying to open it

As per discussion here: [Issue 933](http://code.google.com/p/arduino/issues/detail?id=933)

The static solution was chosen as this has several benefits:
- Does not require refactoring DhcpClient to include a destructor, which may have had unintended knock-ons.
- Maintains the existing behaviour while avoiding the issue.
- Avoids pulling in operator new() when it may not otherwise be pulled in.
- Minimal changes were required.
