### PR TITLE
Update USBAPI.h

### DIFF
--- a/hardware/arduino/cores/arduino/USBAPI.h
+++ b/hardware/arduino/cores/arduino/USBAPI.h
@@ -28,7 +28,7 @@ extern USBDevice_ USBDevice;
 class Serial_ : public Stream
 {
 private:
-	int peek_buffer;
+	int peek_buffer = -1;
 public:
 	void begin(unsigned long);
 	void begin(unsigned long, uint8_t);


### PR DESCRIPTION
Fixes bug where Serial.read() would always return 0 as the first byte.
