### PR TITLE
Boards Directory

### DIFF
--- a/app/src/processing/app/debug/TargetPlatform.java
+++ b/app/src/processing/app/debug/TargetPlatform.java
@@ -53,19 +53,41 @@ public class TargetPlatform {
       String notused = _("Processor");
     }
 
+    PreferencesMap boardPreferences = new PreferencesMap();
+
     try {
       File boardsFile = new File(_folder, "boards.txt");
       if (boardsFile.exists() && boardsFile.canRead()) {
-        PreferencesMap boardPreferences = new PreferencesMap();
         boardPreferences.load(boardsFile);
-        boards = boardPreferences.createFirstLevelMap();
-        customMenus = MapWithSubkeys.createFrom(boards.get("menu"));
-        boards.remove("menu");
       }
     } catch (Exception e) {
-      e.printStackTrace();
-      System.err.println("Error loading boards from boards.txt: " + e);
     }
+
+    try {
+      File boardsDir = new File(_folder, "boards");
+      if (boardsDir.isDirectory()) {
+        for (String name : boardsDir.list()) {
+          if (name.endsWith(".txt")) {
+            try {
+              File boardsFile = new File(boardsDir, name);
+              if (boardsFile.exists()) {
+                boardPreferences.load(boardsFile);
+              }
+            } catch (Exception e) {
+            }
+          }
+        }
+      }
+    } catch (Exception e) {
+    }
+
+    if (boardPreferences.size() == 0) {
+      System.err.println("No board definitions found in boards.txt and boards directory");
+    }
+
+    boards = boardPreferences.createFirstLevelMap();
+    customMenus = MapWithSubkeys.createFrom(boards.get("menu"));
+    boards.remove("menu");
 
     try {
       File platformsFile = new File(_folder, "platform.txt");


### PR DESCRIPTION
Load the board definitions from text files inside "board" directory
in addition to the "boards.txt" file.

This makes users to install a new board definition for third party
Arduino derivatives by just dropping a file.
