### PR TITLE
Allows HttpClient to call https urls

### DIFF
--- a/libraries/Bridge/src/HttpClient.cpp
+++ b/libraries/Bridge/src/HttpClient.cpp
@@ -18,30 +18,43 @@
 
 #include "HttpClient.h"
 
+HttpClient::HttpClient() :
+  insecure(false) {
+  // Empty
+}
+
 unsigned int HttpClient::get(String &url) {
   begin("curl");
-  addParameter("-k");
+  if (insecure) {
+    addParameter("-k");
+  }
   addParameter(url);
   return run();
 }
 
 unsigned int HttpClient::get(const char *url) {
   begin("curl");
-  addParameter("-k");
+  if (insecure) {
+    addParameter("-k");
+  }
   addParameter(url);
   return run();
 }
 
 void HttpClient::getAsynchronously(String &url) {
   begin("curl");
-  addParameter("-k");
+  if (insecure) {
+    addParameter("-k");
+  }
   addParameter(url);
   runAsynchronously();
 }
 
 void HttpClient::getAsynchronously(const char *url) {
   begin("curl");
-  addParameter("-k");
+  if (insecure) {
+    addParameter("-k");
+  }
   addParameter(url);
   runAsynchronously();
 }
@@ -54,4 +67,11 @@ unsigned int HttpClient::getResult() {
   return exitValue();
 }
 
+void HttpClient::noCheckSSL() {
+  insecure = true;
+}
+
+void HttpClient::checkSSL() {
+  insecure = false;
+}
 

--- a/libraries/Bridge/src/HttpClient.h
+++ b/libraries/Bridge/src/HttpClient.h
@@ -23,6 +23,7 @@
 
 class HttpClient : public Process {
   public:
+    HttpClient();
 
     unsigned int get(String &url);
     unsigned int get(const char * url);
@@ -30,6 +31,11 @@ class HttpClient : public Process {
     void getAsynchronously(const char * url);
     boolean ready();
     unsigned int getResult();
+    void noCheckSSL();
+    void checkSSL();
+
+  private:
+    boolean insecure;
 
 };
 


### PR DESCRIPTION
Adds parameter "-k" to every way of calling curl, hence allowing
calling https URLs without checking for the validity of SSL
certificates.
While this makes it a little insecure, nothing else can be done
while keeping the HTTPClient API simple: openwrt does not have a
SSL certificates bundle
Advanced users concerned about security should call "curl" on
their own using Process, supplying parameters such as "--cacert"
Fixes #1860
@cmaglie 
