### PR TITLE
Storing Libraries in subfolders

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1891,7 +1891,7 @@ public class Base {
       try {
         packages.put(target, new TargetPackage(target, subfolder));
       } catch (TargetPlatformException e) {
-        System.out.println("WARNING: Error loading hardware folder " + target);
+        System.out.println("WARNING: Error loading hardware folder " + target + " from " + subfolder);
         System.out.println("  " + e.getMessage());
       }
     }

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1381,14 +1381,6 @@ public class Base {
 
     for (String libName : list) {
       File subfolder = new File(folder, libName);
-      if (!Sketch.isSanitaryName(libName)) {
-        String mess = I18n.format(_("The library \"{0}\" cannot be used.\n"
-            + "Library names must contain only basic letters and numbers.\n"
-            + "(ASCII only and no spaces, and it cannot start with a number)"),
-                                  libName);
-        Base.showMessage(_("Ignoring bad library name"), mess);
-        continue;
-      }
 
       try {
         Library lib = Library.create(subfolder);

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1292,7 +1292,6 @@ public class Base {
     importMenu.add(addLibraryMenuItem);
     
     if (libraries != null) {
-      importMenu.addSeparator();
       try {
         addLibraries(importMenu, libraries);
       } catch (IOException e) {
@@ -1307,12 +1306,28 @@ public class Base {
 
       // Add examples from distribution "example" folder
       boolean found = addSketches(menu, examplesFolder, false);
+      if (found) {
+        // Prepend a label
+        JMenuItem label = new JMenuItem(_("Core examples"));
+        label.setEnabled(false);
+        menu.add(label, 0);
+      }
 
       // Add examples from libraries
       if (libraries != null && !libraries.isEmpty()) {
-        if (found)
-          menu.addSeparator();
-        addLibraryExamples(menu, libraries);
+        for (LibraryList sub : libraries.getSubs()) {
+          if (found)
+            menu.addSeparator();
+
+          // Prepend a label
+          JMenuItem label = new JMenuItem(sub.getName());
+          label.setEnabled(false);
+          menu.add(label);
+
+          addLibraryExamples(menu, sub);
+
+          found = true;
+        }
       }
     } catch (IOException e) {
       e.printStackTrace();
@@ -1820,13 +1835,26 @@ public class Base {
   }
 
   protected void addLibraries(JMenu menu, LibraryList libs) throws IOException {
+    for (LibraryList sub : libs.getSubs()) {
+      menu.addSeparator();
+
+      // Prepend a label
+      JMenuItem label = new JMenuItem(sub.getName());
+      label.setEnabled(false);
+      menu.add(label);
+
+      addLibrariesRecursive(menu, sub);
+    }
+  }
+
+  protected void addLibrariesRecursive(JMenu menu, LibraryList libs) throws IOException {
     // Add any subdirectories first
     for (LibraryList sub : libs.getSubs()) {
       if (sub.isEmpty())
         continue;
 
       JMenu submenu = new JMenu(sub.getName());
-      addLibraries(submenu, sub);
+      addLibrariesRecursive(submenu, sub);
       menu.add(submenu);
       MenuScroller.setScrollerFor(submenu);
     }

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1312,11 +1312,28 @@ public class Base {
       if (libraries != null && !libraries.isEmpty()) {
         if (found)
           menu.addSeparator();
-        for (Library lib : getLibraries())
-          addSketchesSubmenu(menu, lib, false);
+        addLibraryExamples(menu, libraries);
       }
     } catch (IOException e) {
       e.printStackTrace();
+    }
+  }
+
+  protected void addLibraryExamples(JMenu menu, LibraryList libs) throws IOException {
+    // Add any subdirectories first
+    for (LibraryList sub : libs.getSubs()) {
+      if (sub.isEmpty())
+        continue;
+
+      JMenu submenu = new JMenu(sub.getName());
+      addLibraryExamples(submenu, sub);
+      menu.add(submenu);
+      MenuScroller.setScrollerFor(submenu);
+    }
+
+    // Then add the libraries directly in this folder
+    for (Library lib : libs.getLibs()) {
+      addSketchesSubmenu(menu, lib, false);
     }
   }
 
@@ -1803,7 +1820,18 @@ public class Base {
   }
 
   protected void addLibraries(JMenu menu, LibraryList libs) throws IOException {
-    for (Library lib : libs.getAll()) {
+    // Add any subdirectories first
+    for (LibraryList sub : libs.getSubs()) {
+      if (sub.isEmpty())
+        continue;
+
+      JMenu submenu = new JMenu(sub.getName());
+      addLibraries(submenu, sub);
+      menu.add(submenu);
+      MenuScroller.setScrollerFor(submenu);
+    }
+    // Then add the libraries directly in this folder
+    for (Library lib : libs.getLibs()) {
       @SuppressWarnings("serial")
       AbstractAction action = new AbstractAction(lib.getName()) {
         public void actionPerformed(ActionEvent event) {
@@ -1821,8 +1849,6 @@ public class Base {
       JMenuItem item = new JMenuItem(action);
       item.putClientProperty("library", lib);
       menu.add(item);
-
-      // XXX: DAM: should recurse here so that library folders can be nested
     }
   }
 

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1277,20 +1277,6 @@ public class Base {
     }
   }
 
-  public LibraryList getIDELibs() {
-    if (libraries == null)
-      return new LibraryList();
-    LibraryList res = new LibraryList(libraries);
-    res.removeAll(getUserLibs());
-    return res;
-  }
-
-  public LibraryList getUserLibs() {
-    if (libraries == null)
-      return new LibraryList();
-    return libraries.filterLibrariesInSubfolder(getSketchbookFolder());
-  }
-
   public void rebuildImportMenu(JMenu importMenu) {
     importMenu.removeAll();
 
@@ -1304,28 +1290,11 @@ public class Base {
       }
     });
     importMenu.add(addLibraryMenuItem);
-    importMenu.addSeparator();
     
-    // Split between user supplied libraries and IDE libraries
-    TargetPlatform targetPlatform = getTargetPlatform();
-    
-    if (targetPlatform != null) {
-      LibraryList ideLibs = getIDELibs();
-      LibraryList userLibs = getUserLibs();
+    if (libraries != null) {
+      importMenu.addSeparator();
       try {
-        // Find the current target. Get the platform, and then select the
-        // correct name and core path.
-        JMenuItem platformItem = new JMenuItem(_(targetPlatform.getName()));
-        platformItem.setEnabled(false);
-        importMenu.add(platformItem);
-        if (ideLibs.size() > 0) {
-          importMenu.addSeparator();
-          addLibraries(importMenu, ideLibs);
-        }
-        if (userLibs.size() > 0) {
-          importMenu.addSeparator();
-          addLibraries(importMenu, userLibs);
-        }
+        addLibraries(importMenu, libraries);
       } catch (IOException e) {
         e.printStackTrace();
       }
@@ -1338,19 +1307,12 @@ public class Base {
 
       // Add examples from distribution "example" folder
       boolean found = addSketches(menu, examplesFolder, false);
-      if (found) menu.addSeparator();
 
       // Add examples from libraries
-      LibraryList ideLibs = getIDELibs();
-      ideLibs.sort();
-      for (Library lib : ideLibs)
-        addSketchesSubmenu(menu, lib, false);
-
-      LibraryList userLibs = getUserLibs();
-      if (userLibs.size()>0) {
-        menu.addSeparator();
-        userLibs.sort();
-        for (Library lib : userLibs)
+      if (libraries != null && !libraries.isEmpty()) {
+        if (found)
+          menu.addSeparator();
+        for (Library lib : libraries)
           addSketchesSubmenu(menu, lib, false);
       }
     } catch (IOException e) {

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1315,15 +1315,9 @@ public class Base {
       try {
         // Find the current target. Get the platform, and then select the
         // correct name and core path.
-        PreferencesMap prefs = targetPlatform.getPreferences();
-        if (prefs != null) {
-          String platformName = prefs.get("name");
-          if (platformName != null) {
-            JMenuItem platformItem = new JMenuItem(_(platformName));
-            platformItem.setEnabled(false);
-            importMenu.add(platformItem);
-          }
-        }
+        JMenuItem platformItem = new JMenuItem(_(targetPlatform.getName()));
+        platformItem.setEnabled(false);
+        importMenu.add(platformItem);
         if (ideLibs.size() > 0) {
           importMenu.addSeparator();
           addLibraries(importMenu, ideLibs);
@@ -1485,9 +1479,8 @@ public class Base {
         first = false;
 
         // Add a title for each platform
-        String platformLabel = targetPlatform.getPreferences().get("name"); 
-        if (platformLabel != null && !targetPlatform.getBoards().isEmpty()) {
-          JMenuItem menuLabel = new JMenuItem(_(platformLabel));
+        if (!targetPlatform.getBoards().isEmpty()) {
+          JMenuItem menuLabel = new JMenuItem(_(targetPlatform.getName()));
           menuLabel.setEnabled(false);
           boardsMenu.add(menuLabel);
         }

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1412,7 +1412,7 @@ public class Base {
       String referencedCore = core.split(":")[0];
       TargetPlatform referencedPlatform = Base.getTargetPlatform(referencedCore, targetPlatform.getId());
       if (referencedPlatform != null) {
-      File referencedPlatformFolder = referencedPlatform.getFolder();
+        File referencedPlatformFolder = referencedPlatform.getFolder();
         librariesFolders.add(new File(referencedPlatformFolder, "libraries"));
       }
     }

--- a/app/src/processing/app/Sketch.java
+++ b/app/src/processing/app/Sketch.java
@@ -33,7 +33,6 @@ import processing.app.forms.PasswordAuthorizationDialog;
 import processing.app.helpers.PreferencesMap;
 import processing.app.helpers.FileUtils;
 import processing.app.packages.Library;
-import processing.app.packages.LibraryList;
 import processing.app.preproc.*;
 import processing.core.*;
 import static processing.app.I18n._;
@@ -94,7 +93,7 @@ public class Sketch {
   /**
    * List of library folders.
    */
-  private LibraryList importedLibraries;
+  private ArrayList<Library> importedLibraries;
 
   /**
    * File inside the build directory that contains the build options
@@ -1386,7 +1385,7 @@ public class Sketch {
 
     // grab the imports from the code just preproc'd
 
-    importedLibraries = new LibraryList();
+    importedLibraries = new ArrayList<Library>();
     for (String item : preprocessor.getExtraImports()) {
       Library lib = Base.importToLibraryTable.get(item);
       if (lib != null && !importedLibraries.contains(lib)) {
@@ -1419,7 +1418,7 @@ public class Sketch {
   }
 
 
-  public LibraryList getImportedLibraries() {
+  public List<Library> getImportedLibraries() {
     return importedLibraries;
   }
 

--- a/app/src/processing/app/debug/TargetPlatform.java
+++ b/app/src/processing/app/debug/TargetPlatform.java
@@ -141,6 +141,13 @@ public class TargetPlatform {
     return id;
   }
 
+  public String getName() {
+    String name = preferences.get("name");
+    if (name == null)
+      return containerPackage.getId() + ":" + id;
+    return name;
+  }
+
   public File getFolder() {
     return folder;
   }

--- a/app/src/processing/app/packages/Library.java
+++ b/app/src/processing/app/packages/Library.java
@@ -10,6 +10,10 @@ import java.util.List;
 import processing.app.helpers.FileUtils;
 import processing.app.helpers.PreferencesMap;
 import processing.app.helpers.filefilters.OnlyFilesWithExtension;
+import processing.app.Sketch;
+
+import static processing.app.I18n._;
+import processing.app.I18n;
 
 public class Library {
 
@@ -76,6 +80,14 @@ public class Library {
    * @return
    */
   static public Library create(File libFolder) throws IOException {
+    if (!Sketch.isSanitaryName(libFolder.getName())) {
+      String mess = I18n.format(_("The library \"{0}\" cannot be used.\n"
+          + "Library names must contain only basic letters and numbers.\n"
+          + "(ASCII only and no spaces, and it cannot start with a number)"),
+                                libFolder.getName());
+      throw new IOException(mess);
+    }
+
     if (!isProperLibrary(libFolder))
       return createLegacyLibrary(libFolder);
     else

--- a/app/src/processing/app/packages/Library.java
+++ b/app/src/processing/app/packages/Library.java
@@ -37,6 +37,16 @@ public class Library {
       "Uncategorized" });
 
   /**
+   * Check a folder to see if it contains a proper (non-legacy) library.
+   */
+  public static boolean isProperLibrary(File libFolder) throws IOException {
+    // A library is considered "new" if it contains a file called
+    // "library.properties"
+    File check = new File(libFolder, "library.properties");
+    return check.exists() && check.isFile();
+  }
+
+  /**
    * Scans inside a folder and create a Library object out of it. Automatically
    * detects legacy libraries. Automatically fills metadata from
    * library.properties file if found.
@@ -45,10 +55,7 @@ public class Library {
    * @return
    */
   static public Library create(File libFolder) throws IOException {
-    // A library is considered "new" if it contains a file called
-    // "library.properties"
-    File check = new File(libFolder, "library.properties");
-    if (!check.exists() || !check.isFile())
+    if (!isProperLibrary(libFolder))
       return createLegacyLibrary(libFolder);
     else
       return createLibrary(libFolder);

--- a/app/src/processing/app/packages/Library.java
+++ b/app/src/processing/app/packages/Library.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import processing.app.helpers.FileUtils;
 import processing.app.helpers.PreferencesMap;
+import processing.app.helpers.filefilters.OnlyFilesWithExtension;
 
 public class Library {
 
@@ -44,6 +45,26 @@ public class Library {
     // "library.properties"
     File check = new File(libFolder, "library.properties");
     return check.exists() && check.isFile();
+  }
+
+  /**
+   * Check a folder to see if it is a proper library, or looks like a
+   * legacy library (we can never tell for sure, though).
+   */
+  public static boolean isLibrary(File libFolder) throws IOException {
+    if (isProperLibrary(libFolder))
+      return true;
+
+    // If it has a utility folder, then it's probably a legacy library
+    File utilFolder = new File(libFolder, "utility");
+    if (utilFolder.exists() && utilFolder.isDirectory())
+      return true;
+
+    // If it his some .h files, it's probably a legacy library
+    if (libFolder.list(new OnlyFilesWithExtension(".h")).length > 0)
+      return true;
+
+    return false;
   }
 
   /**


### PR DESCRIPTION
These commits make the IDE handle libraries inside subfolders in your sketchbook. e.g., this makes the following layout work:

```
Sketchbook/
    libraries/
        FastLed/
        RF22/
        Displays/
            LiquidCrystal_I2C
            UTFT
            UTouch
```

e.g., allows putting a few display related displayes inside a
subdirectory. This same structure is also shown in the "Import library"
menu. Furthermore, the various library sources (generic IDE libraries,
hardware-specific libraries, user libraries) are now also shown as
submenus. I'm not sure if the actual names for the categories I've used
are the best ones, though.

See below for how that looks (different example than above):

![screenshot from 2014-04-04 17 42 06](https://cloud.githubusercontent.com/assets/194491/2617225/f3ac0c16-bc0f-11e3-8fa2-e5324387ab96.png)
