### PR TITLE
fix for issue #1295 "leonardo as keyboard does not wake windows 7 from sleep"

### DIFF
--- a/hardware/arduino/cores/arduino/HID.cpp
+++ b/hardware/arduino/cores/arduino/HID.cpp
@@ -2,6 +2,8 @@
 
 /* Copyright (c) 2011, Peter Barrett  
 **  
+** Sleep/Wakeup/SystemControl support added by Michael Dreher
+**
 ** Permission to use, copy, modify, and/or distribute this software for  
 ** any purpose with or without fee is hereby granted, provided that the  
 ** above copyright notice and this permission notice appear in all copies.  
@@ -43,16 +45,20 @@ Keyboard_ Keyboard;
 #define RAWHID_TX_SIZE 64
 #define RAWHID_RX_SIZE 64
 
+#define HID_REPORTID_MOUSE (1)
+#define HID_REPORTID_KEYBOARD (2)
+#define HID_REPORTID_RAWHID (3)
+#define HID_REPORTID_SYSTEMCONTROL (4)
 extern const u8 _hidReportDescriptor[] PROGMEM;
 const u8 _hidReportDescriptor[] = {
 	
-	//	Mouse
+    //  Mouse
     0x05, 0x01,                    // USAGE_PAGE (Generic Desktop)	// 54
     0x09, 0x02,                    // USAGE (Mouse)
     0xa1, 0x01,                    // COLLECTION (Application)
     0x09, 0x01,                    //   USAGE (Pointer)
     0xa1, 0x00,                    //   COLLECTION (Physical)
-    0x85, 0x01,                    //     REPORT_ID (1)
+    0x85, HID_REPORTID_MOUSE,      //     REPORT_ID (1)
     0x05, 0x09,                    //     USAGE_PAGE (Button)
     0x19, 0x01,                    //     USAGE_MINIMUM (Button 1)
     0x29, 0x03,                    //     USAGE_MAXIMUM (Button 3)
@@ -76,34 +82,64 @@ const u8 _hidReportDescriptor[] = {
     0xc0,                          //   END_COLLECTION
     0xc0,                          // END_COLLECTION
 
-	//	Keyboard
+    //  Keyboard
     0x05, 0x01,                    // USAGE_PAGE (Generic Desktop)	// 47
     0x09, 0x06,                    // USAGE (Keyboard)
     0xa1, 0x01,                    // COLLECTION (Application)
-    0x85, 0x02,                    //   REPORT_ID (2)
+    0x85, HID_REPORTID_KEYBOARD,   //   REPORT_ID (2)
     0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
    
-	0x19, 0xe0,                    //   USAGE_MINIMUM (Keyboard LeftControl)
+    0x19, 0xe0,                    //   USAGE_MINIMUM (Keyboard LeftControl)
     0x29, 0xe7,                    //   USAGE_MAXIMUM (Keyboard Right GUI)
     0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
     0x25, 0x01,                    //   LOGICAL_MAXIMUM (1)
     0x75, 0x01,                    //   REPORT_SIZE (1)
     
-	0x95, 0x08,                    //   REPORT_COUNT (8)
+    0x95, 0x08,                    //   REPORT_COUNT (8)
     0x81, 0x02,                    //   INPUT (Data,Var,Abs)
     0x95, 0x01,                    //   REPORT_COUNT (1)
     0x75, 0x08,                    //   REPORT_SIZE (8)
     0x81, 0x03,                    //   INPUT (Cnst,Var,Abs)
-    
-	0x95, 0x06,                    //   REPORT_COUNT (6)
+
+    0x95, 0x06,                    //   REPORT_COUNT (6)
     0x75, 0x08,                    //   REPORT_SIZE (8)
     0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
     0x25, 0x65,                    //   LOGICAL_MAXIMUM (101)
     0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
     
-	0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
+    0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
     0x29, 0x65,                    //   USAGE_MAXIMUM (Keyboard Application)
     0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
+    0xc0,                          // END_COLLECTION
+
+    //  System Control (Power Down, Sleep, Wakeup, ...)
+    0x05, 0x01,                    // USAGE_PAGE (Generic Desktop)
+    0x09, 0x80,                    // USAGE (System Control)
+    0xa1, 0x01,                    // COLLECTION (Application)
+    0x85, HID_REPORTID_SYSTEMCONTROL,// REPORT_ID (4)
+    0x09, 0x81,                    //   USAGE (System Power Down)
+    0x09, 0x82,                    //   USAGE (System Sleep)
+    0x09, 0x83,                    //   USAGE (System Wakeup)
+    0x09, 0x8E,                    //   USAGE (System Cold Restart)
+    0x09, 0x8F,                    //   USAGE (System Warm Restart)
+    0x09, 0xA0,                    //   USAGE (System Dock)
+    0x09, 0xA1,                    //   USAGE (System Undock)
+    0x09, 0xA7,                    //   USAGE (System Speaker Mute)
+    0x09, 0xA8,                    //   USAGE (System Hibernate)
+    // although these display usages are not that important, they don't cost much more than declaring
+    // the otherwise necessary constant fill bits
+    0x09, 0xB0,                    //   USAGE (System Display Invert)
+    0x09, 0xB1,                    //   USAGE (System Display Internal)
+    0x09, 0xB2,                    //   USAGE (System Display External)
+    0x09, 0xB3,                    //   USAGE (System Display Both)
+    0x09, 0xB4,                    //   USAGE (System Display Dual)
+    0x09, 0xB5,                    //   USAGE (System Display Toggle Intern/Extern)
+    0x09, 0xB6,                    //   USAGE (System Display Swap)
+    0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
+    0x25, 0x01,                    //   LOGICAL_MAXIMUM (1)
+    0x75, 0x01,                    //   REPORT_SIZE (1)
+    0x95, 0x10,                    //   REPORT_COUNT (16)
+    0x81, 0x02,                    //   INPUT (Data,Var,Abs)
     0xc0,                          // END_COLLECTION
 
 #if RAWHID_ENABLED
@@ -112,7 +148,7 @@ const u8 _hidReportDescriptor[] = {
 	0x0A, LSB(RAWHID_USAGE), MSB(RAWHID_USAGE),
 
 	0xA1, 0x01,				// Collection 0x01
-    0x85, 0x03,             // REPORT_ID (3)
+	0x85, HID_REPORTID_RAWHID,		// REPORT_ID (3)
 	0x75, 0x08,				// report size = 8 bits
 	0x15, 0x00,				// logical minimum = 0
 	0x26, 0xFF, 0x00,		// logical maximum = 255
@@ -228,7 +264,7 @@ void Mouse_::move(signed char x, signed char y, signed char wheel)
 	m[1] = x;
 	m[2] = y;
 	m[3] = wheel;
-	HID_SendReport(1,m,4);
+	HID_SendReport(HID_REPORTID_MOUSE,m,sizeof(m));
 }
 
 void Mouse_::buttons(uint8_t b)
@@ -275,7 +311,7 @@ void Keyboard_::end(void)
 
 void Keyboard_::sendReport(KeyReport* keys)
 {
-	HID_SendReport(2,keys,sizeof(KeyReport));
+	HID_SendReport(HID_REPORTID_KEYBOARD,keys,sizeof(*keys));
 }
 
 extern
@@ -460,6 +496,38 @@ size_t Keyboard_::press(uint8_t k)
 	}
 	sendReport(&_keyReport);
 	return 1;
+}
+
+// System Control
+//  k is one of the SYSTEM_CONTROL defines which come from the HID usage table "Generic Desktop Page (0x01)"
+// in "HID Usage Tables" (HUT1_12v2.pdf)
+size_t Keyboard_::systemControl(uint8_t k) 
+{
+	if(k <= 16)
+	{
+		u16 mask = 0;
+		u8 m[2];
+
+		if(k > 0)
+		{
+			mask = 1 << (k - 1);
+		}
+
+		m[0] = LSB(mask);
+		m[1] = MSB(mask);
+		HID_SendReport(HID_REPORTID_SYSTEMCONTROL,m,sizeof(m));
+
+		// these are all OSCs, so send a clear to make it possible to send it again later
+		m[0] = 0;
+		m[1] = 0;
+		HID_SendReport(HID_REPORTID_SYSTEMCONTROL,m,sizeof(m));
+		return 1;
+	}
+	else
+	{
+		setWriteError();
+		return 0;
+	}
 }
 
 // release() takes the specified key out of the persistent key report and

--- a/hardware/arduino/cores/arduino/HID.cpp
+++ b/hardware/arduino/cores/arduino/HID.cpp
@@ -89,6 +89,7 @@ const u8 _hidReportDescriptor[] = {
     0x85, HID_REPORTID_KEYBOARD,   //   REPORT_ID (2)
     0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
    
+    // Keyboard Modifiers (shift, alt, ...)
     0x19, 0xe0,                    //   USAGE_MINIMUM (Keyboard LeftControl)
     0x29, 0xe7,                    //   USAGE_MAXIMUM (Keyboard Right GUI)
     0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
@@ -101,14 +102,14 @@ const u8 _hidReportDescriptor[] = {
     0x75, 0x08,                    //   REPORT_SIZE (8)
     0x81, 0x03,                    //   INPUT (Cnst,Var,Abs)
 
+    // Keyboard keys
     0x95, 0x06,                    //   REPORT_COUNT (6)
     0x75, 0x08,                    //   REPORT_SIZE (8)
     0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
-    0x25, 0x65,                    //   LOGICAL_MAXIMUM (101)
+    0x26, 0xDF, 0x00,              //   LOGICAL_MAXIMUM (239)
     0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
-    
     0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
-    0x29, 0x65,                    //   USAGE_MAXIMUM (Keyboard Application)
+    0x29, 0xDF,                    //   USAGE_MAXIMUM (Left Control - 1)
     0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
     0xc0,                          // END_COLLECTION
 
@@ -457,9 +458,33 @@ uint8_t USBPutChar(uint8_t c);
 // to the persistent key report and sends the report.  Because of the way 
 // USB HID works, the host acts like the key remains pressed until we 
 // call release(), releaseAll(), or otherwise clear the report and resend.
-size_t Keyboard_::press(uint8_t k) 
+size_t Keyboard_::pressRaw(uint8_t k) 
 {
 	uint8_t i;
+	// Add k to the key report only if it's not already present
+	// and if there is an empty slot.
+	if (_keyReport.keys[0] != k && _keyReport.keys[1] != k && 
+		_keyReport.keys[2] != k && _keyReport.keys[3] != k &&
+		_keyReport.keys[4] != k && _keyReport.keys[5] != k) {
+		
+		for (i=0; i<6; i++) {
+			if (_keyReport.keys[i] == 0x00) {
+				_keyReport.keys[i] = k;
+				break;
+			}
+		}
+		if (i == 6 || (k >= 0xE0)) {
+			setWriteError();
+			return 0;
+		}	
+	}
+	sendReport(&_keyReport);
+	return 1;
+}
+
+// translates ASCII characters to usage
+size_t Keyboard_::press(uint8_t k) 
+{
 	if (k >= 136) {			// it's a non-printing key (not a modifier)
 		k = k - 136;
 	} else if (k >= 128) {	// it's a modifier key
@@ -476,26 +501,46 @@ size_t Keyboard_::press(uint8_t k)
 			k &= 0x7F;
 		}
 	}
-	
-	// Add k to the key report only if it's not already present
-	// and if there is an empty slot.
-	if (_keyReport.keys[0] != k && _keyReport.keys[1] != k && 
-		_keyReport.keys[2] != k && _keyReport.keys[3] != k &&
-		_keyReport.keys[4] != k && _keyReport.keys[5] != k) {
-		
-		for (i=0; i<6; i++) {
-			if (_keyReport.keys[i] == 0x00) {
-				_keyReport.keys[i] = k;
-				break;
-			}
+	return pressRaw(k);
+}
+
+// release() takes the specified key out of the persistent key report and
+// sends the report.  This tells the OS the key is no longer pressed and that
+// it shouldn't be repeated any more.
+size_t Keyboard_::releaseRaw(uint8_t k) 
+{
+	uint8_t i;
+	// Test the key report to see if k is present.  Clear it if it exists.
+	// Check all positions in case the key is present more than once (which it shouldn't be)
+	for (i=0; i<6; i++) {
+		if (0 != k && _keyReport.keys[i] == k) {
+			_keyReport.keys[i] = 0x00;
 		}
-		if (i == 6) {
-			setWriteError();
-			return 0;
-		}	
 	}
+
 	sendReport(&_keyReport);
 	return 1;
+}
+
+// translates ASCII characters to usage
+size_t Keyboard_::release(uint8_t k) 
+{
+	if (k >= 136) {			// it's a non-printing key (not a modifier)
+		k = k - 136;
+	} else if (k >= 128) {	// it's a modifier key
+		_keyReport.modifiers &= ~(1<<(k-128));
+		k = 0;
+	} else {				// it's a printing key
+		k = pgm_read_byte(_asciimap + k);
+		if (!k) {
+			return 0;
+		}
+		if (k & 0x80) {							// it's a capital letter or other character reached with shift
+			_keyReport.modifiers &= ~(0x02);	// the left shift modifier
+			k &= 0x7F;
+		}
+	}
+	return releaseRaw(k);
 }
 
 // System Control
@@ -530,40 +575,6 @@ size_t Keyboard_::systemControl(uint8_t k)
 	}
 }
 
-// release() takes the specified key out of the persistent key report and
-// sends the report.  This tells the OS the key is no longer pressed and that
-// it shouldn't be repeated any more.
-size_t Keyboard_::release(uint8_t k) 
-{
-	uint8_t i;
-	if (k >= 136) {			// it's a non-printing key (not a modifier)
-		k = k - 136;
-	} else if (k >= 128) {	// it's a modifier key
-		_keyReport.modifiers &= ~(1<<(k-128));
-		k = 0;
-	} else {				// it's a printing key
-		k = pgm_read_byte(_asciimap + k);
-		if (!k) {
-			return 0;
-		}
-		if (k & 0x80) {							// it's a capital letter or other character reached with shift
-			_keyReport.modifiers &= ~(0x02);	// the left shift modifier
-			k &= 0x7F;
-		}
-	}
-	
-	// Test the key report to see if k is present.  Clear it if it exists.
-	// Check all positions in case the key is present more than once (which it shouldn't be)
-	for (i=0; i<6; i++) {
-		if (0 != k && _keyReport.keys[i] == k) {
-			_keyReport.keys[i] = 0x00;
-		}
-	}
-
-	sendReport(&_keyReport);
-	return 1;
-}
-
 void Keyboard_::releaseAll(void)
 {
 	_keyReport.keys[0] = 0;
@@ -576,10 +587,17 @@ void Keyboard_::releaseAll(void)
 	sendReport(&_keyReport);
 }
 
+size_t Keyboard_::writeRaw(uint8_t c)
+{	
+	uint8_t p = pressRaw(c);		// Keydown
+	releaseRaw(c);		// Keyup
+	return (p);				// just return the result of press() since release() almost always returns 1
+}
+
 size_t Keyboard_::write(uint8_t c)
 {	
 	uint8_t p = press(c);		// Keydown
-	uint8_t r = release(c);		// Keyup
+	release(c);		// Keyup
 	return (p);					// just return the result of press() since release() almost always returns 1
 }
 

--- a/hardware/arduino/cores/arduino/HID.cpp
+++ b/hardware/arduino/cores/arduino/HID.cpp
@@ -458,33 +458,9 @@ uint8_t USBPutChar(uint8_t c);
 // to the persistent key report and sends the report.  Because of the way 
 // USB HID works, the host acts like the key remains pressed until we 
 // call release(), releaseAll(), or otherwise clear the report and resend.
-size_t Keyboard_::pressRaw(uint8_t k) 
-{
-	uint8_t i;
-	// Add k to the key report only if it's not already present
-	// and if there is an empty slot.
-	if (_keyReport.keys[0] != k && _keyReport.keys[1] != k && 
-		_keyReport.keys[2] != k && _keyReport.keys[3] != k &&
-		_keyReport.keys[4] != k && _keyReport.keys[5] != k) {
-		
-		for (i=0; i<6; i++) {
-			if (_keyReport.keys[i] == 0x00) {
-				_keyReport.keys[i] = k;
-				break;
-			}
-		}
-		if (i == 6 || (k >= 0xE0)) {
-			setWriteError();
-			return 0;
-		}	
-	}
-	sendReport(&_keyReport);
-	return 1;
-}
-
-// translates ASCII characters to usage
 size_t Keyboard_::press(uint8_t k) 
 {
+	uint8_t i;
 	if (k >= 136) {			// it's a non-printing key (not a modifier)
 		k = k - 136;
 	} else if (k >= 128) {	// it's a modifier key
@@ -501,46 +477,26 @@ size_t Keyboard_::press(uint8_t k)
 			k &= 0x7F;
 		}
 	}
-	return pressRaw(k);
-}
-
-// release() takes the specified key out of the persistent key report and
-// sends the report.  This tells the OS the key is no longer pressed and that
-// it shouldn't be repeated any more.
-size_t Keyboard_::releaseRaw(uint8_t k) 
-{
-	uint8_t i;
-	// Test the key report to see if k is present.  Clear it if it exists.
-	// Check all positions in case the key is present more than once (which it shouldn't be)
-	for (i=0; i<6; i++) {
-		if (0 != k && _keyReport.keys[i] == k) {
-			_keyReport.keys[i] = 0x00;
+	
+	// Add k to the key report only if it's not already present
+	// and if there is an empty slot.
+	if (_keyReport.keys[0] != k && _keyReport.keys[1] != k && 
+		_keyReport.keys[2] != k && _keyReport.keys[3] != k &&
+		_keyReport.keys[4] != k && _keyReport.keys[5] != k) {
+		
+		for (i=0; i<6; i++) {
+			if (_keyReport.keys[i] == 0x00) {
+				_keyReport.keys[i] = k;
+				break;
+			}
 		}
+		if (i == 6) {
+			setWriteError();
+			return 0;
+		}	
 	}
-
 	sendReport(&_keyReport);
 	return 1;
-}
-
-// translates ASCII characters to usage
-size_t Keyboard_::release(uint8_t k) 
-{
-	if (k >= 136) {			// it's a non-printing key (not a modifier)
-		k = k - 136;
-	} else if (k >= 128) {	// it's a modifier key
-		_keyReport.modifiers &= ~(1<<(k-128));
-		k = 0;
-	} else {				// it's a printing key
-		k = pgm_read_byte(_asciimap + k);
-		if (!k) {
-			return 0;
-		}
-		if (k & 0x80) {							// it's a capital letter or other character reached with shift
-			_keyReport.modifiers &= ~(0x02);	// the left shift modifier
-			k &= 0x7F;
-		}
-	}
-	return releaseRaw(k);
 }
 
 // System Control
@@ -575,6 +531,40 @@ size_t Keyboard_::systemControl(uint8_t k)
 	}
 }
 
+// release() takes the specified key out of the persistent key report and
+// sends the report.  This tells the OS the key is no longer pressed and that
+// it shouldn't be repeated any more.
+size_t Keyboard_::release(uint8_t k) 
+{
+	uint8_t i;
+	if (k >= 136) {			// it's a non-printing key (not a modifier)
+		k = k - 136;
+	} else if (k >= 128) {	// it's a modifier key
+		_keyReport.modifiers &= ~(1<<(k-128));
+		k = 0;
+	} else {				// it's a printing key
+		k = pgm_read_byte(_asciimap + k);
+		if (!k) {
+			return 0;
+		}
+		if (k & 0x80) {							// it's a capital letter or other character reached with shift
+			_keyReport.modifiers &= ~(0x02);	// the left shift modifier
+			k &= 0x7F;
+		}
+	}
+	
+	// Test the key report to see if k is present.  Clear it if it exists.
+	// Check all positions in case the key is present more than once (which it shouldn't be)
+	for (i=0; i<6; i++) {
+		if (0 != k && _keyReport.keys[i] == k) {
+			_keyReport.keys[i] = 0x00;
+		}
+	}
+
+	sendReport(&_keyReport);
+	return 1;
+}
+
 void Keyboard_::releaseAll(void)
 {
 	_keyReport.keys[0] = 0;
@@ -587,17 +577,10 @@ void Keyboard_::releaseAll(void)
 	sendReport(&_keyReport);
 }
 
-size_t Keyboard_::writeRaw(uint8_t c)
-{	
-	uint8_t p = pressRaw(c);		// Keydown
-	releaseRaw(c);		// Keyup
-	return (p);				// just return the result of press() since release() almost always returns 1
-}
-
 size_t Keyboard_::write(uint8_t c)
 {	
 	uint8_t p = press(c);		// Keydown
-	release(c);		// Keyup
+	uint8_t r = release(c);		// Keyup
 	return (p);					// just return the result of press() since release() almost always returns 1
 }
 

--- a/hardware/arduino/cores/arduino/USBAPI.h
+++ b/hardware/arduino/cores/arduino/USBAPI.h
@@ -18,6 +18,7 @@ public:
 	void attach();
 	void detach();	// Serial port goes down too...
 	void poll();
+	bool wakeupHost(); // returns false, when wakeup cannot be processed
 };
 extern USBDevice_ USBDevice;
 

--- a/hardware/arduino/cores/arduino/USBAPI.h
+++ b/hardware/arduino/cores/arduino/USBAPI.h
@@ -154,11 +154,8 @@ public:
 	void begin(void);
 	void end(void);
 	virtual size_t write(uint8_t k);
-	virtual size_t writeRaw(uint8_t c);
 	virtual size_t press(uint8_t k);
-	virtual size_t pressRaw(uint8_t k);
 	virtual size_t release(uint8_t k);
-	virtual size_t releaseRaw(uint8_t k);
 	virtual void releaseAll(void);
 	virtual size_t systemControl(uint8_t k);
 };

--- a/hardware/arduino/cores/arduino/USBAPI.h
+++ b/hardware/arduino/cores/arduino/USBAPI.h
@@ -4,6 +4,7 @@
 #define __USBAPI__
 
 #if defined(USBCON)
+#define MOUSE_ABS_ENABLED
 
 //================================================================================
 //================================================================================
@@ -65,6 +66,9 @@ public:
 	void end(void);
 	void click(uint8_t b = MOUSE_LEFT);
 	void move(signed char x, signed char y, signed char wheel = 0);	
+#ifdef MOUSE_ABS_ENABLED
+	void moveAbs(int16_t x, int16_t y, int16_t wheel); // all parameters have the range of -32768 to 32767 and must be scaled to screen pixels
+#endif
 	void press(uint8_t b = MOUSE_LEFT);		// press LEFT by default
 	void release(uint8_t b = MOUSE_LEFT);	// release LEFT by default
 	bool isPressed(uint8_t b = MOUSE_LEFT);	// check LEFT by default

--- a/hardware/arduino/cores/arduino/USBAPI.h
+++ b/hardware/arduino/cores/arduino/USBAPI.h
@@ -154,8 +154,11 @@ public:
 	void begin(void);
 	void end(void);
 	virtual size_t write(uint8_t k);
+	virtual size_t writeRaw(uint8_t c);
 	virtual size_t press(uint8_t k);
+	virtual size_t pressRaw(uint8_t k);
 	virtual size_t release(uint8_t k);
+	virtual size_t releaseRaw(uint8_t k);
 	virtual void releaseAll(void);
 	virtual size_t systemControl(uint8_t k);
 };

--- a/hardware/arduino/cores/arduino/USBAPI.h
+++ b/hardware/arduino/cores/arduino/USBAPI.h
@@ -112,6 +112,30 @@ extern Mouse_ Mouse;
 #define KEY_F11				0xCC
 #define KEY_F12				0xCD
 
+
+// System Control values for Keyboard_::systemControl()
+//  these defines come from the HID usage table "Generic Desktop Page (0x01)"
+//  in the USB standard document "HID Usage Tables" (HUT1_12v2.pdf)
+//  Currently this list contains only OSC (one shot control) values,
+//  the implementation of systemControl will have to be changed when
+//  adding OOC or RTC values.
+#define SYSTEM_CONTROL_POWER_DOWN              1
+#define SYSTEM_CONTROL_SLEEP                   2
+#define SYSTEM_CONTROL_WAKEUP                  3
+#define SYSTEM_CONTROL_COLD_RESTART            4
+#define SYSTEM_CONTROL_WARM_RESTART            5
+#define SYSTEM_CONTROL_DOCK                    6
+#define SYSTEM_CONTROL_UNDOCK                  7
+#define SYSTEM_CONTROL_SPEAKER_MUTE            8
+#define SYSTEM_CONTROL_HIBERNATE               9
+#define SYSTEM_CONTROL_DISPLAY_INVERT         10
+#define SYSTEM_CONTROL_DISPLAY_INTERNAL       11
+#define SYSTEM_CONTROL_DISPLAY_EXTERNAL       12
+#define SYSTEM_CONTROL_DISPLAY_BOTH           13
+#define SYSTEM_CONTROL_DISPLAY_DUAL           14
+#define SYSTEM_CONTROL_DISPLAY_TOGGLE_INT_EXT 15
+#define SYSTEM_CONTROL_DISPLAY_SWAP           16
+
 //	Low level key report: up to 6 keys and shift, ctrl etc at once
 typedef struct
 {
@@ -133,6 +157,7 @@ public:
 	virtual size_t press(uint8_t k);
 	virtual size_t release(uint8_t k);
 	virtual void releaseAll(void);
+	virtual size_t systemControl(uint8_t k);
 };
 extern Keyboard_ Keyboard;
 

--- a/hardware/arduino/cores/arduino/USBCore.cpp
+++ b/hardware/arduino/cores/arduino/USBCore.cpp
@@ -656,6 +656,8 @@ static inline void USB_ClockEnable()
 #else
 #error "Clock rate of F_CPU not supported"
 #endif
+#else
+#error "USB Chip not supported, please defined method of USB PLL initialization"
 #endif
 
 	PLLCSR |= (1<<PLLE);

--- a/hardware/arduino/cores/arduino/USBCore.cpp
+++ b/hardware/arduino/cores/arduino/USBCore.cpp
@@ -634,6 +634,8 @@ static inline void USB_ClockEnable()
 	PLLCSR |= (1<<PINDIV);                   // Need 16 MHz xtal
 #elif F_CPU == 8000000UL
 	PLLCSR &= ~(1<<PINDIV);                  // Need  8 MHz xtal
+#else
+#error "Clock rate of F_CPU not supported"
 #endif
 
 // AT90USB646, AT90USB647, AT90USB1286, AT90USB1287 
@@ -646,11 +648,13 @@ static inline void USB_ClockEnable()
 	// For AT90USB64x only. Do not use with AT90USB128x.
 	PLLCSR = (PLLCSR & ~(1<<PLLP0)) | ((1<<PLLP2) | (1<<PLLP1)); // Need 16 MHz xtal
 #else
-#error "USB Chip not supported, please defined method of PLL initialization yourself"
+#error "USB Chip not supported, please defined method of USB PLL initialization"
 #endif
 #elif F_CPU == 8000000UL
 	// for Atmel AT90USB128x and AT90USB64x
 	PLLCSR = (PLLCSR & ~(1<<PLLP2)) | ((1<<PLLP1) | (1<<PLLP0)); // Need 8 MHz xtal
+#else
+#error "Clock rate of F_CPU not supported"
 #endif
 #endif
 

--- a/hardware/arduino/cores/arduino/USBCore.cpp
+++ b/hardware/arduino/cores/arduino/USBCore.cpp
@@ -24,13 +24,13 @@
 
 #if defined(USBCON)
 
-#define EP_TYPE_CONTROL				0x00
-#define EP_TYPE_BULK_IN				0x81
-#define EP_TYPE_BULK_OUT			0x80
-#define EP_TYPE_INTERRUPT_IN		0xC1
-#define EP_TYPE_INTERRUPT_OUT		0xC0
-#define EP_TYPE_ISOCHRONOUS_IN		0x41
-#define EP_TYPE_ISOCHRONOUS_OUT		0x40
+#define EP_TYPE_CONTROL				(0x00)
+#define EP_TYPE_BULK_IN				((1<<EPTYPE1) | (1<<EPDIR))
+#define EP_TYPE_BULK_OUT			(1<<EPTYPE1)
+#define EP_TYPE_INTERRUPT_IN		((1<<EPTYPE1) | (1<<EPTYPE0) | (1<<EPDIR))
+#define EP_TYPE_INTERRUPT_OUT		((1<<EPTYPE1) | (1<<EPTYPE0))
+#define EP_TYPE_ISOCHRONOUS_IN		((1<<EPTYPE0) | (1<<EPDIR))
+#define EP_TYPE_ISOCHRONOUS_OUT		(1<<EPTYPE0)
 
 /** Pulse generation counters to keep track of the number of milliseconds remaining for each pulse type */
 #define TX_RX_LED_PULSE_MS 100
@@ -344,7 +344,7 @@ static
 void InitEP(u8 index, u8 type, u8 size)
 {
 	UENUM = index;
-	UECONX = 1;
+	UECONX = (1<<EPEN);
 	UECFG0X = type;
 	UECFG1X = size;
 }
@@ -355,7 +355,7 @@ void InitEndpoints()
 	for (u8 i = 1; i < sizeof(_initEndpoints); i++)
 	{
 		UENUM = i;
-		UECONX = 1;
+		UECONX = (1<<EPEN);
 		UECFG0X = pgm_read_byte(_initEndpoints+i);
 		UECFG1X = EP_DOUBLE_64;
 	}
@@ -627,11 +627,33 @@ static inline void USB_ClockEnable()
 {
 	UHWCON |= (1<<UVREGE);			// power internal reg
 	USBCON = (1<<USBE) | (1<<FRZCLK);	// clock frozen, usb enabled
+
+// ATmega32U4
+#if defined(PINDIV)
 #if F_CPU == 16000000UL
-	PLLCSR = (1<<PINDIV);                   // Need 16 MHz xtal
+	PLLCSR |= (1<<PINDIV);                   // Need 16 MHz xtal
 #elif F_CPU == 8000000UL
-	PLLCSR = 0x00;				// Need 8 MHz xtal
+	PLLCSR &= ~(1<<PINDIV);                  // Need  8 MHz xtal
 #endif
+
+// AT90USB646, AT90USB647, AT90USB1286, AT90USB1287 
+#elif defined(PLLP2)
+#if F_CPU == 16000000UL
+#if defined(__AVR_AT90USB1286__) || defined(__AVR_AT90USB1287__)
+	// For Atmel AT90USB128x only. Do not use with Atmel AT90USB64x.
+	PLLCSR = (PLLCSR & ~(1<<PLLP1)) | ((1<<PLLP2) | (1<<PLLP0)); // Need 16 MHz xtal
+#elif defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB647__)
+	// For AT90USB64x only. Do not use with AT90USB128x.
+	PLLCSR = (PLLCSR & ~(1<<PLLP0)) | ((1<<PLLP2) | (1<<PLLP1)); // Need 16 MHz xtal
+#else
+#error "USB Chip not supported, please defined method of PLL initialization yourself"
+#endif
+#elif F_CPU == 8000000UL
+	// for Atmel AT90USB128x and AT90USB64x
+	PLLCSR = (PLLCSR & ~(1<<PLLP2)) | ((1<<PLLP1) | (1<<PLLP0)); // Need 8 MHz xtal
+#endif
+#endif
+
 	PLLCSR |= (1<<PLLE);
 	while (!(PLLCSR & (1<<PLOCK)))		// wait for lock pll
 	{
@@ -642,7 +664,13 @@ static inline void USB_ClockEnable()
 	// port touch at 1200 bps. This delay fixes this behaviour.
 	delay(1);
 	USBCON = (USBCON & ~(1<<FRZCLK)) | (1<<OTGPADE);	// start USB clock, enable VBUS Pad
+
+#if defined(RSTCPU)
 	UDCON &= ~((1<<RSTCPU) | (1<<LSM) | (1<<RMWKUP) | (1<<DETACH));	// enable attach resistor, set full speed mode
+#else
+	// AT90USB64x and AT90USB128x don't have RSTCPU
+	UDCON &= ~((1<<LSM) | (1<<RMWKUP) | (1<<DETACH));	// enable attach resistor, set full speed mode
+#endif
 }
 
 

--- a/hardware/arduino/cores/arduino/USBCore.cpp
+++ b/hardware/arduino/cores/arduino/USBCore.cpp
@@ -2,6 +2,8 @@
 
 /* Copyright (c) 2010, Peter Barrett  
 **  
+** Sleep/Wakeup/SystemControl support added by Michael Dreher
+**
 ** Permission to use, copy, modify, and/or distribute this software for  
 ** any purpose with or without fee is hereby granted, provided that the  
 ** above copyright notice and this permission notice appear in all copies.  

--- a/hardware/arduino/cores/arduino/USBCore.h
+++ b/hardware/arduino/cores/arduino/USBCore.h
@@ -79,6 +79,15 @@
 #define USB_INTERFACE_DESCRIPTOR_TYPE          4
 #define USB_ENDPOINT_DESCRIPTOR_TYPE           5
 
+// usb_20.pdf Table 9.6 Standard Feature Selectors
+#define DEVICE_REMOTE_WAKEUP                   1
+#define ENDPOINT_HALT                          2
+#define TEST_MODE                              3
+
+// usb_20.pdf Figure 9-4. Information Returned by a GetStatus() Request to a Device
+#define FEATURE_SELFPOWERED_ENABLED     (1 << 0)
+#define FEATURE_REMOTE_WAKEUP_ENABLED   (1 << 1)
+
 #define USB_DEVICE_CLASS_COMMUNICATIONS        0x02
 #define USB_DEVICE_CLASS_HUMAN_INTERFACE       0x03
 #define USB_DEVICE_CLASS_STORAGE               0x08
@@ -282,7 +291,7 @@ typedef struct
 	{ 18, 1, 0x200, _class,_subClass,_proto,_packetSize0,_vid,_pid,_version,_im,_ip,_is,_configs }
 
 #define D_CONFIG(_totalLength,_interfaces) \
-	{ 9, 2, _totalLength,_interfaces, 1, 0, USB_CONFIG_BUS_POWERED, USB_CONFIG_POWER_MA(500) }
+	{ 9, 2, _totalLength,_interfaces, 1, 0, USB_CONFIG_BUS_POWERED | USB_CONFIG_REMOTE_WAKEUP, USB_CONFIG_POWER_MA(500) }
 
 #define D_INTERFACE(_n,_numEndpoints,_class,_subClass,_protocol) \
 	{ 9, 4, _n, 0, _numEndpoints, _class,_subClass, _protocol, 0 }


### PR DESCRIPTION
This adds a new feature to fix issue #1295 "leonardo as keyboard does not wake windows 7 from sleep"

It makes it possible to wake up the PC when it is in standby mode. Use the following code in the Sketch:
USBDevice.wakeupHost();

Another feature has been added to send the PC to sleep mode:
Keyboard.systemControl(SYSTEM_CONTROL_SLEEP);

See also the discussion in the forum http://forum.arduino.cc/index.php?topic=150157

Tested by me on
    Mac OSX (on a MacBook Pro)
    Windows 7 (on a MacBook Pro)
    Windows 8 (on a Wetab)
