### PR TITLE
Updated String library to use C++11 iterators.

### DIFF
--- a/hardware/arduino/avr/cores/arduino/WString.h
+++ b/hardware/arduino/avr/cores/arduino/WString.h
@@ -89,8 +89,6 @@ public:
 	#ifdef __GXX_EXPERIMENTAL_CXX0X__
 	String & operator = (String &&rval);
 	String & operator = (StringSumHelper &&rval);
-	auto begin() -> const char* { return c_str(); }
-	auto end() -> const char* { return c_str() + length(); }	
 	#endif
 
 	// concatenate (works w/ built-in types)
@@ -163,6 +161,8 @@ public:
 	void toCharArray(char *buf, unsigned int bufsize, unsigned int index=0) const
 		{getBytes((unsigned char *)buf, bufsize, index);}
 	const char * c_str() const { return buffer; }
+	const char* begin() { return c_str(); }
+	const char* end() { return c_str() + length(); }	
 
 	// search
 	int indexOf( char ch ) const;

--- a/hardware/arduino/avr/cores/arduino/WString.h
+++ b/hardware/arduino/avr/cores/arduino/WString.h
@@ -89,6 +89,8 @@ public:
 	#ifdef __GXX_EXPERIMENTAL_CXX0X__
 	String & operator = (String &&rval);
 	String & operator = (StringSumHelper &&rval);
+	auto begin() -> const char* { return c_str(); }
+	auto end() -> const char* { return c_str() + length(); }	
 	#endif
 
 	// concatenate (works w/ built-in types)


### PR DESCRIPTION
This will allow using the String library in a ranged for loop. Also the additions expose the first and last character pointers, which may be of use somewhere.

```C++
void setup() {
  
  Serial.begin( 9600 );
  String s = "Hi, this is a test of C++11 iterators.";
  
  for( char c : s ){
    Serial.print( "Character in string: " );
    Serial.println( c );
  }
}
void loop(){}
```

This modification is placed inside the check for C++11 which is also due for update here: https://github.com/matthijskooijman/Arduino/commit/6624d614fa1f95c26c471ae494012923e03a2e78 