### PR TITLE
Batched CDC writes for improved speed.

### DIFF
--- a/hardware/arduino/cores/arduino/CDC.cpp
+++ b/hardware/arduino/cores/arduino/CDC.cpp
@@ -200,6 +200,11 @@ void Serial_::flush(void)
 
 size_t Serial_::write(uint8_t c)
 {
+	return write(&c, 1);
+}
+
+size_t Serial_::write(const uint8_t *buffer, size_t size)
+{
 	/* only try to send bytes if the high-level CDC connection itself 
 	 is open (not just the pipe) - the OS should set lineState when the port
 	 is opened and clear lineState when the port is closed.
@@ -210,7 +215,7 @@ size_t Serial_::write(uint8_t c)
 	// open connection isn't broken cleanly (cable is yanked out, host dies
 	// or locks up, or host virtual serial port hangs)
 	if (_usbLineInfo.lineState > 0)	{
-		int r = USB_Send(CDC_TX,&c,1);
+		int r = USB_Send(CDC_TX,buffer,size);
 		if (r > 0) {
 			return r;
 		} else {

--- a/hardware/arduino/cores/arduino/USBAPI.h
+++ b/hardware/arduino/cores/arduino/USBAPI.h
@@ -40,6 +40,7 @@ public:
 	virtual int read(void);
 	virtual void flush(void);
 	virtual size_t write(uint8_t);
+	virtual size_t write(const uint8_t*, size_t);
 	using Print::write; // pull in write(str) and write(buf, size) from Print
 	operator bool();
 };


### PR DESCRIPTION
CDC writes can be batched to improve the throughput. In my testing this is almost twice as fast.
