### PR TITLE
SoftwareSerial improvements, fixes and optimizations

### DIFF
--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -178,6 +178,9 @@ inline void SoftwareSerial::tunedDelay(uint16_t delay) {
 // one and returns true if it replaces another 
 bool SoftwareSerial::listen()
 {
+  if (!_rx_delay_stopbit)
+    return false;
+
   if (active_object != this)
   {
     _buffer_overflow = false;

--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -242,15 +242,13 @@ void SoftwareSerial::recv()
     DebugPulse(_DEBUG_PIN2, 1);
 
     // Read each of the 8 bits
-    for (uint8_t i=0x1; i; i <<= 1)
+    for (uint8_t i=8; i > 0; --i)
     {
       tunedDelay(_rx_delay_intrabit);
+      d >>= 1;
       DebugPulse(_DEBUG_PIN2, 1);
-      uint8_t noti = ~i;
       if (rx_pin_read())
-        d |= i;
-      else // else clause added to ensure function timing is ~balanced
-        d &= noti;
+        d |= 0x80;
     }
 
     // skip the stop bit

--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -259,11 +259,12 @@ void SoftwareSerial::recv()
       d = ~d;
 
     // if buffer full, set the overflow flag and return
-    if ((_receive_buffer_tail + 1) % _SS_MAX_RX_BUFF != _receive_buffer_head) 
+    uint8_t next = (_receive_buffer_tail + 1) % _SS_MAX_RX_BUFF;
+    if (next != _receive_buffer_head)
     {
       // save new data in buffer: tail points to where byte goes
       _receive_buffer[_receive_buffer_tail] = d; // save new byte
-      _receive_buffer_tail = (_receive_buffer_tail + 1) % _SS_MAX_RX_BUFF;
+      _receive_buffer_tail = next;
     } 
     else 
     {

--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -403,8 +403,11 @@ void SoftwareSerial::begin(long speed)
   // Set up RX interrupts, but only if we have a valid RX baud rate
   if (_rx_delay_stopbit)
   {
+    // Enable the PCINT for the entire port here, but never disable it
+    // (others might also need it, so we disable the interrupt by using
+    // the per-pin PCMSK register).
     *digitalPinToPCICR(_receivePin) |= _BV(digitalPinToPCICRbit(_receivePin));
-    *digitalPinToPCMSK(_receivePin) |= _BV(digitalPinToPCMSKbit(_receivePin));
+    setRxIntMsk(true);
     tunedDelay(_tx_delay); // if we were low this establishes the end
   }
 
@@ -416,10 +419,18 @@ void SoftwareSerial::begin(long speed)
   listen();
 }
 
+void SoftwareSerial::setRxIntMsk(bool enable)
+{
+    if (enable)
+      *digitalPinToPCMSK(_receivePin) |= _BV(digitalPinToPCMSKbit(_receivePin));
+    else
+      *digitalPinToPCMSK(_receivePin) &= ~_BV(digitalPinToPCMSKbit(_receivePin));
+}
+
 void SoftwareSerial::end()
 {
   if (_rx_delay_stopbit)
-    *digitalPinToPCMSK(_receivePin) &= ~_BV(digitalPinToPCMSKbit(_receivePin));
+    setRxIntMsk(false);
 }
 
 

--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -418,7 +418,7 @@ void SoftwareSerial::begin(long speed)
 
 void SoftwareSerial::end()
 {
-  if (digitalPinToPCMSK(_receivePin))
+  if (_rx_delay_stopbit)
     *digitalPinToPCMSK(_receivePin) &= ~_BV(digitalPinToPCMSKbit(_receivePin));
 }
 

--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -237,6 +237,11 @@ void SoftwareSerial::recv()
   // so interrupt is probably not for us
   if (_inverse_logic ? rx_pin_read() : !rx_pin_read())
   {
+    // Disable further interrupts during reception, this prevents
+    // triggering another interrupt directly after we return, which can
+    // cause problems at higher baudrates.
+    setRxIntMsk(false);
+
     // Wait approximately 1/2 of a bit width to "center" the sample
     tunedDelay(_rx_delay_centering);
     DebugPulse(_DEBUG_PIN2, 1);
@@ -255,6 +260,8 @@ void SoftwareSerial::recv()
     tunedDelay(_rx_delay_stopbit);
     DebugPulse(_DEBUG_PIN2, 1);
 
+    // Re-enable interrupts when we're sure to be inside the stop bit
+    setRxIntMsk(true);
     if (_inverse_logic)
       d = ~d;
 

--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -195,6 +195,17 @@ bool SoftwareSerial::listen()
   return false;
 }
 
+// Stop listening. Returns true if we were actually listening.
+bool SoftwareSerial::stopListening()
+{
+  if (active_object == this)
+  {
+    active_object = NULL;
+    return true;
+  }
+  return false;
+}
+
 //
 // The receive routine called by the interrupt handler
 //

--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -486,33 +486,20 @@ size_t SoftwareSerial::write(uint8_t b)
 
   // Write each of the 8 bits
   if (_inverse_logic)
-  {
-    for (byte mask = 0x01; mask; mask <<= 1)
-    {
-      if (b & mask) // choose bit
-        tx_pin_write(LOW); // send 1
-      else
-        tx_pin_write(HIGH); // send 0
-    
-      tunedDelay(_tx_delay);
-    }
+    b = ~b;
 
-    tx_pin_write(LOW); // restore pin to natural state
-  }
-  else
+  for (byte mask = 0x01; mask; mask <<= 1)
   {
-    for (byte mask = 0x01; mask; mask <<= 1)
-    {
-      if (b & mask) // choose bit
-        tx_pin_write(HIGH); // send 1
-      else
-        tx_pin_write(LOW); // send 0
-    
-      tunedDelay(_tx_delay);
-    }
+    if (b & mask) // choose bit
+      tx_pin_write(HIGH); // send 1
+    else
+      tx_pin_write(LOW); // send 0
 
-    tx_pin_write(HIGH); // restore pin to natural state
+    tunedDelay(_tx_delay);
   }
+
+  // restore pin to natural state
+  tx_pin_write(_inverse_logic ? LOW : HIGH);
 
   SREG = oldSREG; // turn interrupts back on
   tunedDelay(_tx_delay);

--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -385,9 +385,13 @@ void SoftwareSerial::begin(long speed)
     long baud = pgm_read_dword(&table[i].baud);
     if (baud == speed)
     {
-      _rx_delay_centering = pgm_read_word(&table[i].rx_delay_centering);
-      _rx_delay_intrabit = pgm_read_word(&table[i].rx_delay_intrabit);
-      _rx_delay_stopbit = pgm_read_word(&table[i].rx_delay_stopbit);
+      if (digitalPinToPCICR(_receivePin))
+      {
+        // Only setup rx when we have a valid PCINT for this pin
+        _rx_delay_centering = pgm_read_word(&table[i].rx_delay_centering);
+        _rx_delay_intrabit = pgm_read_word(&table[i].rx_delay_intrabit);
+        _rx_delay_stopbit = pgm_read_word(&table[i].rx_delay_stopbit);
+      }
       _tx_delay = pgm_read_word(&table[i].tx_delay);
       break;
     }
@@ -396,11 +400,8 @@ void SoftwareSerial::begin(long speed)
   // Set up RX interrupts, but only if we have a valid RX baud rate
   if (_rx_delay_stopbit)
   {
-    if (digitalPinToPCICR(_receivePin))
-    {
-      *digitalPinToPCICR(_receivePin) |= _BV(digitalPinToPCICRbit(_receivePin));
-      *digitalPinToPCMSK(_receivePin) |= _BV(digitalPinToPCMSKbit(_receivePin));
-    }
+    *digitalPinToPCICR(_receivePin) |= _BV(digitalPinToPCICRbit(_receivePin));
+    *digitalPinToPCMSK(_receivePin) |= _BV(digitalPinToPCMSKbit(_receivePin));
     tunedDelay(_tx_delay); // if we were low this establishes the end
   }
 

--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -442,8 +442,7 @@ void SoftwareSerial::setRxIntMsk(bool enable)
 
 void SoftwareSerial::end()
 {
-  if (_rx_delay_stopbit)
-    setRxIntMsk(false);
+  stopListening();
 }
 
 

--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -175,9 +175,7 @@ void SoftwareSerial::recv()
     } 
     else 
     {
-#if _DEBUG // for scope: pulse pin as overflow indictator
       DebugPulse(_DEBUG_PIN1, 1);
-#endif
       _buffer_overflow = true;
     }
 

--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -183,12 +183,14 @@ bool SoftwareSerial::listen()
 
   if (active_object != this)
   {
+    if (active_object)
+      active_object->stopListening();
+
     _buffer_overflow = false;
-    uint8_t oldSREG = SREG;
-    cli();
     _receive_buffer_head = _receive_buffer_tail = 0;
     active_object = this;
-    SREG = oldSREG;
+
+    setRxIntMsk(true);
     return true;
   }
 
@@ -200,6 +202,7 @@ bool SoftwareSerial::stopListening()
 {
   if (active_object == this)
   {
+    setRxIntMsk(false);
     active_object = NULL;
     return true;
   }
@@ -418,7 +421,6 @@ void SoftwareSerial::begin(long speed)
     // (others might also need it, so we disable the interrupt by using
     // the per-pin PCMSK register).
     *digitalPinToPCICR(_receivePin) |= _BV(digitalPinToPCICRbit(_receivePin));
-    setRxIntMsk(true);
     tunedDelay(_tx_delay); // if we were low this establishes the end
   }
 

--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -266,8 +266,12 @@ SoftwareSerial::~SoftwareSerial()
 
 void SoftwareSerial::setTX(uint8_t tx)
 {
-  pinMode(tx, OUTPUT);
+  // First write, then set output. If we do this the other way around,
+  // the pin would be output low for a short while before switching to
+  // output hihg. Now, it is input with pullup for a short while, which
+  // is fine. With inverse logic, either order is fine.
   digitalWrite(tx, _inverse_logic ? LOW : HIGH);
+  pinMode(tx, OUTPUT);
   _transmitBitMask = digitalPinToBitMask(tx);
   uint8_t port = digitalPinToPort(tx);
   _transmitPortRegister = portOutputRegister(port);

--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -403,6 +403,11 @@ void SoftwareSerial::begin(long speed)
     // (others might also need it, so we disable the interrupt by using
     // the per-pin PCMSK register).
     *digitalPinToPCICR(_receivePin) |= _BV(digitalPinToPCICRbit(_receivePin));
+    // Precalculate the pcint mask register and value, so setRxIntMask
+    // can be used inside the ISR without costing too much time.
+    _pcint_maskreg = digitalPinToPCMSK(_receivePin);
+    _pcint_maskvalue = _BV(digitalPinToPCMSKbit(_receivePin));
+
     tunedDelay(_tx_delay); // if we were low this establishes the end
   }
 
@@ -417,9 +422,9 @@ void SoftwareSerial::begin(long speed)
 void SoftwareSerial::setRxIntMsk(bool enable)
 {
     if (enable)
-      *digitalPinToPCMSK(_receivePin) |= _BV(digitalPinToPCMSKbit(_receivePin));
+      *_pcint_maskreg |= _pcint_maskvalue;
     else
-      *digitalPinToPCMSK(_receivePin) &= ~_BV(digitalPinToPCMSKbit(_receivePin));
+      *_pcint_maskreg &= ~_pcint_maskvalue;
 }
 
 void SoftwareSerial::end()

--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -316,24 +316,15 @@ ISR(PCINT0_vect)
 #endif
 
 #if defined(PCINT1_vect)
-ISR(PCINT1_vect)
-{
-  SoftwareSerial::handle_interrupt();
-}
+ISR(PCINT1_vect, ISR_ALIASOF(PCINT0_vect));
 #endif
 
 #if defined(PCINT2_vect)
-ISR(PCINT2_vect)
-{
-  SoftwareSerial::handle_interrupt();
-}
+ISR(PCINT2_vect, ISR_ALIASOF(PCINT0_vect));
 #endif
 
 #if defined(PCINT3_vect)
-ISR(PCINT3_vect)
-{
-  SoftwareSerial::handle_interrupt();
-}
+ISR(PCINT3_vect, ISR_ALIASOF(PCINT0_vect));
 #endif
 
 //

--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -42,92 +42,7 @@ http://arduiniana.org.
 #include <avr/pgmspace.h>
 #include <Arduino.h>
 #include <SoftwareSerial.h>
-//
-// Lookup table
-//
-typedef struct _DELAY_TABLE
-{
-  long baud;
-  unsigned short rx_delay_centering;
-  unsigned short rx_delay_intrabit;
-  unsigned short rx_delay_stopbit;
-  unsigned short tx_delay;
-} DELAY_TABLE;
-
-#if F_CPU == 16000000
-
-static const DELAY_TABLE PROGMEM table[] = 
-{
-  //  baud    rxcenter   rxintra    rxstop    tx
-  { 115200,   1,         17,        17,       12,    },
-  { 57600,    10,        37,        37,       33,    },
-  { 38400,    25,        57,        57,       54,    },
-  { 31250,    31,        70,        70,       68,    },
-  { 28800,    34,        77,        77,       74,    },
-  { 19200,    54,        117,       117,      114,   },
-  { 14400,    74,        156,       156,      153,   },
-  { 9600,     114,       236,       236,      233,   },
-  { 4800,     233,       474,       474,      471,   },
-  { 2400,     471,       950,       950,      947,   },
-  { 1200,     947,       1902,      1902,     1899,  },
-  { 600,      1902,      3804,      3804,     3800,  },
-  { 300,      3804,      7617,      7617,     7614,  },
-};
-
-const int XMIT_START_ADJUSTMENT = 5;
-
-#elif F_CPU == 8000000
-
-static const DELAY_TABLE table[] PROGMEM = 
-{
-  //  baud    rxcenter    rxintra    rxstop  tx
-  { 115200,   1,          5,         5,      3,      },
-  { 57600,    1,          15,        15,     13,     },
-  { 38400,    2,          25,        26,     23,     },
-  { 31250,    7,          32,        33,     29,     },
-  { 28800,    11,         35,        35,     32,     },
-  { 19200,    20,         55,        55,     52,     },
-  { 14400,    30,         75,        75,     72,     },
-  { 9600,     50,         114,       114,    112,    },
-  { 4800,     110,        233,       233,    230,    },
-  { 2400,     229,        472,       472,    469,    },
-  { 1200,     467,        948,       948,    945,    },
-  { 600,      948,        1895,      1895,   1890,   },
-  { 300,      1895,       3805,      3805,   3802,   },
-};
-
-const int XMIT_START_ADJUSTMENT = 4;
-
-#elif F_CPU == 20000000
-
-// 20MHz support courtesy of the good people at macegr.com.
-// Thanks, Garrett!
-
-static const DELAY_TABLE PROGMEM table[] =
-{
-  //  baud    rxcenter    rxintra    rxstop  tx
-  { 115200,   3,          21,        21,     18,     },
-  { 57600,    20,         43,        43,     41,     },
-  { 38400,    37,         73,        73,     70,     },
-  { 31250,    45,         89,        89,     88,     },
-  { 28800,    46,         98,        98,     95,     },
-  { 19200,    71,         148,       148,    145,    },
-  { 14400,    96,         197,       197,    194,    },
-  { 9600,     146,        297,       297,    294,    },
-  { 4800,     296,        595,       595,    592,    },
-  { 2400,     592,        1189,      1189,   1186,   },
-  { 1200,     1187,       2379,      2379,   2376,   },
-  { 600,      2379,       4759,      4759,   4755,   },
-  { 300,      4759,       9523,      9523,   9520,   },
-};
-
-const int XMIT_START_ADJUSTMENT = 6;
-
-#else
-
-#error This version of SoftwareSerial supports only 20, 16 and 8MHz processors
-
-#endif
+#include <util/delay_basic.h>
 
 //
 // Statics
@@ -162,16 +77,7 @@ inline void DebugPulse(uint8_t pin, uint8_t count)
 
 /* static */ 
 inline void SoftwareSerial::tunedDelay(uint16_t delay) { 
-  uint8_t tmp=0;
-
-  asm volatile("sbiw    %0, 0x01 \n\t"
-    "ldi %1, 0xFF \n\t"
-    "cpi %A0, 0xFF \n\t"
-    "cpc %B0, %1 \n\t"
-    "brne .-10 \n\t"
-    : "+r" (delay), "+a" (tmp)
-    : "0" (delay)
-    );
+  _delay_loop_2(delay);
 }
 
 // This function sets the current object as the "listening"
@@ -256,12 +162,6 @@ void SoftwareSerial::recv()
         d |= 0x80;
     }
 
-    // skip the stop bit
-    tunedDelay(_rx_delay_stopbit);
-    DebugPulse(_DEBUG_PIN2, 1);
-
-    // Re-enable interrupts when we're sure to be inside the stop bit
-    setRxIntMsk(true);
     if (_inverse_logic)
       d = ~d;
 
@@ -280,6 +180,14 @@ void SoftwareSerial::recv()
 #endif
       _buffer_overflow = true;
     }
+
+    // skip the stop bit
+    tunedDelay(_rx_delay_stopbit);
+    DebugPulse(_DEBUG_PIN1, 1);
+
+    // Re-enable interrupts when we're sure to be inside the stop bit
+    setRxIntMsk(true);
+
   }
 
 #if GCC_VERSION < 40302
@@ -378,6 +286,13 @@ void SoftwareSerial::setRX(uint8_t rx)
   _receivePortRegister = portInputRegister(port);
 }
 
+uint16_t SoftwareSerial::subtract_cap(uint16_t num, uint16_t sub) {
+  if (num > sub)
+    return num - sub;
+  else
+    return 1;
+}
+
 //
 // Public methods
 //
@@ -386,26 +301,55 @@ void SoftwareSerial::begin(long speed)
 {
   _rx_delay_centering = _rx_delay_intrabit = _rx_delay_stopbit = _tx_delay = 0;
 
-  for (unsigned i=0; i<sizeof(table)/sizeof(table[0]); ++i)
-  {
-    long baud = pgm_read_dword(&table[i].baud);
-    if (baud == speed)
-    {
-      if (digitalPinToPCICR(_receivePin))
-      {
-        // Only setup rx when we have a valid PCINT for this pin
-        _rx_delay_centering = pgm_read_word(&table[i].rx_delay_centering);
-        _rx_delay_intrabit = pgm_read_word(&table[i].rx_delay_intrabit);
-        _rx_delay_stopbit = pgm_read_word(&table[i].rx_delay_stopbit);
-      }
-      _tx_delay = pgm_read_word(&table[i].tx_delay);
-      break;
-    }
-  }
+  // Precalculate the various delays, in number of 4-cycle delays
+  uint16_t bit_delay = (F_CPU / speed) / 4;
 
-  // Set up RX interrupts, but only if we have a valid RX baud rate
-  if (_rx_delay_stopbit)
-  {
+  // 12 (gcc 4.8.2) or 13 (gcc 4.3.2) cycles from start bit to first bit,
+  // 15 (gcc 4.8.2) or 16 (gcc 4.3.2) cycles between bits,
+  // 12 (gcc 4.8.2) or 14 (gcc 4.3.2) cycles from last bit to stop bit
+  // These are all close enough to just use 15 cycles, since the inter-bit
+  // timings are the most critical (deviations stack 8 times)
+  _tx_delay = subtract_cap(bit_delay, 15 / 4);
+
+  // Only setup rx when we have a valid PCINT for this pin
+  if (digitalPinToPCICR(_receivePin)) {
+    #if GCC_VERSION > 40800
+    // Timings counted from gcc 4.8.2 output. This works up to 115200 on
+    // 16Mhz and 57600 on 8Mhz.
+    //
+    // When the start bit occurs, there are 3 or 4 cycles before the
+    // interrupt flag is set, 4 cycles before the PC is set to the right
+    // interrupt vector address and the old PC is pushed on the stack,
+    // and then 75 cycles of instructions (including the RJMP in the
+    // ISR vector table) until the first delay. After the delay, there
+    // are 17 more cycles until the pin value is read (excluding the
+    // delay in the loop).
+    // We want to have a total delay of 1.5 bit time. Inside the loop,
+    // we already wait for 1 bit time - 23 cycles, so here we wait for
+    // 0.5 bit time - (71 + 18 - 22) cycles.
+    _rx_delay_centering = subtract_cap(bit_delay / 2, (4 + 4 + 75 + 17 - 23) / 4);
+
+    // There are 23 cycles in each loop iteration (excluding the delay)
+    _rx_delay_intrabit = subtract_cap(bit_delay, 23 / 4);
+
+    // There are 37 cycles from the last bit read to the start of
+    // stopbit delay and 11 cycles from the delay until the interrupt
+    // mask is enabled again (which _must_ happen during the stopbit).
+    // This delay aims at 3/4 of a bit time, meaning the end of the
+    // delay will be at 1/4th of the stopbit. This allows some extra
+    // time for ISR cleanup, which makes 115200 baud at 16Mhz work more
+    // reliably
+    _rx_delay_stopbit = subtract_cap(bit_delay * 3 / 4, (37 + 11) / 4);
+    #else // Timings counted from gcc 4.3.2 output
+    // Note that this code is a _lot_ slower, mostly due to bad register
+    // allocation choices of gcc. This works up to 57600 on 16Mhz and
+    // 38400 on 8Mhz.
+    _rx_delay_centering = subtract_cap(bit_delay / 2, (4 + 4 + 97 + 29 - 11) / 4);
+    _rx_delay_intrabit = subtract_cap(bit_delay, 11 / 4);
+    _rx_delay_stopbit = subtract_cap(bit_delay * 3 / 4, (44 + 17) / 4);
+    #endif
+
+
     // Enable the PCINT for the entire port here, but never disable it
     // (others might also need it, so we disable the interrupt by using
     // the per-pin PCMSK register).

--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.h
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.h
@@ -71,7 +71,7 @@ private:
   // private methods
   void recv();
   uint8_t rx_pin_read();
-  void tx_pin_write(uint8_t pin_state);
+  void tx_pin_write(uint8_t pin_state) __attribute__((__always_inline__));
   void setTX(uint8_t transmitPin);
   void setRX(uint8_t receivePin);
   void setRxIntMsk(bool enable);

--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.h
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.h
@@ -53,6 +53,8 @@ private:
   volatile uint8_t *_receivePortRegister;
   uint8_t _transmitBitMask;
   volatile uint8_t *_transmitPortRegister;
+  volatile uint8_t *_pcint_maskreg;
+  uint8_t _pcint_maskvalue;
 
   uint16_t _rx_delay_centering;
   uint16_t _rx_delay_intrabit;

--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.h
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.h
@@ -74,6 +74,7 @@ private:
   void tx_pin_write(uint8_t pin_state);
   void setTX(uint8_t transmitPin);
   void setRX(uint8_t receivePin);
+  void setRxIntMsk(bool enable);
 
   // private static method for timing
   static inline void tunedDelay(uint16_t delay);

--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.h
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.h
@@ -88,7 +88,7 @@ public:
   void end();
   bool isListening() { return this == active_object; }
   bool stopListening();
-  bool overflow() { bool ret = _buffer_overflow; _buffer_overflow = false; return ret; }
+  bool overflow() { bool ret = _buffer_overflow; if (ret) _buffer_overflow = false; return ret; }
   int peek();
 
   virtual size_t write(uint8_t byte);

--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.h
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.h
@@ -69,7 +69,7 @@ private:
   static SoftwareSerial *active_object;
 
   // private methods
-  void recv();
+  void recv() __attribute__((__always_inline__));
   uint8_t rx_pin_read();
   void tx_pin_write(uint8_t pin_state) __attribute__((__always_inline__));
   void setTX(uint8_t transmitPin);
@@ -99,7 +99,7 @@ public:
   using Print::write;
 
   // public only for easy access by interrupt handlers
-  static inline void handle_interrupt();
+  static inline void handle_interrupt() __attribute__((__always_inline__));
 };
 
 // Arduino 0012 workaround

--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.h
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.h
@@ -87,6 +87,7 @@ public:
   bool listen();
   void end();
   bool isListening() { return this == active_object; }
+  bool stopListening();
   bool overflow() { bool ret = _buffer_overflow; _buffer_overflow = false; return ret; }
   int peek();
 

--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.h
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.h
@@ -76,7 +76,7 @@ private:
   void tx_pin_write(uint8_t pin_state) __attribute__((__always_inline__));
   void setTX(uint8_t transmitPin);
   void setRX(uint8_t receivePin);
-  void setRxIntMsk(bool enable);
+  void setRxIntMsk(bool enable) __attribute__((__always_inline__));
 
   // private static method for timing
   static inline void tunedDelay(uint16_t delay);

--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.h
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.h
@@ -56,6 +56,7 @@ private:
   volatile uint8_t *_pcint_maskreg;
   uint8_t _pcint_maskvalue;
 
+  // Expressed as 4-cycle delays (must never be 0!)
   uint16_t _rx_delay_centering;
   uint16_t _rx_delay_intrabit;
   uint16_t _rx_delay_stopbit;
@@ -77,6 +78,9 @@ private:
   void setTX(uint8_t transmitPin);
   void setRX(uint8_t receivePin);
   void setRxIntMsk(bool enable) __attribute__((__always_inline__));
+
+  // Return num - sub, or 1 if the result would be < 1
+  static uint16_t subtract_cap(uint16_t num, uint16_t sub);
 
   // private static method for timing
   static inline void tunedDelay(uint16_t delay);


### PR DESCRIPTION
This pullrequest contains a bit of everything, for the SoftwareSerial library. The first couple of commits I still had lying around from last year, forgot to send a pullrequest for those earlier. They're mostly cleanups around the introduction of a `stopListening()` method, that can be made to disable RX of a SoftwareSerial instance.

The second half of the commits are a lot of optimizations and fixes, to make the SoftwareSerial code faster and more reliable, so it works again at higher baudrates. This is only partly succesful for RX, since at higher baudrates where bytes are sent back-to-back, the CPU spends most of the time in the interrupt handler. At higher baudrates, the interrupt overhead (cleanup and setup) becomes longer than than the available time (from halfway the stopbit to halfway the startbit) and reception starts to fail.

This problem is particularly evident when running at 8Mhz, or when using gcc 4.3.2 (which makes terrible register allocation choices). Using gcc 4.8.2 and running at 16Mhz, things work up to 115200 (though bytes are still regularly corrupted because of the millis() timer ISR delaying the SoftwareSerial interrupt). Using 1.5 or 2 stop bits on the other side will probably help here (though I haven't tested this, and there is no way to make SoftwareSerial do TX with longer stop bits.

There is probably some room for improvment still, but that would require the RX ISR / `recv` method to be handcoded in assembly. The upside of that would be that it's 100% deterministic, without depending on the compiler used, but it's a lot of work that I'm not going to invest right now (getting this far has cost me enough time already).

These commits also remove the delay lookup tables that were previously present, since the values can easily be calculated at runtime. This saves around 160 bytes of program memory.

In addition to making the code faster, it is also a lot smaller. Overall, a typical SoftwareSerial sketch on the Uno saves slightly over 400 bytes of program space (including the savings for the lookup table removal).