### PR TITLE
Update for newer avr-gcc. (solves https://github.com/arduino/Arduino/issues/1807)

### DIFF
--- a/app/src/processing/app/debug/Compiler.java
+++ b/app/src/processing/app/debug/Compiler.java
@@ -547,7 +547,7 @@ public class Compiler implements MessageConsumer {
       avrBasePath + "avr-gcc",
       "-c", // compile, don't link
       "-g", // include debugging info (so errors include line numbers)
-      "-assembler-with-cpp",
+      "-x","assembler-with-cpp",
       "-mmcu=" + boardPreferences.get("build.mcu"),
       "-DF_CPU=" + boardPreferences.get("build.f_cpu"),      
       "-DARDUINO=" + Base.REVISION,


### PR DESCRIPTION
- Newer avr-gcc doesn't use -assembler-with-cpp, but
  uses -x assembler-with-cpp.
