### PR TITLE
Support Atmega8 (and similar that define PE instead of UPE) again

### DIFF
--- a/hardware/arduino/avr/cores/arduino/HardwareSerial_private.h
+++ b/hardware/arduino/avr/cores/arduino/HardwareSerial_private.h
@@ -34,6 +34,11 @@
 // slower.
 #if !defined(TXC0)
 #if defined(TXC)
+// Some chips like ATmega8 don't have UPE, only PE. The other bits are
+// named as expected.
+#if !defined(UPE) && defined(PE)
+#define UPE PE
+#endif
 // On ATmega8, the uart and its bits are not numbered, so there is no TXC0 etc.
 #define TXC0 TXC
 #define RXEN0 RXEN


### PR DESCRIPTION
These chips were previously supported, but since parity error checking
was added, this support has broken. Most chips define UPE0 (etc.) for
the parity error bit. Some chips don't have numbered UARTS so only
define UPE and even fewer define PE instead of UPE. This adds support
for those chips again.

Closes: #2137
