### PR TITLE
Use PGM_P instead of prog_char

### DIFF
--- a/hardware/arduino/avr/cores/arduino/Print.cpp
+++ b/hardware/arduino/avr/cores/arduino/Print.cpp
@@ -41,7 +41,7 @@ size_t Print::write(const uint8_t *buffer, size_t size)
 
 size_t Print::print(const __FlashStringHelper *ifsh)
 {
-  const char PROGMEM *p = (const char PROGMEM *)ifsh;
+  PGM_P p = (PGM_P)ifsh;
   size_t n = 0;
   while (1) {
     unsigned char c = pgm_read_byte(p++);

--- a/hardware/arduino/avr/cores/arduino/WString.cpp
+++ b/hardware/arduino/avr/cores/arduino/WString.cpp
@@ -186,7 +186,7 @@ String & String::copy(const __FlashStringHelper *pstr, unsigned int length)
 		return *this;
 	}
 	len = length;
-	strcpy_P(buffer, (const prog_char *)pstr);
+	strcpy_P(buffer, (PGM_P)pstr);
 	return *this;
 }
 
@@ -246,7 +246,7 @@ String & String::operator = (const char *cstr)
 
 String & String::operator = (const __FlashStringHelper *pstr)
 {
-	if (pstr) copy(pstr, strlen_P((const prog_char *)pstr));
+	if (pstr) copy(pstr, strlen_P((PGM_P)pstr));
 	else invalidate();
 
 	return *this;

--- a/hardware/arduino/sam/cores/arduino/WString.cpp
+++ b/hardware/arduino/sam/cores/arduino/WString.cpp
@@ -187,7 +187,7 @@ String & String::copy(const __FlashStringHelper *pstr, unsigned int length)
 		return *this;
 	}
 	len = length;
-	strcpy_P(buffer, (const prog_char *)pstr);
+	strcpy_P(buffer, (PGM_P)pstr);
 	return *this;
 }
 
@@ -247,7 +247,7 @@ String & String::operator = (const char *cstr)
 
 String & String::operator = (const __FlashStringHelper *pstr)
 {
-	if (pstr) copy(pstr, strlen_P((const prog_char *)pstr));
+	if (pstr) copy(pstr, strlen_P((PGM_P)pstr));
 	else invalidate();
 
 	return *this;


### PR DESCRIPTION
On later versions of avr-libc, prog_char is deprecated. In 0acebeeff48
the one occurence of prog_char was replaced by "char PROGMEM", which is
not entirely correct (PROGMEM is supposed to be an attribute on a
variable, not on a type, even though this is how things work in older
libc versions). However, in 1130fede3a2 a few new occurences of
prog_char are introduced, which break compilation on newer libc versions
again.

This commit changes all these pointer types to use the PGM_P macro from
<avr/pgmspace.h>. This macro is just "const char *" in newer libc
versions and "const prog_char *" in older versions, so it should always
work.

References #795
