### PR TITLE
Updated Wifi Shield firmware update script for OSX to reference correct ...

### DIFF
--- a/hardware/arduino/firmwares/wifishield/scripts/ArduinoWifiShield_upgrade_mac.sh
+++ b/hardware/arduino/firmwares/wifishield/scripts/ArduinoWifiShield_upgrade_mac.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-WIFI_FW_PATH="/hardware/arduino/firmwares/wifi-shield"
+WIFI_FW_PATH="/hardware/arduino/firmwares/wifishield/binary"
 AVR_TOOLS_PATH="/hardware/tools/avr/bin"
 
 progname=$0


### PR DESCRIPTION
...path.

This update reference the files in firmwares/wifishield/binary/ since the MD5
for those files is the same as the ones in
firmwares/wifishield/[specific_firmware]/Release/ and the Linux script
uses the files in the binary/ directory as well.
Also marked the OSX script as runnable.

I was following the instructions for updating the wifi shield [here](http://ohmyfarads.wordpress.com/2013/11/11/updating-firmware-on-arduino-wifi-shield-for-dummies/) and wanted to update the scripts to make the process slightly less circuitous. I was also wondering what the wifi_dnld_2_1.elf and wifiHD_2_1.elf files are, and why there are duplicates of the .elf files in wifishield/wifi_dnld/Release/ and wifishield/wifiHD/Release/.

Please let me know if I should submit this pull request against a different branch.
