### PR TITLE
Improved ADC speed on Arduino Due

### DIFF
--- a/hardware/arduino/sam/cores/arduino/wiring_analog.c
+++ b/hardware/arduino/sam/cores/arduino/wiring_analog.c
@@ -130,6 +130,7 @@ uint32_t analogRead(uint32_t ulPin)
 #endif
 
 #if defined __SAM3X8E__ || defined __SAM3X8H__
+	static uint32_t latestSelectedChannel = -1;
 	switch ( g_APinDescription[ulPin].ulAnalogChannel )
 	{
 		// Handling ADC 12 bits channels
@@ -147,7 +148,10 @@ uint32_t analogRead(uint32_t ulPin)
 		case ADC11 :
 
 			// Enable the corresponding channel
-			adc_enable_channel( ADC, ulChannel );
+			if (ulChannel != latestSelectedChannel) {
+			  adc_enable_channel( ADC, ulChannel );
+			  latestSelectedChannel = ulChannel;
+			}
 
 			// Start the ADC
 			adc_start( ADC );
@@ -161,7 +165,7 @@ uint32_t analogRead(uint32_t ulPin)
 			ulValue = mapResolution(ulValue, ADC_RESOLUTION, _readResolution);
 
 			// Disable the corresponding channel
-			adc_disable_channel(ADC, ulChannel);
+			//adc_disable_channel(ADC, ulChannel);
 
 			break;
 


### PR DESCRIPTION
Proposal to improve ADC reading speed: keep the ADC enabled after every ADC conversion. 

This will bypass ADC startup time, improving its conversion rate at the cost of slightly increasing power consumption (less than ~~1mA~~ 5mA).

See #1418 for more discussion.
