### PR TITLE
Add error handling to HardwareSerial

### DIFF
--- a/hardware/arduino/cores/arduino/HardwareSerial.h
+++ b/hardware/arduino/cores/arduino/HardwareSerial.h
@@ -94,6 +94,10 @@ class HardwareSerial : public Stream
 #define SERIAL_7O2 0x3C
 #define SERIAL_8O2 0x3E
 
+#define SERIAL_ERROR_FRAME   0x01
+#define SERIAL_ERROR_OVERRUN 0x02
+#define SERIAL_ERROR_PARITY  0x04
+
 #if defined(UBRRH) || defined(UBRR0H)
   extern HardwareSerial Serial;
 #elif defined(USBCON)


### PR DESCRIPTION
Check for USART receive error flags and call serialError{|1|2|3} at serialEventRun(). Currently the error flags are not stored in the HardwareSerial class and are cleared after every call.
## 

This is my first pull request so don't hold out on any advice.
