### PR TITLE
Fix typo in SerialEvent3 handling

### DIFF
--- a/hardware/arduino/avr/cores/arduino/HardwareSerial.cpp
+++ b/hardware/arduino/avr/cores/arduino/HardwareSerial.cpp
@@ -72,7 +72,7 @@ void serialEventRun(void)
   if (Serial2_available && serialEvent2 && Serial2_available()) serialEvent2();
 #endif
 #if defined(HAVE_HWSERIAL3)
-  if (Serial3_available && serialEvent2 && Serial3_available()) serialEvent3();
+  if (Serial3_available && serialEvent3 && Serial3_available()) serialEvent3();
 #endif
 }
 


### PR DESCRIPTION
In commit 0e97bcb (Put each HardwareSerial instance in its own .cpp
file), the serial event handling was changed. This was probably a
copy-paste typo.

The effect of this bug was that SerialEvent3 would not run, unless
SerialEvent2 was defined, but also that if SerialEvent2 is defined but
SerialEvent3 is not, this could cause a reset (call to NULL pointer).

This closes #1967, thanks to Peter Olson for finding the bug and fix.
