### PR TITLE
Let EthernetServer::write return the number of bytes written to any client

### DIFF
--- a/build/shared/revisions.txt
+++ b/build/shared/revisions.txt
@@ -22,6 +22,7 @@ We suggest to delay the adoption of the new format until a stable 1.5.x is relea
 * avr: Fixed timeout in Bridge::transfer()
 * sam: Fixed SPI initialization (when using extended API and multiple CS)
 * avr: Fixed behavior of EthernetClient::flush()
+* avr: Improved return value of EthernetServer::write()
 
 [core]
 * sam: Fixed wrong initialization for ADC timings (analogRead speed Arduino DUE improved by a factor x10)

--- a/libraries/Ethernet/src/EthernetServer.cpp
+++ b/libraries/Ethernet/src/EthernetServer.cpp
@@ -83,7 +83,9 @@ size_t EthernetServer::write(const uint8_t *buffer, size_t size)
 
     if (EthernetClass::_server_port[sock] == _port &&
       client.status() == SnSR::ESTABLISHED) {
-      n += client.write(buffer, size);
+      size_t res = client.write(buffer, size);
+      if (res > n)
+	n = res;
     }
   }
   


### PR DESCRIPTION
Before, it would return the sum of the number of bytes written to all
clients, which makes it hard for a caller to find out the length of an
object printed (e.g., for alignment purposes). On the flipside, the
return value is now slightly less useful to detect connection errors,
but if really needed, something different should probably be implemented
anyway.

This change was discussed here:
http://comments.gmane.org/gmane.comp.hardware.arduino.devel/1928
http://forum.arduino.cc/index.php?topic=185835.0