### PR TITLE
Fix HttpClient::ready() return value

### DIFF
--- a/libraries/Bridge/src/HttpClient.cpp
+++ b/libraries/Bridge/src/HttpClient.cpp
@@ -43,7 +43,7 @@ void HttpClient::getAsynchronously(const char *url) {
 }
 
 boolean HttpClient::ready() {
-  return running();
+  return !running();
 }
 
 unsigned int HttpClient::getResult() {


### PR DESCRIPTION
According to the docs (http://arduino.cc/en/Reference/YunHttpClientReady) the return value of HttpClient::ready() should be the inverse of Process::running() instead of the same (to return true if the process is not running and vice versa).
