### PR TITLE
Send byte array from serial-monitor

### DIFF
--- a/app/src/processing/app/ByteStringException.java
+++ b/app/src/processing/app/ByteStringException.java
@@ -1,0 +1,42 @@
+/*
+ * ByteStringException.java
+ * 
+ * Copyright 2013 Sam <sam.sgrs@gmail.com>
+ * 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ * 
+ * 
+ */
+
+package processing.app;
+
+public class ByteStringException extends Exception {
+  public ByteStringException() {
+    super();
+  }
+
+  public ByteStringException(String message) {
+    super(message);
+  }
+
+  public ByteStringException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public ByteStringException(Throwable cause) {
+    super(cause);
+  }
+}


### PR DESCRIPTION
Add the ability to send an array of bytes from the serial-monitor.
You write them using a comma separated list of hex, oct, dec or binary numbers.
It gives an error when the string is malformated.
In this case a new exception, ByteStringException, occures which is getting caught.

![arduino 1](https://f.cloud.github.com/assets/1176649/146075/52fee18e-747c-11e2-80a1-4961cec0f674.png)
![arduino 2](https://f.cloud.github.com/assets/1176649/146076/55ac7a4a-747c-11e2-8516-1e13e5132632.png)
![arduino 3](https://f.cloud.github.com/assets/1176649/146077/57f7d934-747c-11e2-82a2-83b5be228966.png)
![arduino 4](https://f.cloud.github.com/assets/1176649/146078/5a65f7a0-747c-11e2-8894-96b5466d45e1.png)
![arduino 5](https://f.cloud.github.com/assets/1176649/146080/5c65a974-747c-11e2-98e4-7f0ec3783b60.png)
![arduino 6](https://f.cloud.github.com/assets/1176649/146081/5ec19b7e-747c-11e2-8211-8811858ff9da.png)





