### PR TITLE
Fix EXTERNAL_NUM_INTERRUPTS for atmega128rfa1 and atmega256rfr2

### DIFF
--- a/hardware/arduino/avr/cores/arduino/wiring_private.h
+++ b/hardware/arduino/avr/cores/arduino/wiring_private.h
@@ -52,7 +52,7 @@ extern "C"{
 #define EXTERNAL_INT_6 6
 #define EXTERNAL_INT_7 7
 
-#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega128RFA1__) || defined(__AVR_ATmega256RFR2__)
 #define EXTERNAL_NUM_INTERRUPTS 8
 #elif defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega644__) || defined(__AVR_ATmega644A__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644PA__)
 #define EXTERNAL_NUM_INTERRUPTS 3


### PR DESCRIPTION
This makes all 8 interrupts on these chips work. This change was originally submitted by @penguin359 in (the now outdated) #1399.

@cmaglie, I'd be grateful if you could quickly merge this trivial fix, since it currently blocks our users from using all interrupts with our Pinoccio board.
