### PR TITLE
Update FileIO.cpp - Optimization of doBuffer() to avoid shifting the entire buffer

### DIFF
--- a/libraries/Bridge/src/FileIO.cpp
+++ b/libraries/Bridge/src/FileIO.cpp
@@ -119,12 +119,15 @@ void File::doBuffer() {
   // Try to buffer up to BUFFER_SIZE characters
   readPos = 0;
   uint8_t cmd[] = {'G', handle, BUFFER_SIZE - 1};
-  buffered = bridge.transfer(cmd, 3, buffer, BUFFER_SIZE) - 1;
+  buffered = bridge.transfer(cmd, 3, buffer, BUFFER_SIZE);
   //err = buff[0]; // First byte is error code
-  if (buffered > 0) {
-    // Shift the reminder of buffer
-    for (uint8_t i = 0; i < buffered; i++)
-      buffer[i] = buffer[i + 1];
+  if (BridgeClass::TRANSFER_TIMEOUT == buffered || 0 == buffered) {
+    // transfer failed to retrieve any data
+    buffered = 0;
+  } else {
+    // transfer retrieved at least one byte of data so skip the error code character
+    readPos++;
+    buffered--;
   }
 }
 


### PR DESCRIPTION
Optimization of doBuffer() - instead of moving all of the data one byte to the left in the buffer, increment readPos to skip over the error code byte.
