### PR TITLE
typo in Adafruit_ST7735

### DIFF
--- a/libraries/TFT/utility/Adafruit_ST7735.h
+++ b/libraries/TFT/utility/Adafruit_ST7735.h
@@ -25,7 +25,7 @@
 #else
  #include "WProgram.h"
 #endif
-#include <Adafruit_GFX.h>
+#include "Adafruit_GFX.h"
 #include <avr/pgmspace.h>
 
 // some flags for initR() :(


### PR DESCRIPTION
examples fail to build because it can't find Adafruit_GFX.h

this pull fixes that
