### PR TITLE
Added line follow parameters for older Arduino Robots. 

### DIFF
--- a/libraries/Robot_Control/examples/explore/R02_Line_Follow/R02_Line_Follow.ino
+++ b/libraries/Robot_Control/examples/explore/R02_Line_Follow/R02_Line_Follow.ino
@@ -42,8 +42,9 @@ void setup() {
 
   // These are some general values that work for line following 
   // uncomment one or the other to see the different behaviors of the robot
-  // Robot.lineFollowConfig(11, 5, 50, 10);
+  //Robot.lineFollowConfig(14, 9, 50, 10);
   Robot.lineFollowConfig(11, 7, 60, 5);
+  
   
   //set the motor board into line-follow mode
   Robot.setMode(MODE_LINE_FOLLOW);  

--- a/libraries/Robot_Control/examples/explore/R10_Rescue/R10_Rescue.ino
+++ b/libraries/Robot_Control/examples/explore/R10_Rescue/R10_Rescue.ino
@@ -54,7 +54,7 @@ void setup(){
   
   // use this to calibrate the line following algorithm
   // uncomment one or the other to see the different behaviors of the robot
-  // Robot.lineFollowConfig(11, 5, 50, 10);
+  // Robot.lineFollowConfig(14, 9, 50, 10);
   Robot.lineFollowConfig(11, 7, 60, 5);
   
   // run the rescue sequence  


### PR DESCRIPTION
It turns out that the new parameters of line-following(11,7,60,5) doesn't fit very well with older robots(that has "TK" markings on top). So the old ones(14,9,50,10) are added back in the comments for people who needs them.
