### PR TITLE
Add watchdog routines for Due.

### DIFF
--- a/hardware/arduino/sam/cores/arduino/Arduino.h
+++ b/hardware/arduino/sam/cores/arduino/Arduino.h
@@ -194,6 +194,8 @@ extern const PinDescription g_APinDescription[] ;
 #include "wiring_shift.h"
 #include "WInterrupts.h"
 
+#include "watchdog.h"
+
 // USB Device
 #define USB_VID            0x2341 // arduino LLC vid
 #define USB_PID_LEONARDO   0x0034

--- a/hardware/arduino/sam/cores/arduino/main.cpp
+++ b/hardware/arduino/sam/cores/arduino/main.cpp
@@ -41,6 +41,9 @@ void initVariant() { }
  */
 int main( void )
 {
+	// Initialize watchdog
+	watchdogSetup();
+
 	init();
 
 	initVariant();

--- a/hardware/arduino/sam/cores/arduino/watchdog.cpp
+++ b/hardware/arduino/sam/cores/arduino/watchdog.cpp
@@ -1,0 +1,55 @@
+/*
+  Copyright (c) 2014 Arduino.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include <chip.h>
+
+#include "watchdog.h"
+
+
+void watchdogEnable (uint32_t timeout)
+{
+	/* this assumes the slow clock is running at 32.768 kHz
+	   watchdog frequency is therefore 32768 / 128 = 256 Hz */
+	timeout = timeout * 256 / 1000; 
+	if (timeout == 0)
+		timeout = 1;
+	else if (timeout > 0xFFF)
+		timeout = 0xFFF;
+	timeout = WDT_MR_WDRSTEN | WDT_MR_WDRPROC | WDT_MR_WDV(timeout) | WDT_MR_WDD(timeout);
+	WDT_Enable (WDT, timeout);
+}
+
+void watchdogDisable(void)
+{
+	WDT_Disable (WDT);
+}
+
+void watchdogReset(void)
+{
+	WDT_Restart (WDT);
+}
+
+
+extern "C"
+void _watchdogDefaultSetup (void)
+{
+	WDT_Disable (WDT);
+}
+void watchdogSetup (void) __attribute__ ((weak, alias("_watchdogDefaultSetup")));
+
+

--- a/hardware/arduino/sam/cores/arduino/watchdog.h
+++ b/hardware/arduino/sam/cores/arduino/watchdog.h
@@ -1,0 +1,52 @@
+/*
+  Copyright (c) 2014 Arduino.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _WATCHDOG_
+#define _WATCHDOG_
+
+#include <stdint.h>
+
+// Watchdog functions
+
+/*
+ * \brief Enable the watchdog with the specified timeout. Should only be called once.
+ *
+ * \param timeount in milliseconds.
+ */
+void watchdogEnable (uint32_t timeout);
+
+/*
+ * \brief Disable the watchdog timer. Should only be called once.
+ *
+ */
+void watchdogDisable (void);
+
+/*
+ * \brief Reset the watchdog counter.
+ *
+ */
+void watchdogReset (void);
+
+/*
+ * \brief Watchdog initialize hook. This function is called from init(). If the user does not provide
+ * this function, then the default action is to disable watchdog.
+ */
+void watchdogSetup (void);
+
+#endif /* _WATCHDOG_ */
+

--- a/hardware/arduino/sam/variants/arduino_due_x/variant.cpp
+++ b/hardware/arduino/sam/variants/arduino_due_x/variant.cpp
@@ -355,52 +355,6 @@ void serialEventRun(void)
 }
 
 // ----------------------------------------------------------------------------
-extern "C" {
-
-/**
- * Watchdog enable
- *
- * Enable the watchdog timer with the specified settings.
- * WDTO_xxx macros provide standard settings.
- * Should only be called once.
- */
-void wdt_enable (uint32_t mode)
-{
-	WDT_Enable (WDT, mode);
-}
-
-/**
- * Watchdog disable
- *
- * Disable the watchdog timer.
- * Should only be called once.
- */
-void wdt_disable(void)
-{
-	WDT_Disable (WDT);
-}
-
-/**
- * Watchdog reset
- *
- * Resets the watchdog counter
- */
-void wdt_reset(void)
-{
-	WDT_Restart (WDT);
-}
-
-}  // extern "C"
-
-/**
- * Watchdog initialize hook
- *
- * This function is called from init().
- * Default action is to disable watchdog.
- */
-void wdt_initialize(void) __attribute__ ((weak, alias("wdt_disable")));
-
-// ----------------------------------------------------------------------------
 
 #ifdef __cplusplus
 extern "C" {
@@ -418,9 +372,6 @@ void init( void )
     // Capture error
     while (true);
   }
-
-  // Initialize watchdog
-  wdt_initialize();
 
   // Initialize C library
   __libc_init_array();

--- a/hardware/arduino/sam/variants/arduino_due_x/variant.cpp
+++ b/hardware/arduino/sam/variants/arduino_due_x/variant.cpp
@@ -355,6 +355,52 @@ void serialEventRun(void)
 }
 
 // ----------------------------------------------------------------------------
+extern "C" {
+
+/**
+ * Watchdog enable
+ *
+ * Enable the watchdog timer with the specified settings.
+ * WDTO_xxx macros provide standard settings.
+ * Should only be called once.
+ */
+void wdt_enable (uint32_t mode)
+{
+	WDT_Enable (WDT, mode);
+}
+
+/**
+ * Watchdog disable
+ *
+ * Disable the watchdog timer.
+ * Should only be called once.
+ */
+void wdt_disable(void)
+{
+	WDT_Disable (WDT);
+}
+
+/**
+ * Watchdog reset
+ *
+ * Resets the watchdog counter
+ */
+void wdt_reset(void)
+{
+	WDT_Restart (WDT);
+}
+
+}  // extern "C"
+
+/**
+ * Watchdog initialize hook
+ *
+ * This function is called from init().
+ * Default action is to disable watchdog.
+ */
+void wdt_initialize(void) __attribute__ ((weak, alias("wdt_disable")));
+
+// ----------------------------------------------------------------------------
 
 #ifdef __cplusplus
 extern "C" {
@@ -373,8 +419,8 @@ void init( void )
     while (true);
   }
 
-  // Disable watchdog
-  WDT_Disable(WDT);
+  // Initialize watchdog
+  wdt_initialize();
 
   // Initialize C library
   __libc_init_array();

--- a/hardware/arduino/sam/variants/arduino_due_x/variant.h
+++ b/hardware/arduino/sam/variants/arduino_due_x/variant.h
@@ -216,6 +216,25 @@ static const uint8_t CAN1TX = 89;
 #define TC_MIN_DUTY_CYCLE   0
 #define TC_RESOLUTION		8
 
+// Watchdog routines
+
+#define WDTO_15MS	WDT_MR_WDRSTEN | WDT_MR_WDRPROC | WDT_MR_WDV(4) | WDT_MR_WDD(4)
+#define WDTO_30MS	WDT_MR_WDRSTEN | WDT_MR_WDRPROC | WDT_MR_WDV(8) | WDT_MR_WDD(8)
+#define WDTO_60MS 	WDT_MR_WDRSTEN | WDT_MR_WDRPROC | WDT_MR_WDV(15) | WDT_MR_WDD(15)
+#define WDTO_120MS	WDT_MR_WDRSTEN | WDT_MR_WDRPROC | WDT_MR_WDV(31) | WDT_MR_WDD(31)
+#define WDTO_250MS	WDT_MR_WDRSTEN | WDT_MR_WDRPROC | WDT_MR_WDV(64) | WDT_MR_WDD(64)
+#define WDTO_500MS	WDT_MR_WDRSTEN | WDT_MR_WDRPROC | WDT_MR_WDV(128) | WDT_MR_WDD(128)
+#define WDTO_1S		WDT_MR_WDRSTEN | WDT_MR_WDRPROC | WDT_MR_WDV(256) | WDT_MR_WDD(256)
+#define WDTO_2S		WDT_MR_WDRSTEN | WDT_MR_WDRPROC | WDT_MR_WDV(512) | WDT_MR_WDD(512)
+#define WDTO_4S		WDT_MR_WDRSTEN | WDT_MR_WDRPROC | WDT_MR_WDV(1024) | WDT_MR_WDD(1024)
+#define WDTO_8S		WDT_MR_WDRSTEN | WDT_MR_WDRPROC | WDT_MR_WDV(2048) | WDT_MR_WDD(2048)
+
+void wdt_enable (uint32_t mode);
+
+void wdt_disable(void);
+
+void wdt_reset(void);
+
 #ifdef __cplusplus
 }
 #endif
@@ -257,6 +276,7 @@ extern USARTClass Serial3;
 #define SERIAL_PORT_HARDWARE1       Serial1
 #define SERIAL_PORT_HARDWARE2       Serial2
 #define SERIAL_PORT_HARDWARE3       Serial3
+
 
 #endif /* _VARIANT_ARDUINO_DUE_X_ */
 

--- a/hardware/arduino/sam/variants/arduino_due_x/variant.h
+++ b/hardware/arduino/sam/variants/arduino_due_x/variant.h
@@ -216,25 +216,6 @@ static const uint8_t CAN1TX = 89;
 #define TC_MIN_DUTY_CYCLE   0
 #define TC_RESOLUTION		8
 
-// Watchdog routines
-
-#define WDTO_15MS	WDT_MR_WDRSTEN | WDT_MR_WDRPROC | WDT_MR_WDV(4) | WDT_MR_WDD(4)
-#define WDTO_30MS	WDT_MR_WDRSTEN | WDT_MR_WDRPROC | WDT_MR_WDV(8) | WDT_MR_WDD(8)
-#define WDTO_60MS 	WDT_MR_WDRSTEN | WDT_MR_WDRPROC | WDT_MR_WDV(15) | WDT_MR_WDD(15)
-#define WDTO_120MS	WDT_MR_WDRSTEN | WDT_MR_WDRPROC | WDT_MR_WDV(31) | WDT_MR_WDD(31)
-#define WDTO_250MS	WDT_MR_WDRSTEN | WDT_MR_WDRPROC | WDT_MR_WDV(64) | WDT_MR_WDD(64)
-#define WDTO_500MS	WDT_MR_WDRSTEN | WDT_MR_WDRPROC | WDT_MR_WDV(128) | WDT_MR_WDD(128)
-#define WDTO_1S		WDT_MR_WDRSTEN | WDT_MR_WDRPROC | WDT_MR_WDV(256) | WDT_MR_WDD(256)
-#define WDTO_2S		WDT_MR_WDRSTEN | WDT_MR_WDRPROC | WDT_MR_WDV(512) | WDT_MR_WDD(512)
-#define WDTO_4S		WDT_MR_WDRSTEN | WDT_MR_WDRPROC | WDT_MR_WDV(1024) | WDT_MR_WDD(1024)
-#define WDTO_8S		WDT_MR_WDRSTEN | WDT_MR_WDRPROC | WDT_MR_WDV(2048) | WDT_MR_WDD(2048)
-
-void wdt_enable (uint32_t mode);
-
-void wdt_disable(void);
-
-void wdt_reset(void);
-
 #ifdef __cplusplus
 }
 #endif
@@ -276,7 +257,6 @@ extern USARTClass Serial3;
 #define SERIAL_PORT_HARDWARE1       Serial1
 #define SERIAL_PORT_HARDWARE2       Serial2
 #define SERIAL_PORT_HARDWARE3       Serial3
-
 
 #endif /* _VARIANT_ARDUINO_DUE_X_ */
 


### PR DESCRIPTION
I am not sure the wdt_* routines are in the right file, but this illustrates the functionality. 

Perhaps it would be better to have a new module called "watchdog.c" to contain these routines, the implementation is specific to processor series.