### PR TITLE
Scroll the editor tab menu.

### DIFF
--- a/app/src/processing/app/EditorHeader.java
+++ b/app/src/processing/app/EditorHeader.java
@@ -22,6 +22,7 @@
 */
 
 package processing.app;
+import processing.app.tools.MenuScroller;
 import static processing.app.I18n._;
 
 import java.awt.*;
@@ -238,6 +239,7 @@ public class EditorHeader extends JComponent {
 
     } else {
       menu = new JMenu();
+      MenuScroller.setScrollerFor(menu);
       popup = menu.getPopupMenu();
       add(popup);
       popup.setLightWeightPopupEnabled(true);


### PR DESCRIPTION
When the sketch folder contains a lot of source files, the editor
tab menu should scroll. Without this, we don't have a way to select
some files hidden under bottom edge of the screen.
