### PR TITLE
Clean up unused variables from HardwareSerial.cpp

### DIFF
--- a/hardware/arduino/avr/cores/arduino/HardwareSerial_private.h
+++ b/hardware/arduino/avr/cores/arduino/HardwareSerial_private.h
@@ -88,7 +88,7 @@ void HardwareSerial::_rx_complete_irq(void)
     }
   } else {
     // Parity error, read byte but discard it
-    unsigned char c = *_udr;
+    *_udr;
   };
 }
 


### PR DESCRIPTION
This pull request cleans up a couple of unused variables in `HardwareSerial.cpp` to improve clarity.
