### PR TITLE
GSM: Updated PROGMEM compatibility with newer gcc

### DIFF
--- a/libraries/GSM/src/GSM3ShieldV1AccessProvider.cpp
+++ b/libraries/GSM/src/GSM3ShieldV1AccessProvider.cpp
@@ -6,8 +6,8 @@
 #define __TOUTMODEMCONFIGURATION__ 5000//equivalent to 30000 because of time in interrupt routine.
 #define __TOUTAT__ 1000
 
-char _command_AT[] PROGMEM = "AT";
-char _command_CGREG[] PROGMEM = "AT+CGREG?";
+const char _command_AT[] PROGMEM = "AT";
+const char _command_CGREG[] PROGMEM = "AT+CGREG?";
 
 
 GSM3ShieldV1AccessProvider::GSM3ShieldV1AccessProvider(bool debug)

--- a/libraries/GSM/src/GSM3ShieldV1BaseProvider.cpp
+++ b/libraries/GSM/src/GSM3ShieldV1BaseProvider.cpp
@@ -12,7 +12,7 @@ int GSM3ShieldV1BaseProvider::ready()
 	return theGSM3ShieldV1ModemCore.getCommandError();
 };
 
-void GSM3ShieldV1BaseProvider::prepareAuxLocate(PROGMEM prog_char str[], char auxLocate[])
+void GSM3ShieldV1BaseProvider::prepareAuxLocate(PGM_P str, char auxLocate[])
 {
 	int i=0;
 	char c;

--- a/libraries/GSM/src/GSM3ShieldV1BaseProvider.h
+++ b/libraries/GSM/src/GSM3ShieldV1BaseProvider.h
@@ -54,7 +54,7 @@ class GSM3ShieldV1BaseProvider
 		@param str			PROGMEN
 		@param auxLocate	Buffer where to locate strings
 	*/
-	void prepareAuxLocate(PROGMEM prog_char str[], char auxLocate[]);
+	void prepareAuxLocate(PGM_P str, char auxLocate[]);
 
 	/** Manages modem response
 		@param from 		Initial byte of buffer

--- a/libraries/GSM/src/GSM3ShieldV1DataNetworkProvider.cpp
+++ b/libraries/GSM/src/GSM3ShieldV1DataNetworkProvider.cpp
@@ -1,8 +1,8 @@
 #include <GSM3ShieldV1DataNetworkProvider.h>
 #include <Arduino.h>
 
-char _command_CGATT[] PROGMEM = "AT+CGATT=";
-char _command_SEPARATOR[] PROGMEM = "\",\"";
+const char _command_CGATT[] PROGMEM = "AT+CGATT=";
+const char _command_SEPARATOR[] PROGMEM = "\",\"";
 
 //Attach GPRS main function.	
 GSM3_NetworkStatus_t GSM3ShieldV1DataNetworkProvider::attachGPRS(char* apn, char* user_name, char* password, bool synchronous)

--- a/libraries/GSM/src/GSM3ShieldV1ModemCore.cpp
+++ b/libraries/GSM/src/GSM3ShieldV1ModemCore.cpp
@@ -75,7 +75,7 @@ void GSM3ShieldV1ModemCore::closeCommand(int code)
 }
 
 //Generic command (stored in flash).
-void GSM3ShieldV1ModemCore::genericCommand_rq(PROGMEM prog_char str[], bool addCR)
+void GSM3ShieldV1ModemCore::genericCommand_rq(PGM_P str, bool addCR)
 {
 	theBuffer().flush();
 	writePGM(str, addCR);	
@@ -157,7 +157,7 @@ void GSM3ShieldV1ModemCore::openCommand(GSM3ShieldV1BaseProvider* provider, GSM3
 
 };
 
-size_t GSM3ShieldV1ModemCore::writePGM(PROGMEM prog_char str[], bool CR)
+size_t GSM3ShieldV1ModemCore::writePGM(PGM_P str, bool CR)
 {
 	int i=0;
 	char c;

--- a/libraries/GSM/src/GSM3ShieldV1ModemCore.h
+++ b/libraries/GSM/src/GSM3ShieldV1ModemCore.h
@@ -167,7 +167,7 @@ class GSM3ShieldV1ModemCore : public GSM3SoftSerialMgr, public Print
 			@param CR			Carriadge return adding automatically
 			@return size
 		 */
-		virtual size_t writePGM(PROGMEM prog_char str[], bool CR=true);
+		virtual size_t writePGM(PGM_P str, bool CR=true);
 		
 		/** Establish debug mode
 			@param db			Boolean that indicates debug on or off
@@ -182,23 +182,17 @@ class GSM3ShieldV1ModemCore : public GSM3SoftSerialMgr, public Print
 		 */		
 		bool genericParse_rsp(bool& rsp, char* string=0, char* string2=0);
 		
-		/** Generates a generic AT command request from PROGMEM prog_char buffer
+		/** Generates a generic AT command request from PROGMEM buffer
 			@param str			Buffer with AT command
 			@param addCR		Carriadge return adding automatically
 		 */
-		void genericCommand_rq(PROGMEM prog_char str[], bool addCR=true);
+		void genericCommand_rq(PGM_P str, bool addCR=true);
 
 		/** Generates a generic AT command request from a simple char buffer
 			@param str			Buffer with AT command
 			@param addCR		Carriadge return adding automatically
 		 */
 		void genericCommand_rqc(const char* str, bool addCR=true);		
-		
-		/** Generates a generic AT command request from characters buffer
-			@param str			Buffer with AT command
-			@param addCR		Carriadge return adding automatically
-		 */
-		void genericCommand_rq(const char* str, bool addCR=true);		
 		
 		/** Returns the circular buffer
 			@return circular buffer

--- a/libraries/GSM/src/GSM3ShieldV1MultiClientProvider.cpp
+++ b/libraries/GSM/src/GSM3ShieldV1MultiClientProvider.cpp
@@ -1,7 +1,7 @@
 #include <GSM3ShieldV1MultiClientProvider.h>
 #include <GSM3ShieldV1ModemCore.h>
 
-char _command_MultiQISRVC[] PROGMEM = "AT+QISRVC=";
+const char _command_MultiQISRVC[] PROGMEM = "AT+QISRVC=";
 
 #define __TOUTFLUSH__ 10000
 

--- a/libraries/GSM/src/GSM3ShieldV1MultiServerProvider.cpp
+++ b/libraries/GSM/src/GSM3ShieldV1MultiServerProvider.cpp
@@ -4,7 +4,7 @@
 
 #define __NCLIENTS_MAX__ 3
 
-char _command_QILOCIP[] PROGMEM = "AT+QILOCIP";
+const char _command_QILOCIP[] PROGMEM = "AT+QILOCIP";
 
 GSM3ShieldV1MultiServerProvider::GSM3ShieldV1MultiServerProvider()
 {


### PR DESCRIPTION
Partially based on #1448
- add const to PROGMEM
- replace prog_char \* with PGM_P compatibility macro as suggested in #1536

changes not tested.
