### PR TITLE
Resolved a few compile warnings.

### DIFF
--- a/hardware/arduino/cores/arduino/Arduino.h
+++ b/hardware/arduino/cores/arduino/Arduino.h
@@ -128,7 +128,6 @@ unsigned long millis(void);
 unsigned long micros(void);
 void delay(unsigned long);
 void delayMicroseconds(unsigned int us);
-unsigned long pulseIn(uint8_t pin, uint8_t state, unsigned long timeout);
 
 void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t val);
 uint8_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder);
@@ -219,7 +218,7 @@ uint16_t makeWord(byte h, byte l);
 
 #define word(...) makeWord(__VA_ARGS__)
 
-unsigned long pulseIn(uint8_t pin, uint8_t state, unsigned long timeout = 1000000L);
+extern "C" unsigned long pulseIn(uint8_t pin, uint8_t state, unsigned long timeout = 1000000L);
 
 void tone(uint8_t _pin, unsigned int frequency, unsigned long duration = 0);
 void noTone(uint8_t _pin);
@@ -230,6 +229,8 @@ long random(long, long);
 void randomSeed(unsigned int);
 long map(long, long, long, long, long);
 
+#else
+unsigned long pulseIn(uint8_t pin, uint8_t state, unsigned long timeout);
 #endif
 
 #include "pins_arduino.h"

--- a/hardware/arduino/cores/arduino/Arduino.h
+++ b/hardware/arduino/cores/arduino/Arduino.h
@@ -113,7 +113,7 @@ typedef uint8_t boolean;
 typedef uint8_t byte;
 
 void init(void);
-void initVariant(void);
+void initVariant(void) __attribute__((weak));
 
 int atexit(void (*func)()) __attribute__((weak));
 

--- a/hardware/arduino/cores/arduino/Stream.cpp
+++ b/hardware/arduino/cores/arduino/Stream.cpp
@@ -75,7 +75,7 @@ void Stream::setTimeout(unsigned long timeout)  // sets the maximum number of mi
  // find returns true if the target string is found
 bool  Stream::find(char *target)
 {
-  return findUntil(target, "");
+  return findUntil(target, strlen(target), NULL, 0);
 }
 
 // reads data from the stream until the target string of given length is found

--- a/hardware/arduino/cores/arduino/Tone.cpp
+++ b/hardware/arduino/cores/arduino/Tone.cpp
@@ -240,7 +240,7 @@ static int8_t toneBegin(uint8_t _pin)
 
 void tone(uint8_t _pin, unsigned int frequency, unsigned long duration)
 {
-  uint8_t prescalarbits = 0b001;
+  uint8_t prescalarbits = B001;
   long toggle_count = 0;
   uint32_t ocr = 0;
   int8_t _timer;
@@ -256,38 +256,38 @@ void tone(uint8_t _pin, unsigned int frequency, unsigned long duration)
     if (_timer == 0 || _timer == 2)
     {
       ocr = F_CPU / frequency / 2 - 1;
-      prescalarbits = 0b001;  // ck/1: same for both timers
+      prescalarbits = B001;  // ck/1: same for both timers
       if (ocr > 255)
       {
         ocr = F_CPU / frequency / 2 / 8 - 1;
-        prescalarbits = 0b010;  // ck/8: same for both timers
+        prescalarbits = B010;  // ck/8: same for both timers
 
         if (_timer == 2 && ocr > 255)
         {
           ocr = F_CPU / frequency / 2 / 32 - 1;
-          prescalarbits = 0b011;
+          prescalarbits = B011;
         }
 
         if (ocr > 255)
         {
           ocr = F_CPU / frequency / 2 / 64 - 1;
-          prescalarbits = _timer == 0 ? 0b011 : 0b100;
+          prescalarbits = _timer == 0 ? B011 : B100;
 
           if (_timer == 2 && ocr > 255)
           {
             ocr = F_CPU / frequency / 2 / 128 - 1;
-            prescalarbits = 0b101;
+            prescalarbits = B101;
           }
 
           if (ocr > 255)
           {
             ocr = F_CPU / frequency / 2 / 256 - 1;
-            prescalarbits = _timer == 0 ? 0b100 : 0b110;
+            prescalarbits = _timer == 0 ? B100 : B110;
             if (ocr > 255)
             {
               // can't do any better than /1024
               ocr = F_CPU / frequency / 2 / 1024 - 1;
-              prescalarbits = _timer == 0 ? 0b101 : 0b111;
+              prescalarbits = _timer == 0 ? B101 : B111;
             }
           }
         }
@@ -315,30 +315,30 @@ void tone(uint8_t _pin, unsigned int frequency, unsigned long duration)
       // two choices for the 16 bit timers: ck/1 or ck/64
       ocr = F_CPU / frequency / 2 - 1;
 
-      prescalarbits = 0b001;
+      prescalarbits = B001;
       if (ocr > 0xffff)
       {
         ocr = F_CPU / frequency / 2 / 64 - 1;
-        prescalarbits = 0b011;
+        prescalarbits = B011;
       }
 
       if (_timer == 1)
       {
 #if defined(TCCR1B)
-        TCCR1B = (TCCR1B & 0b11111000) | prescalarbits;
+        TCCR1B = (TCCR1B & B11111000) | prescalarbits;
 #endif
       }
 #if defined(TCCR3B)
       else if (_timer == 3)
-        TCCR3B = (TCCR3B & 0b11111000) | prescalarbits;
+        TCCR3B = (TCCR3B & B11111000) | prescalarbits;
 #endif
 #if defined(TCCR4B)
       else if (_timer == 4)
-        TCCR4B = (TCCR4B & 0b11111000) | prescalarbits;
+        TCCR4B = (TCCR4B & B11111000) | prescalarbits;
 #endif
 #if defined(TCCR5B)
       else if (_timer == 5)
-        TCCR5B = (TCCR5B & 0b11111000) | prescalarbits;
+        TCCR5B = (TCCR5B & B11111000) | prescalarbits;
 #endif
 
     }
@@ -447,7 +447,7 @@ void disableTimer(uint8_t _timer)
         TCCR2A = (1 << WGM20);
       #endif
       #if defined(TCCR2B) && defined(CS22)
-        TCCR2B = (TCCR2B & 0b11111000) | (1 << CS22);
+        TCCR2B = (TCCR2B & B11111000) | (1 << CS22);
       #endif
       #if defined(OCR2A)
         OCR2A = 0;

--- a/hardware/arduino/cores/arduino/main.cpp
+++ b/hardware/arduino/cores/arduino/main.cpp
@@ -22,9 +22,8 @@
 //Declared weak in Arduino.h to allow user redefinitions.
 int atexit(void (*func)()) { return 0; }
 
-// Weak empty variant initialization function.
+// Weak empty variant initialization function declared in Arduino.h.
 // May be redefined by variant files.
-void initVariant() __attribute__((weak));
 void initVariant() { }
 
 int main(void)

--- a/hardware/arduino/cores/arduino/new.cpp
+++ b/hardware/arduino/cores/arduino/new.cpp
@@ -20,9 +20,9 @@ void operator delete[](void * ptr)
   free(ptr);
 }
 
-int __cxa_guard_acquire(__guard *g) {return !*(char *)(g);};
-void __cxa_guard_release (__guard *g) {*(char *)g = 1;};
-void __cxa_guard_abort (__guard *) {}; 
+int __cxa_guard_acquire(__guard *g) {return !*(char *)(g);}
+void __cxa_guard_release (__guard *g) {*(char *)g = 1;}
+void __cxa_guard_abort (__guard *) {}
 
-void __cxa_pure_virtual(void) {};
+void __cxa_pure_virtual(void) {}
 


### PR DESCRIPTION
This patch will resolve a handful of warnings when compiling an empty sketch. It would be great to have the core warning free so the `-w` compile flag can be removed.

Sorry for all the commits, still working on the GitHub clone issue.