### PR TITLE
Take 2: Added support for automatically showing the Serial Monitor window upon successful sketch upload

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -539,6 +539,9 @@ public class Editor extends JFrame implements RunnerListener {
     item.addActionListener(new ActionListener() {
         public void actionPerformed(ActionEvent e) {
           handleExport(false);
+          // Hide the serial monitor window. It will reopen at the appropriate time
+          // if "auto show" is enabled
+          serialMonitor.setVisible(false);
         }
       });
     fileMenu.add(item);
@@ -662,9 +665,24 @@ public class Editor extends JFrame implements RunnerListener {
     item = newJMenuItemShift(_("Serial Monitor"), 'M');
     item.addActionListener(new ActionListener() {
         public void actionPerformed(ActionEvent e) {
-          handleSerial();
+          handleSerial(true);
         }
       });
+    menu.add(item);
+
+    // Create the "Auto Show Serial Monitor" menu item (a checkbox). Read the prefs
+    // to see if it should be enabled.
+    final boolean autoShowSerialMonitor = Preferences.getBoolean("serial.auto_show_monitor_window");
+    item = new JCheckBoxMenuItem("Auto Show Serial Monitor", autoShowSerialMonitor);
+    item.addActionListener(new ActionListener() {
+     public void actionPerformed(ActionEvent e) {
+       // Make sure the choice in Preferences matches the checkbox state
+       JCheckBoxMenuItem checkboxMenuItem = (JCheckBoxMenuItem)e.getSource();
+       Preferences.setBoolean("serial.auto_show_monitor_window", checkboxMenuItem.isSelected());
+       // The pref needs to be saved so that other parts of the app will stay in sync
+       Preferences.save();
+     }
+    });
     menu.add(item);
     
     addTools(menu, Base.getToolsFolder());
@@ -941,7 +959,6 @@ public class Editor extends JFrame implements RunnerListener {
     //System.out.println(item.getLabel());
     Preferences.set("serial.port", name);
     serialMonitor.closeSerialPort();
-    serialMonitor.setVisible(false);
     serialMonitor = new SerialMonitor(Preferences.get("serial.port"));
     //System.out.println("set to " + get("serial.port"));
   }
@@ -1893,6 +1910,10 @@ public class Editor extends JFrame implements RunnerListener {
   class DefaultRunHandler implements Runnable {
     public void run() {
       try {
+        // Ensure the serial monitor window is closed until after we successfully 
+        // upload a sketch
+        serialMonitor.setVisible(false);
+
         sketch.prepare();
         sketch.build(false);
         statusNotice(_("Done compiling."));
@@ -2370,16 +2391,21 @@ public class Editor extends JFrame implements RunnerListener {
   // DAM: in Arduino, this is upload
   class DefaultExportHandler implements Runnable {
     public void run() {
+    
+      // Hide the serial monitor window until we are certain the sketch
+      // uploaded successfully
+      serialMonitor.setVisible(false);
 
+      boolean uploadSuccessful = false;
       try {
         serialMonitor.closeSerialPort();
-        serialMonitor.setVisible(false);
-            
+
         uploading = true;
           
         boolean success = sketch.exportApplet(false);
         if (success) {
           statusNotice(_("Done uploading."));
+          uploadSuccessful = true;
         } else {
           // error message will already be visible
         }
@@ -2398,6 +2424,17 @@ public class Editor extends JFrame implements RunnerListener {
       }
       status.unprogress();
       uploading = false;
+
+      // If auto show is enabled make sure the serial monitor is hooked up and visible
+      if (uploadSuccessful) {
+        if (Preferences.getBoolean("serial.auto_show_monitor_window")) {
+          handleSerial(true);
+        }
+      }
+      else {
+        serialMonitor.setVisible(false);
+      }
+
       //toolbar.clear();
       toolbar.deactivate(EditorToolbar.EXPORT);
     }
@@ -2409,7 +2446,6 @@ public class Editor extends JFrame implements RunnerListener {
 
       try {
         serialMonitor.closeSerialPort();
-        serialMonitor.setVisible(false);
             
         uploading = true;
           
@@ -2474,12 +2510,14 @@ public class Editor extends JFrame implements RunnerListener {
   }
 
 
-  public void handleSerial() {
+  public void handleSerial(boolean makeVisible) {
     if (uploading) return;
     
     try {
       serialMonitor.openSerialPort();
-      serialMonitor.setVisible(true);
+      if (makeVisible) {
+        serialMonitor.setVisible(true);
+      }
     } catch (SerialException e) {
       statusError(e);
     }

--- a/app/src/processing/app/EditorToolbar.java
+++ b/app/src/processing/app/EditorToolbar.java
@@ -350,7 +350,7 @@ public class EditorToolbar extends JComponent implements MouseInputListener, Key
       break;
 
     case SERIAL:
-      editor.handleSerial();
+      editor.handleSerial(true);
       break;
     }
   }

--- a/build/shared/lib/preferences.txt
+++ b/build/shared/lib/preferences.txt
@@ -255,6 +255,7 @@ serial.databits=8
 serial.stopbits=1
 serial.parity=N
 serial.debug_rate=9600
+serial.auto_show_monitor_window=false
 
 # I18 Preferences
 


### PR DESCRIPTION
This fix was originally attempted via the following pull request but the Arduino team didn't take it (even though users have been asking for it for years).
https://github.com/rmangino/Arduino/commit/77c869d6b770e66ad47733db7f473255f08c9e01

This new pull request fixes an issue which didn't exist when I made the original pull request (over a year ago).

This support is controlled via a checkbox menu item in the Tools menu ("Auto Show Serial Monitor"). The feature is *disabled by default* and is tracked by a boolean "serial.auto_show_monitor_window" in Preferences.txt. When "auto show" is disabled the Serial Monitor window behavior is unchanged (i.e. if you don't enable "auto show" the IDE will work as it always has).

The serial monitor window is hidden when the sketch fails to compile.

NOTE: The IDE's default behavior has *not* changed. The only difference is that a user may now *explicitly* request that the serial monitor window be shown upon automatically upon successful upload.
Signed-off-by: Reed Mangino <reed@themanginos.com>