### PR TITLE
Update incorrect docs in tonePitchFollower example

### DIFF
--- a/build/shared/examples/02.Digital/tonePitchFollower/tonePitchFollower.ino
+++ b/build/shared/examples/02.Digital/tonePitchFollower/tonePitchFollower.ino
@@ -4,7 +4,7 @@
  Plays a pitch that changes based on a changing analog input
  
  circuit:
- * 8-ohm speaker on digital pin 8
+ * 8-ohm speaker on digital pin 9
  * photoresistor on analog 0 to 5V
  * 4.7K resistor on analog 0 to ground
  


### PR DESCRIPTION
The comments state that the speaker should be on pin 8, but the code references pin 9. Updated the comments to reflect the correct pin.

http://arduino.cc/en/Tutorial/Tone2 also requires an update.
