### PR TITLE
Fixed shiftIn not reading the first input pin

### DIFF
--- a/hardware/arduino/cores/arduino/wiring_shift.c
+++ b/hardware/arduino/cores/arduino/wiring_shift.c
@@ -29,12 +29,12 @@ uint8_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder) {
 	uint8_t i;
 
 	for (i = 0; i < 8; ++i) {
-		digitalWrite(clockPin, HIGH);
+		digitalWrite(clockPin, LOW);
 		if (bitOrder == LSBFIRST)
 			value |= digitalRead(dataPin) << i;
 		else
 			value |= digitalRead(dataPin) << (7 - i);
-		digitalWrite(clockPin, LOW);
+		digitalWrite(clockPin, HIGH);
 	}
 	return value;
 }


### PR DESCRIPTION
Originally, shiftIn would pulse the clock pin before reading from the
data (output on the shift register) pin. This would result in the value
from first input pin being replaced by the value from the second input
pin.
