### PR TITLE
Added a function to LiquidCrystal to tweak the memory offset of the rows...

### DIFF
--- a/libraries/LiquidCrystal/LiquidCrystal.cpp
+++ b/libraries/LiquidCrystal/LiquidCrystal.cpp
@@ -88,6 +88,8 @@ void LiquidCrystal::begin(uint8_t cols, uint8_t lines, uint8_t dotsize) {
   }
   _numlines = lines;
   _currline = 0;
+  int row_offsets[] = { 0x00, 0x40, 0x14, 0x54 };
+  setRowOffsets(row_offsets);
 
   // for some 1 line displays you can select a 10 pixel high font
   if ((dotsize != 0) && (lines == 1)) {
@@ -172,12 +174,17 @@ void LiquidCrystal::home()
 
 void LiquidCrystal::setCursor(uint8_t col, uint8_t row)
 {
-  int row_offsets[] = { 0x00, 0x40, 0x14, 0x54 };
   if ( row >= _numlines ) {
     row = _numlines-1;    // we count rows starting w/0
   }
   
-  command(LCD_SETDDRAMADDR | (col + row_offsets[row]));
+  command(LCD_SETDDRAMADDR | (col + _row_offsets[row]));
+}
+
+// Allows the tweaking of the memory offsets for each row.
+void LiquidCrystal::setRowOffsets(int row_offsets[])
+{
+  _row_offsets = row_offsets;
 }
 
 // Turn the display on/off (quickly)

--- a/libraries/LiquidCrystal/LiquidCrystal.h
+++ b/libraries/LiquidCrystal/LiquidCrystal.h
@@ -78,7 +78,8 @@ public:
   void noAutoscroll();
 
   void createChar(uint8_t, uint8_t[]);
-  void setCursor(uint8_t, uint8_t); 
+  void setCursor(uint8_t, uint8_t);
+  void setRowOffsets(int[]); 
   virtual size_t write(uint8_t);
   void command(uint8_t);
   
@@ -101,6 +102,8 @@ private:
   uint8_t _initialized;
 
   uint8_t _numlines,_currline;
+  
+  int *_row_offsets; // array of memory offsets for the start of each row
 };
 
 #endif

--- a/libraries/LiquidCrystal/keywords.txt
+++ b/libraries/LiquidCrystal/keywords.txt
@@ -30,6 +30,7 @@ rightToLeft	KEYWORD2
 scrollDisplayLeft	KEYWORD2
 scrollDisplayRight	KEYWORD2
 createChar	KEYWORD2
+setRowOffsets	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
Some LCD screens have different memory offsets for the start of their rows, such as the [MC41605B6W-SPR](http://datasheet.octopart.com/MC41605B6W-SPR-Midas-datasheet-10854526.pdf). On the datasheet it says that row 0 starts at 0x00, row 1 starts at 0x40, row 2 starts at 0x10 and row 3 at 0x50. The LiquidCrystal::setRowOffsets() function allows these offsets to be tweaked so the LiquidCrystal::setCursor() function puts the cursor to the right place even with different memory layouts.
