### PR TITLE
In HardwareSerial, don't use int for buffer indices

### DIFF
--- a/hardware/arduino/avr/cores/arduino/HardwareSerial.cpp
+++ b/hardware/arduino/avr/cores/arduino/HardwareSerial.cpp
@@ -171,7 +171,7 @@ int HardwareSerial::read(void)
     return -1;
   } else {
     unsigned char c = _rx_buffer[_rx_buffer_tail];
-    _rx_buffer_tail = (unsigned int)(_rx_buffer_tail + 1) % SERIAL_BUFFER_SIZE;
+    _rx_buffer_tail = (uint8_t)(_rx_buffer_tail + 1) % SERIAL_BUFFER_SIZE;
     return c;
   }
 }
@@ -207,7 +207,7 @@ size_t HardwareSerial::write(uint8_t c)
     sbi(*_ucsra, TXC0);
     return 1;
   }
-  int i = (_tx_buffer_head + 1) % SERIAL_BUFFER_SIZE;
+  uint8_t i = (_tx_buffer_head + 1) % SERIAL_BUFFER_SIZE;
 	
   // If the output buffer is full, there's nothing for it other than to 
   // wait for the interrupt handler to empty it a bit


### PR DESCRIPTION
The index attributes have been uint8_t for a while, so there is no point
in using int for local variables. This should allow the compiler to
generate slightly more efficient code, but (at least on gcc 4.8.2) it
also confuses the register allocator, causing this change to increase
code size by 2 bytes instead due to extra push/pop instructions (but
this will probably change in the future if the compiler improves).
