### PR TITLE
Feature: implement DHCP options provider and parser

### DIFF
--- a/libraries/Ethernet/Dhcp.h
+++ b/libraries/Ethernet/Dhcp.h
@@ -115,7 +115,7 @@ enum
 	dhcpMaxMsgSize		=	57,*/
 	dhcpT1value		=	58,
 	dhcpT2value		=	59,
-	/*dhcpClassIdentifier	=	60,*/
+	dhcpClassIdentifier	=	60,
 	dhcpClientIdentifier	=	61,
 	endOption		=	255
 };
@@ -135,6 +135,9 @@ typedef struct _RIP_MSG_FIXED
 	uint8_t  giaddr[4];
 	uint8_t  chaddr[6];
 }RIP_MSG_FIXED;
+
+typedef void (DhcpOptionParser)(uint8_t optionType, EthernetUDP *client);
+typedef void (DhcpOptionProvider)(uint8_t messageType, EthernetUDP *client);
 
 class DhcpClass {
 private:
@@ -156,6 +159,8 @@ private:
   unsigned long _secTimeout;
   uint8_t _dhcp_state;
   EthernetUDP _dhcpUdpSocket;
+  DhcpOptionProvider* _optionProvider;
+  DhcpOptionParser* _optionParser;
   
   int request_DHCP_lease();
   void reset_DHCP_lease();
@@ -165,6 +170,8 @@ private:
   
   uint8_t parseDHCPResponse(unsigned long responseTimeout, uint32_t& transactionId);
 public:
+  DhcpClass() : _optionParser(NULL), _optionProvider(NULL) {};
+
   IPAddress getLocalIp();
   IPAddress getSubnetMask();
   IPAddress getGatewayIp();
@@ -173,6 +180,9 @@ public:
   
   int beginWithDHCP(uint8_t *, unsigned long timeout = 60000, unsigned long responseTimeout = 4000);
   int checkLease();
+
+  void setOptionParser(DhcpOptionParser* optionParser);
+  void setOptionProvider(DhcpOptionProvider* optionProvider);
 };
 
 #endif

--- a/libraries/Ethernet/Ethernet.cpp
+++ b/libraries/Ethernet/Ethernet.cpp
@@ -8,11 +8,12 @@ uint8_t EthernetClass::_state[MAX_SOCK_NUM] = {
 uint16_t EthernetClass::_server_port[MAX_SOCK_NUM] = { 
   0, 0, 0, 0 };
 
-int EthernetClass::begin(uint8_t *mac_address)
+int EthernetClass::begin(uint8_t *mac_address, DhcpOptionParser* optionParser, DhcpOptionProvider* optionProvider)
 {
   static DhcpClass s_dhcp;
   _dhcp = &s_dhcp;
-
+  _dhcp->setOptionParser(optionParser);
+  _dhcp->setOptionProvider(optionProvider);
 
   // Initialise the basic info
   W5100.init();
@@ -32,6 +33,10 @@ int EthernetClass::begin(uint8_t *mac_address)
   }
 
   return ret;
+}
+
+int EthernetClass::begin(uint8_t *mac_address) {
+  return begin(mac_address, NULL, NULL);
 }
 
 void EthernetClass::begin(uint8_t *mac_address, IPAddress local_ip)

--- a/libraries/Ethernet/Ethernet.h
+++ b/libraries/Ethernet/Ethernet.h
@@ -21,6 +21,7 @@ public:
   // configuration through DHCP.
   // Returns 0 if the DHCP configuration failed, and 1 if it succeeded
   int begin(uint8_t *mac_address);
+  int begin(uint8_t *mac_address, DhcpOptionParser* parser, DhcpOptionProvider* provider);
   void begin(uint8_t *mac_address, IPAddress local_ip);
   void begin(uint8_t *mac_address, IPAddress local_ip, IPAddress dns_server);
   void begin(uint8_t *mac_address, IPAddress local_ip, IPAddress dns_server, IPAddress gateway);


### PR DESCRIPTION
I have implemented a feature to allow Ethernet library user to supply and read DHCP options. 

This functionality is very useful when you need to provide run-time configuration to the Arduino board. Since objective of DHCP is "host configuration" it is an ideal choice to use to pass parameters to the board. This commit also allows board to send additional options as part of the request. In my case, for example, it was necessary to provide additional Vendor Class Identifier (option 60) for the DHCP server to answer.

Here is a sample code:

``` c
// Define two functions to provide the DHCP options:

/** DHCP custom option parser.
 * At the moment will extract DNS domain (option 15) and store it separately).
 *
 * \warning The code must read() through the option even if it is unknown.
 * @param optionType DHCP option type as per standard.
 * @param dhcpUdpSocket Reference to UDP socket where to read the data from.
 */
void dhcpOptionParser(const uint8_t optionType, EthernetUDP *dhcpUdpSocket) {
    uint8_t opt_len = dhcpUdpSocket->read();

    if (optionType == 15) { // domain name
        // read the value with dhcpUdpSocket->read()
    } else {
        while (opt_len--) {
            dhcpUdpSocket->read();
        }        
    }
}

/** DHCP option provider.
 * Send Vendor Class Identifier (60) option as part of DHCP request.
 * @param messageType type of outgoing DHCP message
 * @param dhcpUdpSocket socket to write to
 */
void dhcpOptionProvider(const uint8_t messageType, EthernetUDP *dhcpUdpSocket) {
    uint8_t buffer[] = {
        dhcpClassIdentifier,
        0x08,
        'M','S','F','T',' ','5','.','0'
    };
    dhcpUdpSocket->write(buffer, 10);
}

//...

// Initialize the Ethernet library in setup() phase
void setup() {
    // ...
    Ethernet.begin(mac, (DhcpOptionParser *) &dhcpOptionParser, (DhcpOptionProvider *) &dhcpOptionProvider);
    // ...
}
```

Please refer to dhcp-options(5) http://linux.die.net/man/5/dhcp-options chapter "Defining New Options" for an example on how to provide custom options with isc-dhcp server. Other DHCP servers should have similar support.
