### PR TITLE
Improve CDC read code

### DIFF
--- a/hardware/arduino/cores/arduino/USBAPI.h
+++ b/hardware/arduino/cores/arduino/USBAPI.h
@@ -28,14 +28,13 @@ extern USBDevice_ USBDevice;
 class Serial_ : public Stream
 {
 private:
-	ring_buffer *_cdc_rx_buffer;
+	int peek_buffer;
 public:
 	void begin(unsigned long);
 	void begin(unsigned long, uint8_t);
 	void end(void);
 
 	virtual int available(void);
-	virtual void accept(void);
 	virtual int peek(void);
 	virtual int read(void);
 	virtual void flush(void);

--- a/hardware/arduino/cores/arduino/USBCore.cpp
+++ b/hardware/arduino/cores/arduino/USBCore.cpp
@@ -611,8 +611,6 @@ ISR(USB_GEN_vect)
 	{
 #ifdef CDC_ENABLED
 		USB_Flush(CDC_TX);				// Send a tx frame if found
-		if (USB_Available(CDC_RX))	// Handle received bytes (if any)
-			Serial.accept();
 #endif
 		
 		// check whether the one-shot period has elapsed.  if so, turn off the LED


### PR DESCRIPTION
Remove superfluous ring buffer from the CDC read code. The USB hardware already buffers 128 bytes of data, so just read from that on demand.

The result is smaller, faster, uses substantially less ram, and does not do large data copies in an interrupt handler.
