### PR TITLE
In HardwareSerial::_rx_complete_irq, don't use int for buffer index

### DIFF
--- a/hardware/arduino/avr/cores/arduino/HardwareSerial_private.h
+++ b/hardware/arduino/avr/cores/arduino/HardwareSerial_private.h
@@ -99,7 +99,7 @@ void HardwareSerial::_rx_complete_irq(void)
     // No Parity error, read byte and store it in the buffer if there is
     // room
     unsigned char c = *_udr;
-    int i = (unsigned int)(_rx_buffer_head + 1) % SERIAL_BUFFER_SIZE;
+    uint8_t i = (unsigned int)(_rx_buffer_head + 1) % SERIAL_BUFFER_SIZE;
 
     // if we should be storing the received character into the location
     // just before the tail (meaning that the head would advance to the


### PR DESCRIPTION
This was already fixed for HardwareSerial.cpp in #1863, but there was
one more case hidden in HardwareSerial_private.h.

The index attributes have been uint8_t for a while, so there is no point
in using int for local variables. This should allow the compiler to
generate slightly more efficient code, but (at least on gcc 4.8.2) it
also confuses the register allocator, causing this change to increase
code size by 2 bytes instead due to extra push/pop instructions (but
this will probably change in the future if the compiler improves).
