### PR TITLE
Update RobotIR library to play nice with other versions of IR-Remote

### DIFF
--- a/libraries/RobotIRremote/IRremote.h
+++ b/libraries/RobotIRremote/IRremote.h
@@ -63,13 +63,13 @@ private:
   // These are called by decode
   int getRClevel(decode_results *results, int *offset, int *used, int t1);
   long decodeNEC(decode_results *results);
-  //long decodeSony(decode_results *results);
-  //long decodeSanyo(decode_results *results);
-  //long decodeMitsubishi(decode_results *results);
-  //long decodeRC5(decode_results *results);
-  //long decodeRC6(decode_results *results);
-  //long decodePanasonic(decode_results *results);
-  //long decodeJVC(decode_results *results);
+  long decodeSony(decode_results *results);
+  long decodeSanyo(decode_results *results);
+  long decodeMitsubishi(decode_results *results);
+  long decodeRC5(decode_results *results);
+  long decodeRC6(decode_results *results);
+  long decodePanasonic(decode_results *results);
+  long decodeJVC(decode_results *results);
   long decodeHash(decode_results *results);
   int compare(unsigned int oldval, unsigned int newval);
 
@@ -82,6 +82,30 @@ private:
 #else
 #define VIRTUAL
 #endif
+
+class IRsend
+{
+public:
+  IRsend() {}
+  void sendNEC(unsigned long data, int nbits);
+  void sendSony(unsigned long data, int nbits);
+  // Neither Sanyo nor Mitsubishi send is implemented yet
+  //  void sendSanyo(unsigned long data, int nbits);
+  //  void sendMitsubishi(unsigned long data, int nbits);
+  void sendRaw(unsigned int buf[], int len, int hz);
+  void sendRC5(unsigned long data, int nbits);
+  void sendRC6(unsigned long data, int nbits);
+  void sendDISH(unsigned long data, int nbits);
+  void sendSharp(unsigned long data, int nbits);
+  void sendPanasonic(unsigned int address, unsigned long data);
+  void sendJVC(unsigned long data, int nbits, int repeat); // *Note instead of sending the REPEAT constant if you want the JVC repeat signal sent, send the original code value and change the repeat argument from 0 to 1. JVC protocol repeats by skipping the header NOT by sending a separate code value like NEC does.
+  // private:
+  void enableIROut(int khz);
+  VIRTUAL void mark(int usec);
+  VIRTUAL void space(int usec);
+}
+;
+
 // Some useful constants
 
 #define USECPERTICK 50  // microseconds per clock interrupt tick

--- a/libraries/RobotIRremote/IRremoteInt.h
+++ b/libraries/RobotIRremote/IRremoteInt.h
@@ -28,8 +28,6 @@
 // are using another library which uses timer2, you have options
 // to switch IRremote to use a different timer.
 
-//#define __AVR_ATtinyX5__
-
 // Arduino Mega
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
   //#define IR_USE_TIMER1   // tx = pin 11

--- a/libraries/RobotIRremote/IRremoteInt.h
+++ b/libraries/RobotIRremote/IRremoteInt.h
@@ -28,6 +28,8 @@
 // are using another library which uses timer2, you have options
 // to switch IRremote to use a different timer.
 
+//#define __AVR_ATtinyX5__
+
 // Arduino Mega
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
   //#define IR_USE_TIMER1   // tx = pin 11
@@ -61,6 +63,25 @@
 #elif defined(__AVR_ATmega8P__) || defined(__AVR_ATmega8__)
   #define IR_USE_TIMER1   // tx = pin 9
 
+#elif defined( __AVR_ATtinyX4__ )
+  #define IR_USE_TIMER1   // tx = pin 6
+
+#elif defined( __AVR_ATtinyX5__ )
+
+  #ifndef cbi
+    #define cbi(sfr, bit) (_SFR_BYTE(sfr) &= ~_BV(bit))
+  #endif
+  #ifndef sbi
+    #define sbi(sfr, bit) (_SFR_BYTE(sfr) |= _BV(bit))
+  #endif
+
+ #define CLKFUDGE 5      // fudge factor for clock interrupt overhead
+#define CLK 256      // max value for clock (timer 2)
+#define PRESCALE 8      // timer2 clock prescale
+ #define CLKSPERUSEC (SYSCLOCK/PRESCALE/1000000)   // timer clocks per microsecond
+
+  #define IR_ATTINY_85   // OCR1A, pin 6
+
 // Arduino Duemilanove, Diecimila, LilyPad, Mini, Fio, etc
 #else
   //#define IR_USE_TIMER1   // tx = pin 9
@@ -90,24 +111,24 @@
 // Pulse parms are *50-100 for the Mark and *50+100 for the space
 // First MARK is the one after the long gap
 // pulse parameters in usec
-#define NEC_HDR_MARK	9000
-#define NEC_HDR_SPACE	4500
-#define NEC_BIT_MARK	560
-#define NEC_ONE_SPACE	1600
-#define NEC_ZERO_SPACE	560
-#define NEC_RPT_SPACE	2250
+#define NEC_HDR_MARK  9000
+#define NEC_HDR_SPACE 4500
+#define NEC_BIT_MARK  560
+#define NEC_ONE_SPACE 1600
+#define NEC_ZERO_SPACE  560
+#define NEC_RPT_SPACE 2250
 
-#define SONY_HDR_MARK	2400
-#define SONY_HDR_SPACE	600
-#define SONY_ONE_MARK	1200
-#define SONY_ZERO_MARK	600
+#define SONY_HDR_MARK 2400
+#define SONY_HDR_SPACE  600
+#define SONY_ONE_MARK 1200
+#define SONY_ZERO_MARK  600
 #define SONY_RPT_LENGTH 45000
 #define SONY_DOUBLE_SPACE_USECS  500  // usually ssee 713 - not using ticks as get number wrapround
 
 // SA 8650B
-#define SANYO_HDR_MARK	3500  // seen range 3500
-#define SANYO_HDR_SPACE	950 //  seen 950
-#define SANYO_ONE_MARK	2400 // seen 2400  
+#define SANYO_HDR_MARK  3500  // seen range 3500
+#define SANYO_HDR_SPACE 950 //  seen 950
+#define SANYO_ONE_MARK  2400 // seen 2400  
 #define SANYO_ZERO_MARK 700 //  seen 700
 #define SANYO_DOUBLE_SPACE_USECS  800  // usually ssee 713 - not using ticks as get number wrapround
 #define SANYO_RPT_LENGTH 45000
@@ -115,21 +136,21 @@
 // Mitsubishi RM 75501
 // 14200 7 41 7 42 7 42 7 17 7 17 7 18 7 41 7 18 7 17 7 17 7 18 7 41 8 17 7 17 7 18 7 17 7 
 
-// #define MITSUBISHI_HDR_MARK	250  // seen range 3500
-#define MITSUBISHI_HDR_SPACE	350 //  7*50+100
-#define MITSUBISHI_ONE_MARK	1950 // 41*50-100
+// #define MITSUBISHI_HDR_MARK  250  // seen range 3500
+#define MITSUBISHI_HDR_SPACE  350 //  7*50+100
+#define MITSUBISHI_ONE_MARK 1950 // 41*50-100
 #define MITSUBISHI_ZERO_MARK  750 // 17*50-100
 // #define MITSUBISHI_DOUBLE_SPACE_USECS  800  // usually ssee 713 - not using ticks as get number wrapround
 // #define MITSUBISHI_RPT_LENGTH 45000
 
 
-#define RC5_T1		889
-#define RC5_RPT_LENGTH	46000
+#define RC5_T1    889
+#define RC5_RPT_LENGTH  46000
 
-#define RC6_HDR_MARK	2666
-#define RC6_HDR_SPACE	889
-#define RC6_T1		444
-#define RC6_RPT_LENGTH	46000
+#define RC6_HDR_MARK  2666
+#define RC6_HDR_SPACE 889
+#define RC6_T1    444
+#define RC6_RPT_LENGTH  46000
 
 #define SHARP_BIT_MARK 245
 #define SHARP_ONE_SPACE 1805
@@ -264,7 +285,13 @@ extern volatile irparams_t irparams;
   #define TIMER_ENABLE_INTR    (TIMSK1 = _BV(OCIE1A))
   #define TIMER_DISABLE_INTR   (TIMSK1 = 0)
 #endif
-#define TIMER_INTR_NAME      TIMER1_COMPA_vect
+
+#if defined(__AVR_ATtinyX4__)
+  #define TIMER_INTR_NAME      TIM1_COMPA_vect
+#else // for attiny85
+  #define TIMER_INTR_NAME      TIMER1_COMPA_vect
+#endif
+
 #define TIMER_CONFIG_KHZ(val) ({ \
   const uint16_t pwmval = SYSCLOCK / 2000 / (val); \
   TCCR1A = _BV(WGM11); \
@@ -284,6 +311,8 @@ extern volatile irparams_t irparams;
 #define TIMER_PWM_PIN        11  /* Arduino Mega */
 #elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644__)
 #define TIMER_PWM_PIN        13 /* Sanguino */
+#elif defined(__AVR_ATtinyX4__)
+#define TIMER_PWM_PIN        6 /* ATTiny84 */
 #else
 #define TIMER_PWM_PIN        9  /* Arduino Duemilanove, Diecimila, LilyPad, etc */
 #endif
@@ -418,6 +447,28 @@ extern volatile irparams_t irparams;
 #error "Please add OC5A pin number here\n"
 #endif
 
+// defines for timer5 (16 bits)
+#elif defined(IR_ATTINY_85)
+
+#define TIMER_RESET          TCNT1 = (CLK - USECPERTICK*CLKSPERUSEC + CLKFUDGE)
+#define TIMER_ENABLE_PWM     TCCR1 |= _BV(COM0B1) // Enable pin 3 PWM output
+#define TIMER_DISABLE_PWM    TCCR1 &= ~(_BV(COM0B1)) // Disable pin 3 PWM output
+#define TIMER_ENABLE_INTR    //sbi(TIMSK,TOIE0); //Timer2 Overflow Interrupt Enable
+#define TIMER_DISABLE_INTR   TIMSK &= ~_BV(TOIE0) //Timer2 Overflow Interrupt
+#define TIMER_INTR_NAME      TIMER1_OVF_vect
+
+#define TIMER_CONFIG_KHZ(val) ({ \
+  const uint16_t pwmval = SYSCLOCK / 1000 / (val); \
+  TCCR1 = _BV(CTC1) | _BV(CS13); \
+  OCR1C = SYSCLOCK / 2 / pwmval / 1000; \
+  OCR1A = OCR1A / 3; \
+})
+#define TIMER_CONFIG_NORMAL() ({ \
+  TCCR1 = _BV(CTC1) | _BV(CS13); \
+  OCR1C = 24; \
+  OCR1A = 0; \
+})
+#define TIMER_PWM_PIN        3 /* ATTiny85 */
 
 #else // unknown timer
 #error "Internal code configuration error, no known IR_USE_TIMER# defined\n"

--- a/libraries/RobotIRremote/IRremoteTools.cpp
+++ b/libraries/RobotIRremote/IRremoteTools.cpp
@@ -2,6 +2,7 @@
 #include "IRremoteTools.h"
 #include <Arduino.h>
 
+#ifdef AVR_ROBOT_CONTROL || AVR_ROBOT_MOTOR
 int RECV_PIN = TKD2; // the pin the IR receiver is connected to
 IRrecv irrecv(RECV_PIN); // an instance of the IR receiver object
 decode_results results; // container for received IR codes
@@ -21,3 +22,4 @@ void resumeIRremote(){
 unsigned long getIRresult(){
 	return results.value;
 }
+#endif


### PR DESCRIPTION
This leaves all the functionality of RobotIR in place but updates the underlying IRRemote library that I'm maintaining now. The AVR_ROBOT_CONTROL and AVR_ROBOT_MOTOR #defines are used to indicate that the board is the Arduino Robot and that the pin defines should be left in.