### PR TITLE
Wire library, move hard references IRQn to defines in variant.h

### DIFF
--- a/hardware/arduino/sam/libraries/Wire/Wire.cpp
+++ b/hardware/arduino/sam/libraries/Wire/Wire.cpp
@@ -343,10 +343,10 @@ static void Wire_Init(void) {
 			g_APinDescription[PIN_WIRE_SCL].ulPin,
 			g_APinDescription[PIN_WIRE_SCL].ulPinConfiguration);
 
-	NVIC_DisableIRQ(TWI1_IRQn);
-	NVIC_ClearPendingIRQ(TWI1_IRQn);
-	NVIC_SetPriority(TWI1_IRQn, 0);
-	NVIC_EnableIRQ(TWI1_IRQn);
+	NVIC_DisableIRQ(WIRE_ISR_ID);
+	NVIC_ClearPendingIRQ(WIRE_ISR_ID);
+	NVIC_SetPriority(WIRE_ISR_ID, 0);
+	NVIC_EnableIRQ(WIRE_ISR_ID);
 }
 
 TwoWire Wire = TwoWire(WIRE_INTERFACE, Wire_Init);
@@ -370,10 +370,10 @@ static void Wire1_Init(void) {
 			g_APinDescription[PIN_WIRE1_SCL].ulPin,
 			g_APinDescription[PIN_WIRE1_SCL].ulPinConfiguration);
 
-	NVIC_DisableIRQ(TWI0_IRQn);
-	NVIC_ClearPendingIRQ(TWI0_IRQn);
-	NVIC_SetPriority(TWI0_IRQn, 0);
-	NVIC_EnableIRQ(TWI0_IRQn);
+	NVIC_DisableIRQ(WIRE1_ISR_ID);
+	NVIC_ClearPendingIRQ(WIRE1_ISR_ID);
+	NVIC_SetPriority(WIRE1_ISR_ID, 0);
+	NVIC_EnableIRQ(WIRE1_ISR_ID);
 }
 
 TwoWire Wire1 = TwoWire(WIRE1_INTERFACE, Wire1_Init);

--- a/hardware/arduino/sam/variants/arduino_due_x/variant.h
+++ b/hardware/arduino/sam/variants/arduino_due_x/variant.h
@@ -128,12 +128,14 @@ extern "C"{
 #define WIRE_INTERFACE       TWI1
 #define WIRE_INTERFACE_ID    ID_TWI1
 #define WIRE_ISR_HANDLER     TWI1_Handler
+#define WIRE_ISR_ID          TWI1_IRQn
 
 #define PIN_WIRE1_SDA        (70u)
 #define PIN_WIRE1_SCL        (71u)
 #define WIRE1_INTERFACE      TWI0
 #define WIRE1_INTERFACE_ID   ID_TWI0
 #define WIRE1_ISR_HANDLER    TWI0_Handler
+#define WIRE1_ISR_ID         TWI0_IRQn
 
 /*
  * UART/USART Interfaces


### PR DESCRIPTION
SAM wire library had hard coded TWI1_IRQn and TWI0_IRQn, these should be done via variant.h defines to be board neutral.
