### PR TITLE
Unescape special characters in dependency files

### DIFF
--- a/app/src/processing/app/debug/Compiler.java
+++ b/app/src/processing/app/debug/Compiler.java
@@ -297,6 +297,9 @@ public class Compiler implements MessageConsumer {
           line = line.substring(0, line.length() - 1);
         }
         line = line.trim();
+        // Strip backslash escape sequences. This replaces \\ with \ and
+        // removes all other backslashes
+        line = line.replaceAll("\\\\(.)", "$1");
         if (line.length() == 0) continue; // ignore blank lines
         if (need_obj_parse) {
           // line is supposed to be the object file - make sure it really is!


### PR DESCRIPTION
When a path contains spaces (or other special characters, probably), gcc
escapes them with a \ in the generated .d files. This previously caused
problems when parsing these files, causing recompiles to happen even
when not needed.

This applies a rather simple approach to unescaping these strings, which
seems to be sufficient because the file format of the .d files is so
predictable (e.g., we don't actuall split on colons or spaces when
parsing it).
