### PR TITLE
Fix platform-specific preferences in some cases

### DIFF
--- a/app/src/processing/app/helpers/PreferencesMap.java
+++ b/app/src/processing/app/helpers/PreferencesMap.java
@@ -109,7 +109,7 @@ public class PreferencesMap extends LinkedHashMap<String, String> {
 
         key = processPlatformSuffix(key, ".linux", Base.isLinux());
         key = processPlatformSuffix(key, ".windows", Base.isWindows());
-        key = processPlatformSuffix(key, ".macos", Base.isMacOS());
+        key = processPlatformSuffix(key, ".macosx", Base.isMacOS());
 
         if (key != null)
           put(key, value);


### PR DESCRIPTION
While working with the new platform.local.txt support, I stumbled upon a problem (or at least something unexpected) in the way platform-specific preferences are handled, which is fixed by the first commit. The second commit addresses platform-specific preferences for macosx, which were not working at all AFAICS.
