### PR TITLE
Add appdata.xml file

### DIFF
--- a/build/linux/dist/appdata.xml
+++ b/build/linux/dist/appdata.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- See https://wiki.gnome.org/GnomeGoals/AppDataGnomeSoftware -->
+<application>
+  <id type="desktop">arduino.desktop</id>
+  <licence>CC-BY-SA</licence>
+  <description>
+    <p>
+      Arduino is an open-source electronics prototyping platform based
+      on flexible, easy-to-use hardware and software.  It's intended for
+      artists, designers, hobbyists, and anyone interested in creating
+      interactive objects or environments.
+    </p>
+    <p>
+      Included is an integrated development environment that can be used
+      to develop and upload code to compatible microcontrollers.
+    </p>
+  </description>
+  <screenshots>
+    <screenshot type="default" width="624" height="351">http://mavit.fedorapeople.org/appdata/arduino-screenshot.png</screenshot>
+    <screenshot width="704" height="396">http://mavit.fedorapeople.org/appdata/arduino-photo.jpg</screenshot>
+  </screenshots>
+  <url type="homepage">http://arduino.cc/</url>
+  <updatecontact>arduino.appdata.xml@mavit.org.uk</updatecontact>
+</application>


### PR DESCRIPTION
This file can be shipped in Linux packages and allows the Gnome
application browser to show some additional metadata.

This is essentially just the file from #1572, with a typo fix and a comment added pointing to the gnome wiki. Note that the updatecontact address still points to mavit@. I looked at pointing to the development mailing list or something generic like that, but that doesn't allow non-member postings, so I guess mavit can just keep the file up-to-date if needed :-)

The screenshots also still point to mavit's webspace. Not sure what the proper way to do this is. It seems to make sense to include the screenshots in git, but I can't find out if that's possible from the [appdata "specification"](http://people.freedesktop.org/~hughsient/appdata/). Perhaps putting the screenshots on arduino.cc instead is better?
