### PR TITLE
1.5.x enhancements: serial monitor autostart and editor window size autosave

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -875,6 +875,10 @@ public class Base {
     // Close the running window, avoid window boogers with multiple sketches
     editor.internalCloseRunner();
 
+	int[] location = editor.getPlacement();
+    Preferences.setInteger("editor.window.width.default", location[2]);
+    Preferences.setInteger("editor.window.height.default", location[3]);
+
     if (editors.size() == 1) {
       // For 0158, when closing the last window /and/ it was already an
       // untitled sketch, just give up and let the user quit.

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -2414,14 +2414,14 @@ public class Editor extends JFrame implements RunnerListener {
   // DAM: in Arduino, this is upload
   class DefaultExportHandler implements Runnable {
     public void run() {
-
+      boolean success = false;
       try {
         serialMonitor.closeSerialPort();
         serialMonitor.setVisible(false);
             
         uploading = true;
           
-        boolean success = sketch.exportApplet(false);
+        success = sketch.exportApplet(false);
         if (success) {
           statusNotice(_("Done uploading."));
         } else {
@@ -2444,20 +2444,24 @@ public class Editor extends JFrame implements RunnerListener {
       uploading = false;
       //toolbar.clear();
       toolbar.deactivate(EditorToolbar.EXPORT);
+      if (success && Preferences.getBoolean("serial.autostart")) {
+        statusNotice(_("Done uploading... Opening serial monitor."));
+        handleSerial();
+      }
     }
   }
 
   // DAM: in Arduino, this is upload (with verbose output)
   class DefaultExportAppHandler implements Runnable {
     public void run() {
-
+      boolean success = false;
       try {
         serialMonitor.closeSerialPort();
         serialMonitor.setVisible(false);
             
         uploading = true;
           
-        boolean success = sketch.exportApplet(true);
+        success = sketch.exportApplet(true);
         if (success) {
           statusNotice(_("Done uploading."));
         } else {
@@ -2480,6 +2484,10 @@ public class Editor extends JFrame implements RunnerListener {
       uploading = false;
       //toolbar.clear();
       toolbar.deactivate(EditorToolbar.EXPORT);
+      if (success && Preferences.getBoolean("serial.autostart")) {
+        statusNotice(_("Done uploading... Opening serial monitor."));
+        handleSerial();
+      }
     }
   }
 

--- a/app/src/processing/app/EditorListener.java
+++ b/app/src/processing/app/EditorListener.java
@@ -131,8 +131,7 @@ public class EditorListener {
 
       // The char is not control code when CTRL key pressed? It should be a shortcut.
       if (!Character.isISOControl(c)) {
-        event.consume();
-        return true;
+        return false;
       }
     }
 

--- a/build/shared/lib/preferences.txt
+++ b/build/shared/lib/preferences.txt
@@ -259,6 +259,7 @@ serial.databits=8
 serial.stopbits=1
 serial.parity=N
 serial.debug_rate=9600
+serial.autostart=false
 
 # I18 Preferences
 

--- a/build/shared/revisions.txt
+++ b/build/shared/revisions.txt
@@ -1,3 +1,10 @@
+﻿ARDUINO 1.5.3 BETA
+
+[ide]
+* Add preference serial.autostart to start serial monitor after a
+  successful upload (Martin Falatic)
+* Save editor.window.{width|height}.default values based on last
+  editor window closed (Martin Falatic)
 
 ARDUINO 1.5.3 BETA
 


### PR DESCRIPTION
I've created two small enhancements targeting 1.5.x:

* Add preference serial.autostart to start serial monitor after a successful upload (Martin Falatic)

* Save editor.window.{width|height}.default values based on last editor window closed (Martin Falatic)
