### PR TITLE
Arduino Pro and Pro Mini should use eightanaloginputs variant

### DIFF
--- a/hardware/arduino/avr/boards.txt
+++ b/hardware/arduino/avr/boards.txt
@@ -564,7 +564,7 @@ pro.bootloader.lock_bits=0x0F
 
 pro.build.board=AVR_PRO
 pro.build.core=arduino
-pro.build.variant=standard
+pro.build.variant=eightanaloginputs
 
 ## Arduino Pro or Pro Mini (5V, 16 MHz) w/ ATmega328
 ## -------------------------------------------------


### PR DESCRIPTION
This allows the user to use all 8 analog pins available on the TQFP and QFN/MLF packages.
