### PR TITLE
Fixed "runtime.hardware.path" and "runtime.platform.path" values

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1554,6 +1554,10 @@ public class Base {
     Preferences.set("target_platform", targetPlatform.getId());
     Preferences.set("board", targetBoard.getId());
 
+    File platformFolder = targetPlatform.getFolder();
+    Preferences.set("runtime.platform.path", platformFolder.getAbsolutePath());
+    Preferences.set("runtime.hardware.path", platformFolder.getParentFile().getAbsolutePath());
+    
     filterVisibilityOfSubsequentBoardMenus(targetBoard, 1);
 
     onBoardOrPortChange();

--- a/app/src/processing/app/Preferences.java
+++ b/app/src/processing/app/Preferences.java
@@ -231,7 +231,6 @@ public class Preferences {
 
     // set some runtime constants (not saved on preferences file)
     File hardwareFolder = Base.getHardwareFolder();
-    table.put("runtime.hardware.path", hardwareFolder.getAbsolutePath());
     table.put("runtime.ide.path", hardwareFolder.getParentFile().getAbsolutePath());
     table.put("runtime.ide.version", "" + Base.REVISION);
     

--- a/hardware/arduino/avr/platform.txt
+++ b/hardware/arduino/avr/platform.txt
@@ -84,7 +84,7 @@ tools.avrdude.erase.pattern="{cmd.path}" "-C{config.path}" {erase.verbose} -p{bu
 
 tools.avrdude.bootloader.params.verbose=-v -v -v -v
 tools.avrdude.bootloader.params.quiet=-q -q
-tools.avrdude.bootloader.pattern="{cmd.path}" "-C{config.path}" {bootloader.verbose} -p{build.mcu} -c{protocol} {program.extra_params} "-Uflash:w:{runtime.ide.path}/hardware/arduino/avr/bootloaders/{bootloader.file}:i" -Ulock:w:{bootloader.lock_bits}:m
+tools.avrdude.bootloader.pattern="{cmd.path}" "-C{config.path}" {bootloader.verbose} -p{build.mcu} -c{protocol} {program.extra_params} "-Uflash:w:{runtime.platform.path}/bootloaders/{bootloader.file}:i" -Ulock:w:{bootloader.lock_bits}:m
 
 
 # USB Default Flags


### PR DESCRIPTION
This should fix #1176 and #1761.

"runtime.hardware.path" now contains the path to the hardware folder of the currently selected board (for example sketchbook/hardware/provider).
"runtime.platform.path" is a new variable with the path down to the specific platform (for example sketchbook/hardware/rovider/avr).
