### PR TITLE
Fix race condition in USB CDC transmit

### DIFF
--- a/hardware/arduino/cores/arduino/USBCore.cpp
+++ b/hardware/arduino/cores/arduino/USBCore.cpp
@@ -290,9 +290,12 @@ int USB_Send(u8 ep, const void* d, int len)
 
 		if (n > len)
 			n = len;
-		len -= n;
 		{
 			LockEP lock(ep);
+			// Frame may have been released by the SOF interrupt handler
+			if (!ReadWriteAllowed())
+				continue;
+			len -= n;
 			if (ep & TRANSFER_ZERO)
 			{
 				while (n--)


### PR DESCRIPTION
This patch fixes a race that can cause data corruption/loss when sending data over the USB CDC serial port.  Exact details in commit message.

The window for the race condition is quite small, and the CDC code very slow (byte writes), so the hardware double buffering means this occurs extremely rarely for most sketches.

I have however seen it occur in real life.
