### PR TITLE
9-bit frame support to Hardware Serial 1.0.X

### DIFF
--- a/hardware/arduino/cores/arduino/HardwareSerial.h
+++ b/hardware/arduino/cores/arduino/HardwareSerial.h
@@ -18,6 +18,7 @@
 
   Modified 28 September 2010 by Mark Sproul
   Modified 14 August 2012 by Alarus
+  Modified 12 April 2014 by Bouni
 */
 
 #ifndef HardwareSerial_h
@@ -40,6 +41,7 @@ class HardwareSerial : public Stream
     volatile uint8_t *_ucsrb;
     volatile uint8_t *_ucsrc;
     volatile uint8_t *_udr;
+    uint8_t _ucsz2;
     uint8_t _rxen;
     uint8_t _txen;
     uint8_t _rxcie;
@@ -51,48 +53,60 @@ class HardwareSerial : public Stream
       volatile uint8_t *ubrrh, volatile uint8_t *ubrrl,
       volatile uint8_t *ucsra, volatile uint8_t *ucsrb,
       volatile uint8_t *ucsrc, volatile uint8_t *udr,
-      uint8_t rxen, uint8_t txen, uint8_t rxcie, uint8_t udrie, uint8_t u2x);
+      uint8_t ucsz2, uint8_t rxen, uint8_t txen, uint8_t rxcie, uint8_t udrie, uint8_t u2x);
     void begin(unsigned long);
-    void begin(unsigned long, uint8_t);
+    void begin(unsigned long, unsigned int);
     void end();
     virtual int available(void);
     virtual int peek(void);
     virtual int read(void);
     virtual void flush(void);
-    virtual size_t write(uint8_t);
-    inline size_t write(unsigned long n) { return write((uint8_t)n); }
-    inline size_t write(long n) { return write((uint8_t)n); }
-    inline size_t write(unsigned int n) { return write((uint8_t)n); }
-    inline size_t write(int n) { return write((uint8_t)n); }
+    virtual size_t write(unsigned int);
+    inline size_t write(uint8_t n) { return write((unsigned int)n); }
+    inline size_t write(int8_t n) { return write((unsigned int)n); }
+    inline size_t write(int n) { return write((unsigned int)n); }
+    inline size_t write(unsigned long n) { return write((unsigned int)n); }
+    inline size_t write(long n) { return write((unsigned int)n); }
     using Print::write; // pull in write(str) and write(buf, size) from Print
     operator bool();
 };
 
 // Define config for Serial.begin(baud, config);
-#define SERIAL_5N1 0x00
-#define SERIAL_6N1 0x02
-#define SERIAL_7N1 0x04
-#define SERIAL_8N1 0x06
-#define SERIAL_5N2 0x08
-#define SERIAL_6N2 0x0A
-#define SERIAL_7N2 0x0C
-#define SERIAL_8N2 0x0E
-#define SERIAL_5E1 0x20
-#define SERIAL_6E1 0x22
-#define SERIAL_7E1 0x24
-#define SERIAL_8E1 0x26
-#define SERIAL_5E2 0x28
-#define SERIAL_6E2 0x2A
-#define SERIAL_7E2 0x2C
-#define SERIAL_8E2 0x2E
-#define SERIAL_5O1 0x30
-#define SERIAL_6O1 0x32
-#define SERIAL_7O1 0x34
-#define SERIAL_8O1 0x36
-#define SERIAL_5O2 0x38
-#define SERIAL_6O2 0x3A
-#define SERIAL_7O2 0x3C
-#define SERIAL_8O2 0x3E
+#define SERIAL_5N1 0x000 //0b000000000
+#define SERIAL_6N1 0x002 //0b000000010
+#define SERIAL_7N1 0x004 //0b000000100
+#define SERIAL_8N1 0x006 //0b000000110
+#define SERIAL_9N1 0x106 //0b100000110
+
+#define SERIAL_5N2 0x008 //0b000001000
+#define SERIAL_6N2 0x00A //0b000001010
+#define SERIAL_7N2 0x00C //0b000001100
+#define SERIAL_8N2 0x00E //0b000001110
+#define SERIAL_9N2 0x10E //0b100001110
+
+#define SERIAL_5E1 0x020 //0b000100000
+#define SERIAL_6E1 0x022 //0b000100010
+#define SERIAL_7E1 0x024 //0b000100100
+#define SERIAL_8E1 0x026 //0b000100110
+#define SERIAL_9E1 0x126 //0b100100110
+
+#define SERIAL_5E2 0x028 //0b000101000
+#define SERIAL_6E2 0x02A //0b000101010
+#define SERIAL_7E2 0x02C //0b000101100
+#define SERIAL_8E2 0x02E //0b000101110
+#define SERIAL_9E2 0x12E //0b100101110
+
+#define SERIAL_5O1 0x030 //0b000110000
+#define SERIAL_6O1 0x032 //0b000110010
+#define SERIAL_7O1 0x034 //0b000110100
+#define SERIAL_8O1 0x036 //0b000110110
+#define SERIAL_9O1 0x136 //0b100110110
+
+#define SERIAL_5O2 0x038 //0b000111000
+#define SERIAL_6O2 0x03A //0b000111010
+#define SERIAL_7O2 0x03C //0b000111100
+#define SERIAL_8O2 0x03E //0b000111110
+#define SERIAL_9O2 0x13E //0b100111110
 
 #if defined(UBRRH) || defined(UBRR0H)
   extern HardwareSerial Serial;


### PR DESCRIPTION
I've added support for sending and receiving 9-bit frames for AVR based boards.
The changes are tested with a test sketch [1] and also with a logic analyzer (Saleae Logic 8).

I use two bytes in the buffer for storing a 9 bit frame. So i don't have to change the buffer type to uint16_t which means that all other modes then 9 bit don't waste RAM. The only downside for 9 bit users is that the buffer has only half the size.

[1] [Test Sketch](https://gist.github.com/Bouni/7087db3915bc530b41c2)
