### PR TITLE
Use reinterpret_cast to cast __FlashStringHelper to const char*

### DIFF
--- a/hardware/arduino/avr/cores/arduino/Print.cpp
+++ b/hardware/arduino/avr/cores/arduino/Print.cpp
@@ -41,7 +41,7 @@ size_t Print::write(const uint8_t *buffer, size_t size)
 
 size_t Print::print(const __FlashStringHelper *ifsh)
 {
-  const char PROGMEM *p = (const char PROGMEM *)ifsh;
+  const char *p = reinterpret_cast<const char *>(ifsh);
   size_t n = 0;
   while (1) {
     unsigned char c = pgm_read_byte(p++);


### PR DESCRIPTION
The cast from __FlashStringHelper to const char\* produced the following warning:

```
/Users/Lauszus/GitHub/Arduino/build/macosx/work/Arduino.app/Contents/Resources/Java/hardware/arduino/avr/cores/arduino/Print.cpp: In member function 'size_t Print::print(const __FlashStringHelper*)':
/Users/Lauszus/GitHub/Arduino/build/macosx/work/Arduino.app/Contents/Resources/Java/hardware/arduino/avr/cores/arduino/Print.cpp:44: warning: '__progmem__' attribute ignored
```

As the F() macro is defined this way: https://github.com/arduino/Arduino/blob/c86eed942dd3d7d0bced4fb26fb28ee57fccff07/hardware/arduino/avr/cores/arduino/WString.h#L38. We should use reinterpret_cast to cast it back to a const char*.
