### PR TITLE
Resolved possible jnidispatch.dll conflict on Windows

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -666,16 +666,16 @@
   </target>
 
   <target name="download-launch4j-windows">
-    <get src="http://switch.dl.sourceforge.net/project/launch4j/launch4j-3/3.0.2/launch4j-3.0.2-win32.zip" dest="windows" usetimestamp="true" skipexisting="true" verbose="true" />
-    <unzip dest="windows/launcher/" src="windows/launch4j-3.0.2-win32.zip" overwrite="true"/>
+    <get src="http://switch.dl.sourceforge.net/project/launch4j/launch4j-3/3.6/launch4j-3.6-win32.zip" dest="windows" usetimestamp="true" skipexisting="true" verbose="true" />
+    <unzip dest="windows/launcher/" src="windows/launch4j-3.6-win32.zip" overwrite="true"/>
   </target>
 
   <target name="download-launch4j-linux">
-    <get src="http://switch.dl.sourceforge.net/project/launch4j/launch4j-3/3.0.2/launch4j-3.0.2-linux.tgz" dest="windows" usetimestamp="true" skipexisting="true" verbose="true" />
+    <get src="http://switch.dl.sourceforge.net/project/launch4j/launch4j-3/3.6/launch4j-3.6-linux.tgz" dest="windows" usetimestamp="true" skipexisting="true" verbose="true" />
 
     <exec executable="tar" dir="windows/launcher">
       <arg value="-xf"/>
-      <arg value="../launch4j-3.0.2-linux.tgz"/>
+      <arg value="../launch4j-3.6-linux.tgz"/>
     </exec>
   </target>
 

--- a/build/windows/launcher/config.xml
+++ b/build/windows/launcher/config.xml
@@ -32,7 +32,7 @@
     <minVersion>1.6.0</minVersion>
     <maxVersion></maxVersion>
     <jdkPreference>preferJre</jdkPreference>
-    <opt>-Xms128m -Xmx128m</opt>
+    <opt>-Djna.nosys=true -Xms128m -Xmx128m</opt>
   </jre>
   <splash>
     <file>about.bmp</file>

--- a/build/windows/launcher/config_debug.xml
+++ b/build/windows/launcher/config_debug.xml
@@ -32,7 +32,7 @@
     <minVersion>1.6.0</minVersion>
     <maxVersion></maxVersion>
     <jdkPreference>preferJre</jdkPreference>
-    <opt>-Xms128m -Xmx128m</opt>
+    <opt>-Djna.nosys=true -Xms128m -Xmx128m</opt>
   </jre>
   <messages>
     <startupErr>An error occurred while starting the application.</startupErr>


### PR DESCRIPTION
This pull request needs to be tested on affected systems.

From: https://github.com/processing/processing/issues/2239

```
  If there's is some other Java program installed that uses JNA and
  jnidispatch.dll happens to be in the path then JNA in Processing
  will try to load it and probably crash due to some version mismatch.

  The issue can easily be solved by setting jna.nosys to make sure JNA
  will always extract the correct native lib from it's jar and ignore
  any libs in the system path:

    -Djna.nosys=true
```

Fix #1948