### PR TITLE
Refresh the available list of libraries whenever the Import Library menu is expanded

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -950,6 +950,9 @@ public class Base {
   }
 
 
+  // NOTE(remoun): This method is called whenever the Sketch > Import Library
+  // menu is expanded, so make sure not to break that completely.
+  // Showing an error dialog and skipping invalid entries is fine.
   public void rebuildImportMenu(final Editor editor) {
     JMenu importMenu = Editor.importMenu;
     importMenu.removeAll();

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1016,8 +1016,7 @@ public class Base {
     }  
   }
 
-  
-  public void rebuildBoardsMenu(JMenu menu, final Editor editor) {
+  public void rebuildBoardsMenu(JMenu menu) {
     //System.out.println("rebuilding boards menu");
     menu.removeAll();      
     ButtonGroup group = new ButtonGroup();

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -950,15 +950,16 @@ public class Base {
   }
 
 
-  public void rebuildImportMenu(JMenu importMenu, final Editor editor) {
+  public void rebuildImportMenu(final Editor editor) {
+    JMenu importMenu = Editor.importMenu;
     importMenu.removeAll();
-    
+
     JMenuItem addLibraryMenuItem = new JMenuItem(_("Add Library..."));
     addLibraryMenuItem.addActionListener(new ActionListener() {
       public void actionPerformed(ActionEvent e) {
         Base.this.handleAddLibrary(editor);
         Base.this.onBoardOrPortChange();
-        Base.this.rebuildImportMenu(Editor.importMenu, editor);
+        Base.this.rebuildImportMenu(editor);
         Base.this.rebuildExamplesMenu(Editor.examplesMenu);
       }
     });

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -629,6 +629,14 @@ public class Editor extends JFrame implements RunnerListener {
 
     if (importMenu == null) {
       importMenu = new JMenu(_("Import Library..."));
+      importMenu.addItemListener(new ItemListener() {
+        public void itemStateChanged(ItemEvent e) {
+          if (e.getStateChange() == ItemEvent.SELECTED) {
+            base.rebuildImportMenu(importMenu, Editor.this);
+          }
+        }
+      });
+      // Rebuild the import menu here, so it's faster the first time it expands.
       base.rebuildImportMenu(importMenu, this);
     }
     sketchMenu.add(importMenu);

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -690,7 +690,7 @@ public class Editor extends JFrame implements RunnerListener {
     
     if (boardsMenu == null) {
       boardsMenu = new JMenu(_("Board"));
-      base.rebuildBoardsMenu(boardsMenu, this);
+      base.rebuildBoardsMenu(boardsMenu);
     }
     menu.add(boardsMenu);
     

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -632,12 +632,12 @@ public class Editor extends JFrame implements RunnerListener {
       importMenu.addItemListener(new ItemListener() {
         public void itemStateChanged(ItemEvent e) {
           if (e.getStateChange() == ItemEvent.SELECTED) {
-            base.rebuildImportMenu(importMenu, Editor.this);
+            base.rebuildImportMenu(Editor.this);
           }
         }
       });
       // Rebuild the import menu here, so it's faster the first time it expands.
-      base.rebuildImportMenu(importMenu, this);
+      base.rebuildImportMenu(this);
     }
     sketchMenu.add(importMenu);
 


### PR DESCRIPTION
This way the Arduino IDE doesn't need to be restarted whenever a user drops a new library directory into Documents/Arduino/libraries or the sketchbook's libraries folder.

Note: I'm not sure how slow the `rebuildImportMenu` call can get if there are tons of libraries, but I expect it won't be so bad, since it's just a few `stat()` calls. Perhaps we could guard it with a setting (preferably defaulting to true [rebuild]) if it proves too slow.