### PR TITLE
Enable immediate evaluation of a Serial rx

### DIFF
--- a/hardware/arduino/cores/arduino/HardwareSerial.cpp
+++ b/hardware/arduino/cores/arduino/HardwareSerial.cpp
@@ -110,6 +110,7 @@ inline void store_char(unsigned char c, ring_buffer *buffer)
 #else
   void serialEvent() __attribute__((weak));
   void serialEvent() {}
+  void serialEventImmediate() __attribute__((weak));
   #define serialEvent_implemented
 #if defined(USART_RX_vect)
   ISR(USART_RX_vect)
@@ -136,6 +137,7 @@ inline void store_char(unsigned char c, ring_buffer *buffer)
   #else
     #error UDR not defined
   #endif
+    if (serialEventImmediate) serialEventImmediate();
   }
 #endif
 #endif


### PR DESCRIPTION
Added a call to a new Serial rx event function,
"serialEventImmediate()". It allows users the advanced option of
processing an incoming serial character at the time of the interrupt
rather than having to wait for the current loop() to finish.

While the new function should be used with caution as it's called within
an interrupt routine, it enables processing of high priority incoming
data. eg. an abort or e-stop command