### PR TITLE
Improve low free memory reporting

### DIFF
--- a/app/src/processing/app/Sketch.java
+++ b/app/src/processing/app/Sketch.java
@@ -1683,7 +1683,7 @@ public class Sketch {
 
     int warnDataPercentage = Integer.parseInt(prefs.get("build.warn_data_percentage"));
     if (maxDataSize > 0 && dataSize > maxDataSize*warnDataPercentage/100)
-	  System.out.println(_("Low memory available, stability problems may occur"));
+      System.err.println(_("Low memory available, stability problems may occur."));
   }
 
   protected boolean upload(String buildPath, String suggestedClassName, boolean usingProgrammer) throws Exception {


### PR DESCRIPTION
A couple of small enhancements to the memory usage report at the end of a successful compile:
- Send the low available memory warning to err rather than out so that it appears as a more visible warning.
- Remember the size of the text and data from the last compile and show how much of a change there was (if any).
