### PR TITLE
Updated LiquidCrystal.h to fix ambiguous call to overloaded write() method.

### DIFF
--- a/libraries/LiquidCrystal/LiquidCrystal.h
+++ b/libraries/LiquidCrystal/LiquidCrystal.h
@@ -82,7 +82,13 @@ public:
   virtual size_t write(uint8_t);
   void command(uint8_t);
   
-  using Print::write;
+    // using Print::write;
+    // The above line was commented out to eliminate the ambiguous
+    // overloading of the write function, which caused compile error.  The problem
+    // was that it could not determine the the type of argument when using lcd.write(0);
+    // It would work if first defining a variable of type ] int or char or byte
+    // such as byte custHeartChar = 0; and then using lcd.write(custHeartChar);
+    
 private:
   void send(uint8_t, uint8_t);
   void write4bits(uint8_t);


### PR DESCRIPTION
When the argument to a call to `lcd.write()` is a zero - `lcd.write(0)` - the compiler cannot ascertain the data type of the argument. This is evidenced in example CustomCharacter.ino. However, it compiles properly when the argument is made clear, for example, first declare a variable of type byte (works with int , char, etc. also) such as `byte custHeartChar = 0;`  Then call `lcd.write(custHeartChar);`  Then, all is well.  I commented out `using Print:write` as the fix.  This does not seem to break anything, but additional tests may be warranted. I am setting some up now to validate. 
