### PR TITLE
newer avr-libc debricated some typedefs, this enables compatabillity

### DIFF
--- a/app/src/processing/app/debug/Compiler.java
+++ b/app/src/processing/app/debug/Compiler.java
@@ -553,6 +553,7 @@ public class Compiler implements MessageConsumer {
       "-DARDUINO=" + Base.REVISION,
       "-DUSB_VID=" + boardPreferences.get("build.vid"),
       "-DUSB_PID=" + boardPreferences.get("build.pid"),
+      "-D__PROG_TYPES_COMPAT__",
     }));
 
     for (int i = 0; i < includePaths.size(); i++) {
@@ -583,6 +584,7 @@ public class Compiler implements MessageConsumer {
       "-DUSB_VID=" + boardPreferences.get("build.vid"),
       "-DUSB_PID=" + boardPreferences.get("build.pid"),
       "-DARDUINO=" + Base.REVISION, 
+      "-D__PROG_TYPES_COMPAT__",
     }));
 		
     for (int i = 0; i < includePaths.size(); i++) {
@@ -616,6 +618,7 @@ public class Compiler implements MessageConsumer {
       "-DUSB_VID=" + boardPreferences.get("build.vid"),
       "-DUSB_PID=" + boardPreferences.get("build.pid"),      
       "-DARDUINO=" + Base.REVISION,
+      "-D__PROG_TYPES_COMPAT__",
     }));
 
     for (int i = 0; i < includePaths.size(); i++) {


### PR DESCRIPTION
many examples/libraries will fail to compile with newer avr-libc that no longer has the typedef for prog_uchar and many other variables. This flag enables compatibility.