### PR TITLE
Makes it possible to link to another linux-system, not running with

### DIFF
--- a/libraries/Bridge/src/Bridge.h
+++ b/libraries/Bridge/src/Bridge.h
@@ -81,7 +81,12 @@ public:
   }
   
   void begin() {
-    serial.begin(250000);
+    serial.begin(250000);    // for Yun
+    BridgeClass::begin();
+  }
+  
+  void begin(int baudrate) {
+    serial.begin(baudrate);  // for other linux-systems
     BridgeClass::begin();
   }
   


### PR DESCRIPTION
250000 (not Yun, but f.i. an Arduino mega2560 with a modified/expanded
WR703N).

The default could stay at 250000 (Yun).
