### PR TITLE
USB CDC Serial_::begin fixes.

### DIFF
--- a/hardware/arduino/cores/arduino/CDC.cpp
+++ b/hardware/arduino/cores/arduino/CDC.cpp
@@ -134,6 +134,10 @@ void Serial_::begin(unsigned long baud_count)
 {
 }
 
+void Serial_::begin(unsigned long baud_count, byte config)
+{
+}
+
 void Serial_::end(void)
 {
 }

--- a/hardware/arduino/cores/arduino/USBAPI.h
+++ b/hardware/arduino/cores/arduino/USBAPI.h
@@ -31,6 +31,7 @@ private:
 	ring_buffer *_cdc_rx_buffer;
 public:
 	void begin(unsigned long);
+	void begin(unsigned long, uint8_t);
 	void end(void);
 
 	virtual int available(void);


### PR DESCRIPTION
On a board with native USB (e.g. Leonardo), Serial.begin(115200); gives a compiler warning:
   warning: large integer implicitly truncated to unsigned type
Serial.begin(9600, SERIAL_8N1); doesn't compile at all.

Pull request fixes these by:
- Change the CDC Serial_::begin prototype to match that of HardwareSerial::begin.
- Two argument form of begin()
