### PR TITLE
Don't forbid unknown files in a library

### DIFF
--- a/app/src/processing/app/packages/Library.java
+++ b/app/src/processing/app/packages/Library.java
@@ -31,11 +31,6 @@ public class Library {
       .asList(new String[] { "architectures", "author", "core-dependencies",
           "dependencies", "email", "name", "paragraph", "sentence", "url",
           "version" });
-  private static final List<String> OPTIONAL_FOLDERS = Arrays
-      .asList(new String[] { "arch", "examples", "extras", "src" });
-  private static final List<String> OPTIONAL_FILES = Arrays
-      .asList(new String[] { "keywords.txt", "library.properties" });
-
 
   /**
    * Scans inside a folder and create a Library object out of it. Automatically
@@ -73,21 +68,6 @@ public class Library {
     File srcFolder = new File(libFolder, "src");
     if (!srcFolder.exists() || !srcFolder.isDirectory())
       throw new IOException("Missing 'src' folder");
-
-    // 3. check if root folder contains prohibited stuff
-    for (File file : libFolder.listFiles()) {
-      if (file.isDirectory()) {
-        if (FileUtils.isSCCSOrHiddenFile(file)) {
-          System.out.println("WARNING: Ignoring spurious " + file.getName() + " folder in '" + properties.get("name") + "' library");
-          continue;
-        }
-        if (!OPTIONAL_FOLDERS.contains(file.getName()))
-          throw new IOException("Invalid folder '" + file.getName() + "'.");
-      } else {
-        if (!OPTIONAL_FILES.contains(file.getName()))
-          throw new IOException("Invalid file '" + file.getName() + "'.");
-      }
-    }
 
     // Extract metadata info
     List<String> archs = new ArrayList<String>();


### PR DESCRIPTION
The current code forbids any files it does not know about, but this is
bad because:
- It breaks forward compatibility if we later add more files or
  directories to the library format.
- It breaks for people who want to have some extra stuff in their
  library (say, .gitignore or a README file). We can't keep a list of
  "allowed" stuff, since there will always be stuff missing.

This commit removes that code and just allows all files again.
