### PR TITLE
Allow the serial monitor to stay opened during upload, disabling it

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -2374,8 +2374,7 @@ public class Editor extends JFrame implements RunnerListener {
     public void run() {
 
       try {
-        serialMonitor.closeSerialPort();
-        serialMonitor.setVisible(false);
+    	serialMonitor.suspend();
             
         uploading = true;
           
@@ -2402,6 +2401,14 @@ public class Editor extends JFrame implements RunnerListener {
       uploading = false;
       //toolbar.clear();
       toolbar.deactivate(EditorToolbar.EXPORT);
+      
+      // Return the serial monitor window to its initial state
+      try {
+    	  serialMonitor.resume();
+      }
+      catch (SerialException e) {
+          statusError(e);
+      }
     }
   }
 
@@ -2476,12 +2483,9 @@ public class Editor extends JFrame implements RunnerListener {
   }
 
 
-  public void handleSerial() {
-    if (uploading) return;
-    
+  public void handleSerial() {  
     try {
-      serialMonitor.openSerialPort();
-      serialMonitor.setVisible(true);
+      serialMonitor.openSerialMonitor();
     } catch (SerialException e) {
       statusError(e);
     }

--- a/app/src/processing/app/SerialMonitor.java
+++ b/app/src/processing/app/SerialMonitor.java
@@ -40,10 +40,11 @@ public class SerialMonitor extends JFrame implements MessageConsumer {
   private JComboBox lineEndings;
   private JComboBox serialRates;
   private int serialRate;
+  private boolean serialMonitorEnabled;
+  
 
   public SerialMonitor(String port) {
     super(port);
-  
     this.port = port;
   
     addWindowListener(new WindowAdapter() {
@@ -171,6 +172,8 @@ public class SerialMonitor extends JFrame implements MessageConsumer {
         }
       }
     }
+    
+    serialMonitorEnabled = true;
   }
   
   protected void setPlacement(int[] location) {
@@ -227,5 +230,51 @@ public class SerialMonitor extends JFrame implements MessageConsumer {
         	textArea.setCaretPosition(textArea.getDocument().getLength());
         }
       }});
+  }
+  
+  public void enableWindow(boolean enable)
+  {
+	  textArea.setEnabled(enable);
+	  scrollPane.setEnabled(enable);
+	  textField.setEnabled(enable);
+	  sendButton.setEnabled(enable);
+	  autoscrollBox.setEnabled(enable);
+	  lineEndings.setEnabled(enable);
+	  serialRates.setEnabled(enable);
+	  
+	  serialMonitorEnabled = enable;
+  }
+  
+  // Make the serial monitor window operational
+  public void openSerialMonitor() throws SerialException
+  {
+	  // If the serial monitor is not currently disabled, open
+	  // the serial port
+	  if (serialMonitorEnabled)
+		  openSerialPort();
+	  
+	  // Make the window visible
+	  setVisible(true);
+  }
+
+  // Puts the window in suspend state, closing the serial port
+  // to allow other entity (the programmer) to use it
+  public void suspend()
+  {
+	  if (serial != null) 
+		  // Serial is opened. Record this fact and close it
+		  closeSerialPort();
+	  
+	  enableWindow(false);	  
+  }
+  
+  public void resume() throws SerialException
+  {
+	  // Enable the window
+	  enableWindow(true);		  
+
+	  // If the window is visible, try to open the serial port
+	  if (isVisible())
+			openSerialPort();
   }
 }


### PR DESCRIPTION
Currently, the serial monitor window closes when starting program uploading. I find this behavior very annoying since the monitor window has to be opened over and over again after each upload. The attached patch fixes this issue. When upload starts, the window gets disabled. When the upload process ends the window gets re-enabled and become operational immediately (if it is visible). The user can also now open the serial monitor window while uploading is in progress.