### PR TITLE
Added support for all variants of Sanguino

### DIFF
--- a/hardware/arduino/cores/arduino/Arduino.h
+++ b/hardware/arduino/cores/arduino/Arduino.h
@@ -46,7 +46,7 @@ extern "C"{
 #define EXTERNAL 1
 #define INTERNAL 2
 #else  
-#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega644P__)
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega644__) || defined(__AVR_ATmega644A__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644PA__)
 #define INTERNAL1V1 2
 #define INTERNAL2V56 3
 #else

--- a/hardware/arduino/cores/arduino/wiring_analog.c
+++ b/hardware/arduino/cores/arduino/wiring_analog.c
@@ -45,7 +45,7 @@ int analogRead(uint8_t pin)
 	if (pin >= 54) pin -= 54; // allow for channel or pin numbers
 #elif defined(__AVR_ATmega32U4__)
 	if (pin >= 18) pin -= 18; // allow for channel or pin numbers
-#elif defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega644P__)
+#elif defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega644__) || defined(__AVR_ATmega644A__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644PA__)
 	if (pin >= 24) pin -= 24; // allow for channel or pin numbers
 #elif defined(analogPinToChannel) && (defined(__AVR_ATtiny25__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__))
 	pin = analogPinToChannel(pin);

--- a/hardware/arduino/cores/arduino/wiring_private.h
+++ b/hardware/arduino/cores/arduino/wiring_private.h
@@ -54,7 +54,7 @@ extern "C"{
 
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
 #define EXTERNAL_NUM_INTERRUPTS 8
-#elif defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega644P__)
+#elif defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega644__) || defined(__AVR_ATmega644A__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644PA__)
 #define EXTERNAL_NUM_INTERRUPTS 3
 #elif defined(__AVR_ATmega32U4__)
 #define EXTERNAL_NUM_INTERRUPTS 4


### PR DESCRIPTION
I have created a git repository with support for all variants of Sanguino:
- ATmega644
- ATmega644A
- ATmega644P
- ATmega644PA
- ATmega1284
- ATmega1284P

Both 16MHz and 8MHz versions are available.

My repo can be found here: https://github.com/Lauszus/Sanguino.

I don't know how your opinion is regarding adding support for other MCU's, but I think these are rather popular and they are also available in a DIP package, so I think it would be nice if they where supported in the official core.
