### PR TITLE
Only disable timer interrupt instead of all interrutps in millis()/micros()

### DIFF
--- a/hardware/arduino/cores/arduino/wiring.c
+++ b/hardware/arduino/cores/arduino/wiring.c
@@ -67,22 +67,21 @@ ISR(TIMER0_OVF_vect)
 unsigned long millis()
 {
 	unsigned long m;
-	uint8_t oldSREG = SREG;
 
-	// disable interrupts while we read timer0_millis or we might get an
+	// disable overflow interrupt while we read timer0_millis or we might get an
 	// inconsistent value (e.g. in the middle of a write to timer0_millis)
-	cli();
+	// See: http://forum.arduino.cc/index.php?topic=168864.0
+	TIMSK0 &= ~(1 << TOIE0); // Clear Overflow Interrupt Enable
 	m = timer0_millis;
-	SREG = oldSREG;
-
+	TIMSK0 |= 1 << TOIE0; // Sets Overflow Interrupt Enable
 	return m;
 }
 
 unsigned long micros() {
 	unsigned long m;
-	uint8_t oldSREG = SREG, t;
+	uint8_t t;
 	
-	cli();
+	TIMSK0 &= ~(1 << TOIE0); // Clear Overflow Interrupt Enable
 	m = timer0_overflow_count;
 #if defined(TCNT0)
 	t = TCNT0;
@@ -101,7 +100,7 @@ unsigned long micros() {
 		m++;
 #endif
 
-	SREG = oldSREG;
+	TIMSK0 |= 1 << TOIE0; // Sets Overflow Interrupt Enable
 	
 	return ((m << 8) + t) * (64 / clockCyclesPerMicrosecond());
 }


### PR DESCRIPTION
In wiring lib, usualy a global interrupt disabled is issued when not realy needed.
It's very bad for timed interrupt sensitive designs
More info at: http://forum.arduino.cc/index.php?topic=168586.0
