### PR TITLE
SAM Wire: fixed NACK/timeout behavior of requestFrom() and available()

### DIFF
--- a/hardware/arduino/sam/libraries/Wire/Wire.cpp
+++ b/hardware/arduino/sam/libraries/Wire/Wire.cpp
@@ -125,8 +125,10 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint8_t sendStop
 		if (readed + 1 == quantity)
 			TWI_SendSTOPCondition( twi);
 
-		TWI_WaitByteReceived(twi, RECV_TIMEOUT);
-		rxBuffer[readed++] = TWI_ReadByte(twi);
+		if (TWI_WaitByteReceived(twi, RECV_TIMEOUT))
+			rxBuffer[readed++] = TWI_ReadByte(twi);
+		else
+			break;
 	} while (readed < quantity);
 	TWI_WaitTransferComplete(twi, RECV_TIMEOUT);
 


### PR DESCRIPTION
`readed` is no longer incremented in `requestFrom()` if `TWI_WaitByteReceived()` gets a NACK or times out. This corrects the behavior (return values) of `requestFrom()` and `available()` to match the Arduino reference; they should return the number of bytes actually available for `read()`, not the number of bytes requested, which was the previous behavior. Fixes arduino/Arduino#1311