### PR TITLE
Fix loops in the SAM banzai() reset function

### DIFF
--- a/hardware/arduino/sam/cores/arduino/Reset.cpp
+++ b/hardware/arduino/sam/cores/arduino/Reset.cpp
@@ -31,12 +31,12 @@ void banzai() {
 	// Set bootflag to run SAM-BA bootloader at restart
 	const int EEFC_FCMD_CGPB = 0x0C;
 	const int EEFC_KEY = 0x5A;
-	while (EFC0->EEFC_FSR & EEFC_FSR_FRDY == 0);
+	while ((EFC0->EEFC_FSR & EEFC_FSR_FRDY) == 0);
 	EFC0->EEFC_FCR =
 		EEFC_FCR_FCMD(EEFC_FCMD_CGPB) |
 		EEFC_FCR_FARG(1) |
 		EEFC_FCR_FKEY(EEFC_KEY);
-	while (EFC0->EEFC_FSR & EEFC_FSR_FRDY == 0);
+	while ((EFC0->EEFC_FSR & EEFC_FSR_FRDY) == 0);
 
 	// From here flash memory is no more available.
 


### PR DESCRIPTION
(Note: I have only compile-tested this code. I haven't got a Due to actually test this, nor the know-how to tell if the fixed code is really correct, but I am sure that the old code is wrong).

The code used to say:

  while (EFC0->EEFC_FSR & EEFC_FSR_FRDY == 0);

This triggered a compiler warning, which is why I looked at this line
more closely:

```
warning: suggest parentheses around comparison in operand of '&'
```

As the warning indicates, because the == operator has higher precedence
than the & operator, the compiler is interpreting this line as:

  while (EFC0->EEFC_FSR & (EEFC_FSR_FRDY == 0));

Since EEFC_FSR_FRDY is defined as 1, (EEFC_FSR_FRDY == 0) is always
false (== 0) and this reduces to:

  while (EFC0->EEFC_FSR & 0);

Which reduces to:

  while (0);

So effectively this line is a no-op.

This commit adds parenthesis to restore the intended behaviour.
