### PR TITLE
Add rts dtr and baudrate public functions in CDC Serial_ class

### DIFF
--- a/hardware/arduino/cores/arduino/CDC.cpp
+++ b/hardware/arduino/cores/arduino/CDC.cpp
@@ -237,6 +237,23 @@ Serial_::operator bool() {
 	return result;
 }
 
+
+unsigned long Serial_::baudrate(void)
+{
+	return 	_usbLineInfo.dwDTERate;
+}
+
+bool Serial_::dtr(void)
+{
+	return (_usbLineInfo.lineState & 0x01) == 0x01;
+}
+
+bool Serial_::rts(void)
+{
+	return (_usbLineInfo.lineState & 0x02) == 0x02;
+}
+
+
 Serial_ Serial;
 
 #endif

--- a/hardware/arduino/cores/arduino/USBAPI.h
+++ b/hardware/arduino/cores/arduino/USBAPI.h
@@ -40,6 +40,9 @@ public:
 	virtual int read(void);
 	virtual void flush(void);
 	virtual size_t write(uint8_t);
+	virtual unsigned long baudrate(void);
+	virtual bool dtr(void);
+	virtual bool rts(void);
 	using Print::write; // pull in write(str) and write(buf, size) from Print
 	operator bool();
 };


### PR DESCRIPTION
This permit to use the CDC serial link like a modem. For example configuration
mode while DTR is low and data mode otherwise.

Signed-off-by: Stany MARCEL <stanypub@gmail.com>