### PR TITLE
Use of eeprom_update_byte instead of eeprom_write_byte

### DIFF
--- a/libraries/EEPROM/EEPROM.cpp
+++ b/libraries/EEPROM/EEPROM.cpp
@@ -44,7 +44,7 @@ uint8_t EEPROMClass::read(int address)
 
 void EEPROMClass::write(int address, uint8_t value)
 {
-	eeprom_write_byte((unsigned char *) address, value);
+	eeprom_update_byte((unsigned char *) address, value);
 }
 
 EEPROMClass EEPROM;


### PR DESCRIPTION
Using eeprom_update_byte the code won't write on the EEPROM cell if it already contains the value that the user wants to write into it.