### PR TITLE
Make some operators in IPAddress const

### DIFF
--- a/hardware/arduino/avr/cores/arduino/IPAddress.cpp
+++ b/hardware/arduino/avr/cores/arduino/IPAddress.cpp
@@ -37,7 +37,7 @@ IPAddress& IPAddress::operator=(uint32_t address)
     return *this;
 }
 
-bool IPAddress::operator==(const uint8_t* addr)
+bool IPAddress::operator==(const uint8_t* addr) const
 {
     return memcmp(addr, _address, sizeof(_address)) == 0;
 }

--- a/hardware/arduino/avr/cores/arduino/IPAddress.h
+++ b/hardware/arduino/avr/cores/arduino/IPAddress.h
@@ -49,9 +49,9 @@ public:
 
     // Overloaded cast operator to allow IPAddress objects to be used where a pointer
     // to a four-byte uint8_t array is expected
-    operator uint32_t() { return *((uint32_t*)_address); };
-    bool operator==(const IPAddress& addr) { return (*((uint32_t*)_address)) == (*((uint32_t*)addr._address)); };
-    bool operator==(const uint8_t* addr);
+    operator uint32_t() const { return *((uint32_t*)_address); };
+    bool operator==(const IPAddress& addr) const { return (*((uint32_t*)_address)) == (*((uint32_t*)addr._address)); };
+    bool operator==(const uint8_t* addr) const;
 
     // Overloaded index operator to allow getting and setting individual octets of the address
     uint8_t operator[](int index) const { return _address[index]; };

--- a/hardware/arduino/sam/cores/arduino/IPAddress.cpp
+++ b/hardware/arduino/sam/cores/arduino/IPAddress.cpp
@@ -37,7 +37,7 @@ IPAddress& IPAddress::operator=(uint32_t address)
     return *this;
 }
 
-bool IPAddress::operator==(const uint8_t* addr)
+bool IPAddress::operator==(const uint8_t* addr) const
 {
     return memcmp(addr, _address, sizeof(_address)) == 0;
 }

--- a/hardware/arduino/sam/cores/arduino/IPAddress.h
+++ b/hardware/arduino/sam/cores/arduino/IPAddress.h
@@ -48,9 +48,9 @@ public:
 
     // Overloaded cast operator to allow IPAddress objects to be used where a pointer
     // to a four-byte uint8_t array is expected
-    operator uint32_t() { return *((uint32_t*)_address); };
-    bool operator==(const IPAddress& addr) { return (*((uint32_t*)_address)) == (*((uint32_t*)addr._address)); };
-    bool operator==(const uint8_t* addr);
+    operator uint32_t() const { return *((uint32_t*)_address); };
+    bool operator==(const IPAddress& addr) const { return (*((uint32_t*)_address)) == (*((uint32_t*)addr._address)); };
+    bool operator==(const uint8_t* addr) const;
 
     // Overloaded index operator to allow getting and setting individual octets of the address
     uint8_t operator[](int index) const { return _address[index]; };


### PR DESCRIPTION
These functions do not modify the IPAddress object, but were not marked
as const. This meant that you could not do:

void set_ip(const IPAddress& ip) {
    this->ip = ip;
}

Since calling operator uint32_t() on ip would discard the constness of
the reference.
