### PR TITLE
If 2 libs have same .h file, use the lib with same dir name

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1245,6 +1245,13 @@ public class Base {
         String packages[] =
           Compiler.headerListFromIncludePath(subfolder.getAbsolutePath());
         for (String pkg : packages) {
+          File old = importToLibraryTable.get(pkg);
+          if (old != null) {
+            // If a library was already found with this header, keep it if
+            // the library's directory name matches the header name.
+            String name = pkg.substring(0, pkg.length() - 2);
+            if (old.getPath().endsWith(name)) continue;
+          }
           importToLibraryTable.put(pkg, subfolder);
         }
       } catch (IOException e) {


### PR DESCRIPTION
When 2 libraries have a header with the same name, Arduino will use the last one it finds, because the list is built with very simple code that stores the last directory name it finds.

This has caused a lot of headaches for libraries like Adafruit_GFX where a copy is located in Robot_Control.  Even with Robot_Control modified to avoid this specific conflict, the opportunity for incorrect matching is still present.  ANY library that contains the file "Adafruit_GFX.h" can cause the correct library to not be used by the Arduino IDE.

This patch causes the IDE to always give preference to a library whose name matches the header file.

If 2 libraries have the same header, but neither matches the library name, the IDE will still use the last one it find.  This patch only addresses the easy but most important case, where the header and library name match.
