### PR TITLE
Fixed string constructor overloading bug

### DIFF
--- a/hardware/arduino/cores/arduino/WString.cpp
+++ b/hardware/arduino/cores/arduino/WString.cpp
@@ -21,7 +21,6 @@
 
 #include "WString.h"
 
-
 /*********************************************/
 /*  Constructors                             */
 /*********************************************/
@@ -36,6 +35,12 @@ String::String(const String &value)
 {
 	init();
 	*this = value;
+}
+
+String::String(const __FlashStringHelper *pstr)
+{
+	init();
+	*this = pstr;
 }
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
@@ -63,7 +68,7 @@ String::String(char c)
 String::String(unsigned char value, unsigned char base)
 {
 	init();
-	char buf[9];
+	char buf[1 + 8 * sizeof(unsigned char)];
 	utoa(value, buf, base);
 	*this = buf;
 }
@@ -71,7 +76,7 @@ String::String(unsigned char value, unsigned char base)
 String::String(int value, unsigned char base)
 {
 	init();
-	char buf[18];
+	char buf[2 + 8 * sizeof(int)];
 	itoa(value, buf, base);
 	*this = buf;
 }
@@ -79,7 +84,7 @@ String::String(int value, unsigned char base)
 String::String(unsigned int value, unsigned char base)
 {
 	init();
-	char buf[17];
+	char buf[1 + 8 * sizeof(unsigned int)];
 	utoa(value, buf, base);
 	*this = buf;
 }
@@ -87,7 +92,7 @@ String::String(unsigned int value, unsigned char base)
 String::String(long value, unsigned char base)
 {
 	init();
-	char buf[34];
+	char buf[2 + 8 * sizeof(long)];
 	ltoa(value, buf, base);
 	*this = buf;
 }
@@ -95,7 +100,7 @@ String::String(long value, unsigned char base)
 String::String(unsigned long value, unsigned char base)
 {
 	init();
-	char buf[33];
+	char buf[1 + 8 * sizeof(unsigned long)];
 	ultoa(value, buf, base);
 	*this = buf;
 }
@@ -113,6 +118,7 @@ String::String(double value, unsigned char decimalPlaces)
 	char buf[33];
 	*this = dtostrf(value, (decimalPlaces + 2), decimalPlaces, buf);
 }
+
 String::~String()
 {
 	free(buffer);
@@ -127,7 +133,6 @@ inline void String::init(void)
 	buffer = NULL;
 	capacity = 0;
 	len = 0;
-	flags = 0;
 }
 
 void String::invalidate(void)
@@ -170,6 +175,17 @@ String & String::copy(const char *cstr, unsigned int length)
 	}
 	len = length;
 	strcpy(buffer, cstr);
+	return *this;
+}
+
+String & String::copy(const __FlashStringHelper *pstr, unsigned int length)
+{
+	if (!reserve(length)) {
+		invalidate();
+		return *this;
+	}
+	len = length;
+	strcpy_P(buffer, (PGM_P)pstr);
 	return *this;
 }
 
@@ -227,6 +243,14 @@ String & String::operator = (const char *cstr)
 	return *this;
 }
 
+String & String::operator = (const __FlashStringHelper *pstr)
+{
+	if (pstr) copy(pstr, strlen_P((PGM_P)pstr));
+	else invalidate();
+
+	return *this;
+}
+
 /*********************************************/
 /*  concat                                   */
 /*********************************************/
@@ -263,35 +287,35 @@ unsigned char String::concat(char c)
 
 unsigned char String::concat(unsigned char num)
 {
-	char buf[4];
+	char buf[1 + 3 * sizeof(unsigned char)];
 	itoa(num, buf, 10);
 	return concat(buf, strlen(buf));
 }
 
 unsigned char String::concat(int num)
 {
-	char buf[7];
+	char buf[2 + 3 * sizeof(int)];
 	itoa(num, buf, 10);
 	return concat(buf, strlen(buf));
 }
 
 unsigned char String::concat(unsigned int num)
 {
-	char buf[6];
+	char buf[1 + 3 * sizeof(unsigned int)];
 	utoa(num, buf, 10);
 	return concat(buf, strlen(buf));
 }
 
 unsigned char String::concat(long num)
 {
-	char buf[12];
+	char buf[2 + 3 * sizeof(long)];
 	ltoa(num, buf, 10);
 	return concat(buf, strlen(buf));
 }
 
 unsigned char String::concat(unsigned long num)
 {
-	char buf[11];
+	char buf[1 + 3 * sizeof(unsigned long)];
 	ultoa(num, buf, 10);
 	return concat(buf, strlen(buf));
 }
@@ -299,15 +323,27 @@ unsigned char String::concat(unsigned long num)
 unsigned char String::concat(float num)
 {
 	char buf[20];
-	char* string = dtostrf(num, 8, 6, buf);
+	char* string = dtostrf(num, 4, 2, buf);
 	return concat(string, strlen(string));
 }
 
 unsigned char String::concat(double num)
 {
 	char buf[20];
-	char* string = dtostrf(num, 8, 6, buf);
+	char* string = dtostrf(num, 4, 2, buf);
 	return concat(string, strlen(string));
+}
+
+unsigned char String::concat(const __FlashStringHelper * str)
+{
+	if (!str) return 0;
+	int length = strlen_P((const char *) str);
+	if (length == 0) return 1;
+	unsigned int newlen = len + length;
+	if (!reserve(newlen)) return 0;
+	strcpy_P(buffer + len, (const char *) str);
+	len = newlen;
+	return 1;
 }
 
 /*********************************************/
@@ -383,6 +419,14 @@ StringSumHelper & operator + (const StringSumHelper &lhs, double num)
 	if (!a.concat(num)) a.invalidate();
 	return a;
 }
+
+StringSumHelper & operator + (const StringSumHelper &lhs, const __FlashStringHelper *rhs)
+{
+	StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
+	if (!a.concat(rhs))	a.invalidate();
+	return a;
+}
+
 /*********************************************/
 /*  Comparison                               */
 /*********************************************/
@@ -567,11 +611,6 @@ int String::lastIndexOf(const String &s2, unsigned int fromIndex) const
 	return found;
 }
 
-String String::substring( unsigned int left ) const
-{
-	return substring(left, len);
-}
-
 String String::substring(unsigned int left, unsigned int right) const
 {
 	if (left > right) {
@@ -697,7 +736,6 @@ long String::toInt(void) const
 	if (buffer) return atol(buffer);
 	return 0;
 }
-
 
 float String::toFloat(void) const
 {

--- a/hardware/arduino/cores/arduino/WString.h
+++ b/hardware/arduino/cores/arduino/WString.h
@@ -58,6 +58,7 @@ public:
 	// be false).
 	String(const char *cstr = "");
 	String(const String &str);
+	String(const __FlashStringHelper *str);
 	#ifdef __GXX_EXPERIMENTAL_CXX0X__
 	String(String &&rval);
 	String(StringSumHelper &&rval);
@@ -68,8 +69,8 @@ public:
 	explicit String(unsigned int, unsigned char base=10);
 	explicit String(long, unsigned char base=10);
 	explicit String(unsigned long, unsigned char base=10);
-    explicit String(float, unsigned char decimalPlaces=6);
-    explicit String(double, unsigned char decimalPlaces=6);
+	explicit String(float, unsigned char decimalPlaces=2);
+	explicit String(double, unsigned char decimalPlaces=2);
 	~String(void);
 
 	// memory management
@@ -84,6 +85,7 @@ public:
 	// marked as invalid ("if (s)" will be false).
 	String & operator = (const String &rhs);
 	String & operator = (const char *cstr);
+	String & operator = (const __FlashStringHelper *str);
 	#ifdef __GXX_EXPERIMENTAL_CXX0X__
 	String & operator = (String &&rval);
 	String & operator = (StringSumHelper &&rval);
@@ -104,6 +106,7 @@ public:
 	unsigned char concat(unsigned long num);
 	unsigned char concat(float num);
 	unsigned char concat(double num);
+	unsigned char concat(const __FlashStringHelper * str);
 	
 	// if there's not enough memory for the concatenated value, the string
 	// will be left unchanged (but this isn't signalled in any way)
@@ -115,6 +118,9 @@ public:
 	String & operator += (unsigned int num)		{concat(num); return (*this);}
 	String & operator += (long num)			{concat(num); return (*this);}
 	String & operator += (unsigned long num)	{concat(num); return (*this);}
+	String & operator += (float num)		{concat(num); return (*this);}
+	String & operator += (double num)		{concat(num); return (*this);}
+	String & operator += (const __FlashStringHelper *str){concat(str); return (*this);}
 
 	friend StringSumHelper & operator + (const StringSumHelper &lhs, const String &rhs);
 	friend StringSumHelper & operator + (const StringSumHelper &lhs, const char *cstr);
@@ -126,6 +132,7 @@ public:
 	friend StringSumHelper & operator + (const StringSumHelper &lhs, unsigned long num);
 	friend StringSumHelper & operator + (const StringSumHelper &lhs, float num);
 	friend StringSumHelper & operator + (const StringSumHelper &lhs, double num);
+	friend StringSumHelper & operator + (const StringSumHelper &lhs, const __FlashStringHelper *rhs);
 
 	// comparison (only works w/ Strings and "strings")
 	operator StringIfHelperType() const { return buffer ? &String::StringIfHelper : 0; }
@@ -164,7 +171,7 @@ public:
 	int lastIndexOf( char ch, unsigned int fromIndex ) const;
 	int lastIndexOf( const String &str ) const;
 	int lastIndexOf( const String &str, unsigned int fromIndex ) const;
-	String substring( unsigned int beginIndex ) const;
+	String substring( unsigned int beginIndex ) const { return substring(beginIndex, len); };
 	String substring( unsigned int beginIndex, unsigned int endIndex ) const;
 
 	// modification
@@ -184,7 +191,6 @@ protected:
 	char *buffer;	        // the actual char array
 	unsigned int capacity;  // the array length minus one (for the '\0')
 	unsigned int len;       // the String length (not counting the '\0')
-	unsigned char flags;    // unused, for future features
 protected:
 	void init(void);
 	void invalidate(void);
@@ -193,6 +199,7 @@ protected:
 
 	// copy and move
 	String & copy(const char *cstr, unsigned int length);
+	String & copy(const __FlashStringHelper *pstr, unsigned int length);
 	#ifdef __GXX_EXPERIMENTAL_CXX0X__
 	void move(String &rhs);
 	#endif
@@ -209,6 +216,8 @@ public:
 	StringSumHelper(unsigned int num) : String(num) {}
 	StringSumHelper(long num) : String(num) {}
 	StringSumHelper(unsigned long num) : String(num) {}
+	StringSumHelper(float num) : String(num) {}
+	StringSumHelper(double num) : String(num) {}
 };
 
 #endif  // __cplusplus


### PR DESCRIPTION
Given the following code:

```
void setup() {
  int v = 4385;
  String s(v, HEX);
} 

void loop() { }
```

the current overloading of the String constructor causes the error:

sketch_apr01a:3: error: call of overloaded ‘String(int&, int)’ is ambiguous
/home/matt/git/Arduino/build/linux/work/hardware/arduino/cores/arduino/WString.h:72: note: candidates are: String::String(double, int)
/home/matt/git/Arduino/build/linux/work/hardware/arduino/cores/arduino/WString.h:71: note:                 String::String(float, int)
/home/matt/git/Arduino/build/linux/work/hardware/arduino/cores/arduino/WString.h:70: note:                 String::String(long unsigned int, unsigned char)
/home/matt/git/Arduino/build/linux/work/hardware/arduino/cores/arduino/WString.h:69: note:                 String::String(long int, unsigned char)
/home/matt/git/Arduino/build/linux/work/hardware/arduino/cores/arduino/WString.h:68: note:                 String::String(unsigned int, unsigned char)
/home/matt/git/Arduino/build/linux/work/hardware/arduino/cores/arduino/WString.h:67: note:                 String::String(int, unsigned char)
/home/matt/git/Arduino/build/linux/work/hardware/arduino/cores/arduino/WString.h:66: note:                 String::String(unsigned char, unsigned char)

Switching the float/double decimal places parameter to an unsigned char like the rest of the constructors resolves the issue.
