### PR TITLE
Strings without null-termination

### DIFF
--- a/hardware/arduino/avr/cores/arduino/WString.cpp
+++ b/hardware/arduino/avr/cores/arduino/WString.cpp
@@ -696,7 +696,7 @@ void String::remove(unsigned int index, unsigned int count){
 	if (count > len - index) { count = len - index; }
 	char *writeTo = buffer + index;
 	len = len - count;
-	strncpy(writeTo, buffer + index + count,len - index);
+	memmove(writeTo, buffer + index + count, len - index);
 	buffer[len] = 0;
 }
 

--- a/hardware/arduino/avr/cores/arduino/WString.cpp
+++ b/hardware/arduino/avr/cores/arduino/WString.cpp
@@ -174,7 +174,7 @@ String & String::copy(const char *cstr, unsigned int length)
 		return *this;
 	}
 	len = length;
-	strcpy(buffer, cstr);
+	memcpy(buffer, cstr, length);
 	return *this;
 }
 
@@ -194,7 +194,7 @@ void String::move(String &rhs)
 {
 	if (buffer) {
 		if (capacity >= rhs.len) {
-			strcpy(buffer, rhs.buffer);
+			memcpy(buffer, rhs.buffer, rhs.len);
 			len = rhs.len;
 			rhs.len = 0;
 			return;
@@ -266,7 +266,7 @@ unsigned char String::concat(const char *cstr, unsigned int length)
 	if (!cstr) return 0;
 	if (length == 0) return 1;
 	if (!reserve(newlen)) return 0;
-	strcpy(buffer + len, cstr);
+	memcpy(buffer + len, cstr, length);
 	len = newlen;
 	return 1;
 }

--- a/hardware/arduino/avr/cores/arduino/WString.cpp
+++ b/hardware/arduino/avr/cores/arduino/WString.cpp
@@ -289,49 +289,49 @@ unsigned char String::concat(unsigned char num)
 {
 	char buf[1 + 3 * sizeof(unsigned char)];
 	itoa(num, buf, 10);
-	return concat(buf, strlen(buf));
+	return concat(buf);
 }
 
 unsigned char String::concat(int num)
 {
 	char buf[2 + 3 * sizeof(int)];
 	itoa(num, buf, 10);
-	return concat(buf, strlen(buf));
+	return concat(buf);
 }
 
 unsigned char String::concat(unsigned int num)
 {
 	char buf[1 + 3 * sizeof(unsigned int)];
 	utoa(num, buf, 10);
-	return concat(buf, strlen(buf));
+	return concat(buf);
 }
 
 unsigned char String::concat(long num)
 {
 	char buf[2 + 3 * sizeof(long)];
 	ltoa(num, buf, 10);
-	return concat(buf, strlen(buf));
+	return concat(buf);
 }
 
 unsigned char String::concat(unsigned long num)
 {
 	char buf[1 + 3 * sizeof(unsigned long)];
 	ultoa(num, buf, 10);
-	return concat(buf, strlen(buf));
+	return concat(buf);
 }
 
 unsigned char String::concat(float num)
 {
 	char buf[20];
 	char* string = dtostrf(num, 4, 2, buf);
-	return concat(string, strlen(string));
+	return concat(string);
 }
 
 unsigned char String::concat(double num)
 {
 	char buf[20];
 	char* string = dtostrf(num, 4, 2, buf);
-	return concat(string, strlen(string));
+	return concat(string);
 }
 
 unsigned char String::concat(const __FlashStringHelper * str)
@@ -360,7 +360,7 @@ StringSumHelper & operator + (const StringSumHelper &lhs, const String &rhs)
 StringSumHelper & operator + (const StringSumHelper &lhs, const char *cstr)
 {
 	StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-	if (!cstr || !a.concat(cstr, strlen(cstr))) a.invalidate();
+	if (!cstr || !a.concat(cstr)) a.invalidate();
 	return a;
 }
 

--- a/hardware/arduino/avr/cores/arduino/WString.cpp
+++ b/hardware/arduino/avr/cores/arduino/WString.cpp
@@ -31,6 +31,12 @@ String::String(const char *cstr)
 	if (cstr) copy(cstr, strlen(cstr));
 }
 
+String::String(const char *cstr, unsigned int length)
+{
+	init();
+	if (cstr) copy(cstr, length);
+}
+
 String::String(const String &value)
 {
 	init();

--- a/hardware/arduino/avr/cores/arduino/WString.cpp
+++ b/hardware/arduino/avr/cores/arduino/WString.cpp
@@ -624,10 +624,7 @@ String String::substring(unsigned int left, unsigned int right) const
 	String out;
 	if (left >= len) return out;
 	if (right > len) right = len;
-	char temp = buffer[right];  // save the replaced character
-	buffer[right] = '\0';	
-	out = buffer + left;  // pointer arithmetic
-	buffer[right] = temp;  //restore character
+	out.copy(buffer + left, right - left);
 	return out;
 }
 

--- a/hardware/arduino/avr/cores/arduino/WString.cpp
+++ b/hardware/arduino/avr/cores/arduino/WString.cpp
@@ -279,10 +279,7 @@ unsigned char String::concat(const char *cstr)
 
 unsigned char String::concat(char c)
 {
-	char buf[2];
-	buf[0] = c;
-	buf[1] = 0;
-	return concat(buf, 1);
+	return concat(&c, 1);
 }
 
 unsigned char String::concat(unsigned char num)

--- a/hardware/arduino/avr/cores/arduino/WString.h
+++ b/hardware/arduino/avr/cores/arduino/WString.h
@@ -57,6 +57,7 @@ public:
 	// fails, the string will be marked as invalid (i.e. "if (s)" will
 	// be false).
 	String(const char *cstr = "");
+	String(const char *cstr, unsigned int length);
 	String(const String &str);
 	String(const __FlashStringHelper *str);
        #if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)

--- a/hardware/arduino/avr/cores/arduino/WString.h
+++ b/hardware/arduino/avr/cores/arduino/WString.h
@@ -98,6 +98,7 @@ public:
 	// concatenation is considered unsucessful.  
 	unsigned char concat(const String &str);
 	unsigned char concat(const char *cstr);
+	unsigned char concat(const char *cstr, unsigned int length);
 	unsigned char concat(char c);
 	unsigned char concat(unsigned char c);
 	unsigned char concat(int num);
@@ -195,7 +196,6 @@ protected:
 	void init(void);
 	void invalidate(void);
 	unsigned char changeBuffer(unsigned int maxStrLen);
-	unsigned char concat(const char *cstr, unsigned int length);
 
 	// copy and move
 	String & copy(const char *cstr, unsigned int length);

--- a/hardware/arduino/avr/cores/arduino/WString.h
+++ b/hardware/arduino/avr/cores/arduino/WString.h
@@ -58,6 +58,7 @@ public:
 	// be false).
 	String(const char *cstr = "");
 	String(const char *cstr, unsigned int length);
+	String(const uint8_t *cstr, unsigned int length) : String((const char*)cstr, length) {}
 	String(const String &str);
 	String(const __FlashStringHelper *str);
        #if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)

--- a/hardware/arduino/avr/cores/arduino/WString.h
+++ b/hardware/arduino/avr/cores/arduino/WString.h
@@ -100,6 +100,7 @@ public:
 	unsigned char concat(const String &str);
 	unsigned char concat(const char *cstr);
 	unsigned char concat(const char *cstr, unsigned int length);
+	unsigned char concat(const uint8_t *cstr, unsigned int length) {return concat((const char*)cstr, length);}
 	unsigned char concat(char c);
 	unsigned char concat(unsigned char c);
 	unsigned char concat(int num);

--- a/hardware/arduino/sam/cores/arduino/WString.cpp
+++ b/hardware/arduino/sam/cores/arduino/WString.cpp
@@ -291,49 +291,49 @@ unsigned char String::concat(unsigned char num)
 {
 	char buf[1 + 3 * sizeof(unsigned char)];
 	itoa(num, buf, 10);
-	return concat(buf, strlen(buf));
+	return concat(buf);
 }
 
 unsigned char String::concat(int num)
 {
 	char buf[2 + 3 * sizeof(int)];
 	itoa(num, buf, 10);
-	return concat(buf, strlen(buf));
+	return concat(buf);
 }
 
 unsigned char String::concat(unsigned int num)
 {
 	char buf[1 + 3 * sizeof(unsigned int)];
 	utoa(num, buf, 10);
-	return concat(buf, strlen(buf));
+	return concat(buf);
 }
 
 unsigned char String::concat(long num)
 {
 	char buf[2 + 3 * sizeof(long)];
 	ltoa(num, buf, 10);
-	return concat(buf, strlen(buf));
+	return concat(buf);
 }
 
 unsigned char String::concat(unsigned long num)
 {
 	char buf[1 + 3 * sizeof(unsigned long)];
 	ultoa(num, buf, 10);
-	return concat(buf, strlen(buf));
+	return concat(buf);
 }
 
 unsigned char String::concat(float num)
 {
 	char buf[20];
 	char* string = dtostrf(num, 4, 2, buf);
-	return concat(string, strlen(string));
+	return concat(string);
 }
 
 unsigned char String::concat(double num)
 {
 	char buf[20];
 	char* string = dtostrf(num, 4, 2, buf);
-	return concat(string, strlen(string));
+	return concat(string);
 }
 
 unsigned char String::concat(const __FlashStringHelper * str)
@@ -362,7 +362,7 @@ StringSumHelper & operator + (const StringSumHelper &lhs, const String &rhs)
 StringSumHelper & operator + (const StringSumHelper &lhs, const char *cstr)
 {
 	StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-	if (!cstr || !a.concat(cstr, strlen(cstr))) a.invalidate();
+	if (!cstr || !a.concat(cstr)) a.invalidate();
 	return a;
 }
 

--- a/hardware/arduino/sam/cores/arduino/WString.cpp
+++ b/hardware/arduino/sam/cores/arduino/WString.cpp
@@ -281,10 +281,7 @@ unsigned char String::concat(const char *cstr)
 
 unsigned char String::concat(char c)
 {
-	char buf[2];
-	buf[0] = c;
-	buf[1] = 0;
-	return concat(buf, 1);
+	return concat(&c, 1);
 }
 
 unsigned char String::concat(unsigned char num)

--- a/hardware/arduino/sam/cores/arduino/WString.cpp
+++ b/hardware/arduino/sam/cores/arduino/WString.cpp
@@ -33,6 +33,12 @@ String::String(const char *cstr)
 	if (cstr) copy(cstr, strlen(cstr));
 }
 
+String::String(const char *cstr, unsigned int length)
+{
+	init();
+	if (cstr) copy(cstr, length);
+}
+
 String::String(const String &value)
 {
 	init();

--- a/hardware/arduino/sam/cores/arduino/WString.cpp
+++ b/hardware/arduino/sam/cores/arduino/WString.cpp
@@ -626,10 +626,7 @@ String String::substring(unsigned int left, unsigned int right) const
 	String out;
 	if (left >= len) return out;
 	if (right > len) right = len;
-	char temp = buffer[right];  // save the replaced character
-	buffer[right] = '\0';	
-	out = buffer + left;  // pointer arithmetic
-	buffer[right] = temp;  //restore character
+	out.copy(buffer + left, right - left);
 	return out;
 }
 

--- a/hardware/arduino/sam/cores/arduino/WString.cpp
+++ b/hardware/arduino/sam/cores/arduino/WString.cpp
@@ -698,7 +698,7 @@ void String::remove(unsigned int index, unsigned int count){
 	if (count > len - index) { count = len - index; }
 	char *writeTo = buffer + index;
 	len = len - count;
-	strncpy(writeTo, buffer + index + count,len - index);
+	memmove(writeTo, buffer + index + count, len - index);
 	buffer[len] = 0;
 }
 

--- a/hardware/arduino/sam/cores/arduino/WString.cpp
+++ b/hardware/arduino/sam/cores/arduino/WString.cpp
@@ -176,7 +176,7 @@ String & String::copy(const char *cstr, unsigned int length)
 		return *this;
 	}
 	len = length;
-	strcpy(buffer, cstr);
+	memcpy(buffer, cstr, length);
 	return *this;
 }
 
@@ -196,7 +196,7 @@ void String::move(String &rhs)
 {
 	if (buffer) {
 		if (capacity >= rhs.len) {
-			strcpy(buffer, rhs.buffer);
+			memcpy(buffer, rhs.buffer, rhs.len);
 			len = rhs.len;
 			rhs.len = 0;
 			return;
@@ -268,7 +268,7 @@ unsigned char String::concat(const char *cstr, unsigned int length)
 	if (!cstr) return 0;
 	if (length == 0) return 1;
 	if (!reserve(newlen)) return 0;
-	strcpy(buffer + len, cstr);
+	memcpy(buffer + len, cstr, length);
 	len = newlen;
 	return 1;
 }

--- a/hardware/arduino/sam/cores/arduino/WString.h
+++ b/hardware/arduino/sam/cores/arduino/WString.h
@@ -57,6 +57,7 @@ public:
 	// fails, the string will be marked as invalid (i.e. "if (s)" will
 	// be false).
 	String(const char *cstr = "");
+	String(const char *cstr, unsigned int length);
 	String(const String &str);
 	String(const __FlashStringHelper *str);
        #if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)

--- a/hardware/arduino/sam/cores/arduino/WString.h
+++ b/hardware/arduino/sam/cores/arduino/WString.h
@@ -98,6 +98,7 @@ public:
 	// concatenation is considered unsucessful.  
 	unsigned char concat(const String &str);
 	unsigned char concat(const char *cstr);
+	unsigned char concat(const char *cstr, unsigned int length);
 	unsigned char concat(char c);
 	unsigned char concat(unsigned char c);
 	unsigned char concat(int num);
@@ -195,7 +196,6 @@ protected:
 	void init(void);
 	void invalidate(void);
 	unsigned char changeBuffer(unsigned int maxStrLen);
-	unsigned char concat(const char *cstr, unsigned int length);
 
 	// copy and move
 	String & copy(const char *cstr, unsigned int length);

--- a/hardware/arduino/sam/cores/arduino/WString.h
+++ b/hardware/arduino/sam/cores/arduino/WString.h
@@ -58,6 +58,7 @@ public:
 	// be false).
 	String(const char *cstr = "");
 	String(const char *cstr, unsigned int length);
+	String(const uint8_t *cstr, unsigned int length) : String((const char*)cstr, length) {}
 	String(const String &str);
 	String(const __FlashStringHelper *str);
        #if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)

--- a/hardware/arduino/sam/cores/arduino/WString.h
+++ b/hardware/arduino/sam/cores/arduino/WString.h
@@ -100,6 +100,7 @@ public:
 	unsigned char concat(const String &str);
 	unsigned char concat(const char *cstr);
 	unsigned char concat(const char *cstr, unsigned int length);
+	unsigned char concat(const uint8_t *cstr, unsigned int length) {return concat((const char*)cstr, length);}
 	unsigned char concat(char c);
 	unsigned char concat(unsigned char c);
 	unsigned char concat(int num);


### PR DESCRIPTION
When working with the Arduino String class, I've found that I couldn't efficiently combine it with some external libraries that explicitely pass `char*` and length around, without nul-terminating their strings. This prompted me to modify  and expose the `concat (const char* cstr, unsigned int length)` method, add a new `String(const char* cstr, unsigned int length)` constructor. While I was going over the string class, I found some other minor improvements, which are included here.
