### PR TITLE
paths were wrong, tested in mac, not on windows

### DIFF
--- a/hardware/arduino/firmwares/wifishield/scripts/ArduinoWifiShield_upgrade.sh
+++ b/hardware/arduino/firmwares/wifishield/scripts/ArduinoWifiShield_upgrade.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-WIFI_FW_PATH="/hardware/arduino/firmwares/wifishield/binary"
-AVR_TOOLS_PATH="/hardware/tools/avr/bin"
+WIFI_FW_PATH="hardware/arduino/firmwares/wifishield/binary/"
+AVR_TOOLS_PATH="hardware/tools/avr/bin"
 
 TARGET_MICRO="at32uc3a1256"
 

--- a/hardware/arduino/firmwares/wifishield/scripts/ArduinoWifiShield_upgrade_mac.sh
+++ b/hardware/arduino/firmwares/wifishield/scripts/ArduinoWifiShield_upgrade_mac.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-WIFI_FW_PATH="/hardware/arduino/firmwares/wifi-shield"
-AVR_TOOLS_PATH="/hardware/tools/avr/bin"
+WIFI_FW_PATH="hardware/arduino/firmwares/wifishield/binary/"
+AVR_TOOLS_PATH="hardware/tools/avr/bin"
 
 progname=$0
 


### PR DESCRIPTION
The firmware upgrade script has bad paths

```

       Arduino WiFi Shield upgrade
=========================================
Disclaimer: to access to the USB devices correctly, the dfu-programmer needs to be used as root. Run this script as root.

./avr-objcopy: '/Applications/Arduino.app/Contents/Resources/Java//hardware/arduino/firmwares/wifi-shield/wifi_dnld.elf': No such file
./avr-objcopy: '/Applications/Arduino.app/Contents/Resources/Java//hardware/arduino/firmwares/wifi-shield/wifiHD.elf': No such file
****Upgrade WiFi Shield firmware****

Error opening the file.
Something went wrong with creating the memory image.

Done. Remove the J3 jumper and press the RESET button on the shield.
Thank you!

```
