### PR TITLE
Ide 1.5.x Cleaned up a few warnings and fixed strict-aliasing

### DIFF
--- a/hardware/arduino/avr/cores/arduino/HardwareSerial.cpp
+++ b/hardware/arduino/avr/cores/arduino/HardwareSerial.cpp
@@ -54,9 +54,9 @@
 // to which to write the next incoming character and tail is the index of the
 // location from which to read.
 #if (RAMEND < 1000)
-  #define SERIAL_BUFFER_SIZE 16
+  #define SERIAL_BUFFER_SIZE 16U
 #else
-  #define SERIAL_BUFFER_SIZE 64
+  #define SERIAL_BUFFER_SIZE 64U
 #endif
 
 struct ring_buffer
@@ -89,7 +89,7 @@ struct ring_buffer
 
 inline void store_char(unsigned char c, ring_buffer *buffer)
 {
-  int i = (unsigned int)(buffer->head + 1) % SERIAL_BUFFER_SIZE;
+  unsigned int i = (unsigned int)(buffer->head + 1) % SERIAL_BUFFER_SIZE;
 
   // if we should be storing the received character into the location
   // just before the tail (meaning that the head would advance to the
@@ -120,18 +120,20 @@ inline void store_char(unsigned char c, ring_buffer *buffer)
 #endif
   {
   #if defined(UDR0)
+    unsigned char c;
     if (bit_is_clear(UCSR0A, UPE0)) {
-      unsigned char c = UDR0;
+      c = UDR0;
       store_char(c, &rx_buffer);
     } else {
-      unsigned char c = UDR0;
+      c = UDR0;
     };
   #elif defined(UDR)
+    unsigned char c;
     if (bit_is_clear(UCSRA, PE)) {
-      unsigned char c = UDR;
+      c = UDR;
       store_char(c, &rx_buffer);
     } else {
-      unsigned char c = UDR;
+      c = UDR;
     };
   #else
     #error UDR not defined
@@ -146,11 +148,12 @@ inline void store_char(unsigned char c, ring_buffer *buffer)
   #define serialEvent1_implemented
   ISR(USART1_RX_vect)
   {
+    unsigned char c;
     if (bit_is_clear(UCSR1A, UPE1)) {
-      unsigned char c = UDR1;
+      c = UDR1;
       store_char(c, &rx_buffer1);
     } else {
-      unsigned char c = UDR1;
+      c = UDR1;
     };
   }
 #endif
@@ -161,11 +164,12 @@ inline void store_char(unsigned char c, ring_buffer *buffer)
   #define serialEvent2_implemented
   ISR(USART2_RX_vect)
   {
+    unsigned char c;
     if (bit_is_clear(UCSR2A, UPE2)) {
-      unsigned char c = UDR2;
+      c = UDR2;
       store_char(c, &rx_buffer2);
     } else {
-      unsigned char c = UDR2;
+      c = UDR2;
     };
   }
 #endif
@@ -176,11 +180,12 @@ inline void store_char(unsigned char c, ring_buffer *buffer)
   #define serialEvent3_implemented
   ISR(USART3_RX_vect)
   {
+    unsigned char c;
     if (bit_is_clear(UCSR3A, UPE3)) {
-      unsigned char c = UDR3;
+      c = UDR3;
       store_char(c, &rx_buffer3);
     } else {
-      unsigned char c = UDR3;
+      c = UDR3;
     };
   }
 #endif
@@ -365,7 +370,6 @@ try_again:
 void HardwareSerial::begin(unsigned long baud, byte config)
 {
   uint16_t baud_setting;
-  uint8_t current_config;
   bool use_u2x = true;
 
 #if F_CPU == 16000000UL
@@ -453,13 +457,14 @@ int HardwareSerial::read(void)
 void HardwareSerial::flush()
 {
   // UDR is kept full while the buffer is not empty, so TXC triggers when EMPTY && SENT
-  while (transmitting && ! (*_ucsra & _BV(TXC0)));
+  while (transmitting && ! (*_ucsra & _BV(TXC0)))
+	  ;
   transmitting = false;
 }
 
 size_t HardwareSerial::write(uint8_t c)
 {
-  int i = (_tx_buffer->head + 1) % SERIAL_BUFFER_SIZE;
+  unsigned int i = (_tx_buffer->head + 1) % SERIAL_BUFFER_SIZE;
 	
   // If the output buffer is full, there's nothing for it other than to 
   // wait for the interrupt handler to empty it a bit

--- a/hardware/arduino/avr/cores/arduino/IPAddress.h
+++ b/hardware/arduino/avr/cores/arduino/IPAddress.h
@@ -48,8 +48,14 @@ public:
 
     // Overloaded cast operator to allow IPAddress objects to be used where a pointer
     // to a four-byte uint8_t array is expected
-    operator uint32_t() { return *((uint32_t*)_address); };
-    bool operator==(const IPAddress& addr) { return (*((uint32_t*)_address)) == (*((uint32_t*)addr._address)); };
+    operator uint32_t() { return ((uint32_t)_address[0] << 0 |
+		    		  (uint32_t)_address[1] << 8 |
+				  (uint32_t)_address[2] << 16 |
+				  (uint32_t)_address[3] << 24); }
+    bool operator==(const IPAddress& addr) { return (_address[0] == addr._address[0] &&
+		    				     _address[1] == addr._address[1] &&
+		    				     _address[2] == addr._address[2] &&
+		    				     _address[3] == addr._address[3]); }
     bool operator==(const uint8_t* addr);
 
     // Overloaded index operator to allow getting and setting individual octets of the address

--- a/hardware/arduino/avr/cores/arduino/Print.cpp
+++ b/hardware/arduino/avr/cores/arduino/Print.cpp
@@ -41,7 +41,7 @@ size_t Print::write(const uint8_t *buffer, size_t size)
 
 size_t Print::print(const __FlashStringHelper *ifsh)
 {
-  const char PROGMEM *p = (const char PROGMEM *)ifsh;
+  const char *p = (const char *)ifsh;
   size_t n = 0;
   while (1) {
     unsigned char c = pgm_read_byte(p++);

--- a/hardware/arduino/avr/cores/arduino/Stream.cpp
+++ b/hardware/arduino/avr/cores/arduino/Stream.cpp
@@ -176,7 +176,7 @@ float Stream::parseFloat(char skipChar){
   boolean isNegative = false;
   boolean isFraction = false;
   long value = 0;
-  char c;
+  signed char c;
   float fraction = 1.0;
 
   c = peekNextDigit();

--- a/hardware/arduino/avr/cores/arduino/wiring_private.h
+++ b/hardware/arduino/avr/cores/arduino/wiring_private.h
@@ -52,7 +52,8 @@ extern "C"{
 #define EXTERNAL_INT_6 6
 #define EXTERNAL_INT_7 7
 
-#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || \
+    defined(__AVR_ATmega128RFA1__) || defined(__AVR_ATmega256RFR2__)
 #define EXTERNAL_NUM_INTERRUPTS 8
 #elif defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega644P__)
 #define EXTERNAL_NUM_INTERRUPTS 3


### PR DESCRIPTION
Cleaned up warnings about unsigned types, unused variables, and
declarations.

Explicitly declare char as signed for cases when compiling with
-funsigned-char.

Fixed strict-aliasing issues in IPAddress.h.

Fixed array overrun where EXTERNAL_NUM_INTERRUPTS was defined too small.
