### PR TITLE
Use block transfer for printing String objects

### DIFF
--- a/hardware/arduino/cores/arduino/Print.cpp
+++ b/hardware/arduino/cores/arduino/Print.cpp
@@ -53,11 +53,7 @@ size_t Print::print(const __FlashStringHelper *ifsh)
 
 size_t Print::print(const String &s)
 {
-  size_t n = 0;
-  for (uint16_t i = 0; i < s.length(); i++) {
-    n += write(s[i]);
-  }
-  return n;
+  return write((const uint8_t *)s.c_str(), s.length());
 }
 
 size_t Print::print(const char str[])


### PR DESCRIPTION
Use existing block write routine when printing String objects, instead of iterating over the string.
This is both simpler and generates smaller code.
In some cases it is also substantially faster.

Signed-off-by: Paul Brook paul@nowt.org
