### PR TITLE
LiquidCrystal improvements (support 16x4 displays)

### DIFF
--- a/libraries/LiquidCrystal/src/LiquidCrystal.cpp
+++ b/libraries/LiquidCrystal/src/LiquidCrystal.cpp
@@ -87,7 +87,6 @@ void LiquidCrystal::begin(uint8_t cols, uint8_t lines, uint8_t dotsize) {
     _displayfunction |= LCD_2LINE;
   }
   _numlines = lines;
-  _currline = 0;
 
   setRowOffsets(0x00, 0x40, 0x00 + cols, 0x40 + cols);  
 

--- a/libraries/LiquidCrystal/src/LiquidCrystal.h
+++ b/libraries/LiquidCrystal/src/LiquidCrystal.h
@@ -101,7 +101,7 @@ private:
 
   uint8_t _initialized;
 
-  uint8_t _numlines,_currline;
+  uint8_t _numlines;
   uint8_t _row_offsets[4];
 };
 


### PR DESCRIPTION
This pullrequest was inspired by #55 and starts out with a cleaned up version of the main commit from that pullreq.

This allows setting custom row offsets for LCDs to support different LCD hardware configurations. Additionally, this changes the default row offsets (based on the number of columns set), so now 16x4 (and possibly others) are also supported out of the box.
