### PR TITLE
String index fixes and cleanups

### DIFF
--- a/hardware/arduino/avr/cores/arduino/WString.cpp
+++ b/hardware/arduino/avr/cores/arduino/WString.cpp
@@ -619,7 +619,7 @@ String String::substring(unsigned int left, unsigned int right) const
 		left = temp;
 	}
 	String out;
-	if (left > len) return out;
+	if (left >= len) return out;
 	if (right > len) right = len;
 	char temp = buffer[right];  // save the replaced character
 	buffer[right] = '\0';	


### PR DESCRIPTION
This pullrequest adds support for using negative indices in Strings to index a String from the end instead of the start. This changes all methods that accept indices: `operator[]`, `charAt`, `setCharAt`, `indexOf`, `lastIndexOf`, `substring` and `remove`.

I also added some fixes and simplifications I ran across while implementing the negative indices.
