### PR TITLE
Reorder HardwareSerial initialisation list to fix compiler warnings

### DIFF
--- a/hardware/arduino/avr/cores/arduino/HardwareSerial_private.h
+++ b/hardware/arduino/avr/cores/arduino/HardwareSerial_private.h
@@ -63,8 +63,8 @@ HardwareSerial::HardwareSerial(
     _ubrrh(ubrrh), _ubrrl(ubrrl),
     _ucsra(ucsra), _ucsrb(ucsrb), _ucsrc(ucsrc),
     _udr(udr),
-    _tx_buffer_head(0), _tx_buffer_tail(0),
-    _rx_buffer_head(0), _rx_buffer_tail(0)
+    _rx_buffer_head(0), _rx_buffer_tail(0),
+    _tx_buffer_head(0), _tx_buffer_tail(0)
 {
 }
 


### PR DESCRIPTION
Switch the tx and rx buffer head/tail entries in the `HardwareSerial` initialisation list so that they match the order the fields are defined in.

This fixes the following compiler warning (repeated for each of the `HardwareSerial*.cpp` source files the header is used in) introduced as part of the improvements in #1711:

```
In file included from HardwareSerial.cpp:31:
HardwareSerial.h: In constructor 'HardwareSerial::HardwareSerial(volatile uint8_t*, volatile uint8_t*, volatile uint8_t*, volatile uint8_t*, volatile uint8_t*, volatile uint8_t*)':
HardwareSerial.h:81: warning: 'HardwareSerial::_tx_buffer_tail' will be initialized after
HardwareSerial.h:78: warning:   'volatile uint8_t HardwareSerial::_rx_buffer_head'
HardwareSerial_private.h:62: warning:   when initialized here
```
