### PR TITLE
Default sketchbook folder for Linux should be "Arduino".

### DIFF
--- a/app/src/processing/app/linux/Platform.java
+++ b/app/src/processing/app/linux/Platform.java
@@ -53,6 +53,12 @@ public class Platform extends processing.app.Platform {
   }
 
 
+  public File getDefaultSketchbookFolder() throws Exception {
+    File home = new File(System.getProperty("user.home"));
+    return new File(home, "Arduino");
+  }
+
+
   public void openURL(String url) throws Exception {
     if (openFolderAvailable()) {
       String launcher = Preferences.get("launcher");


### PR DESCRIPTION
This is a pull request based on "ide-1.5.x" branch. You may want to make the same modification on "master" branch.
