### PR TITLE
set correct max size for mega2560 (to address issue #2277)

### DIFF
--- a/hardware/arduino/avr/boards.txt
+++ b/hardware/arduino/avr/boards.txt
@@ -186,7 +186,7 @@ mega.build.board=AVR_MEGA2560
 mega.menu.cpu.atmega2560=ATmega2560 (Mega 2560)
 
 mega.menu.cpu.atmega2560.upload.protocol=wiring
-mega.menu.cpu.atmega2560.upload.maximum_size=258048
+mega.menu.cpu.atmega2560.upload.maximum_size=253952
 mega.menu.cpu.atmega2560.upload.speed=115200
 
 mega.menu.cpu.atmega2560.bootloader.high_fuses=0xD8
@@ -222,7 +222,7 @@ megaADK.pid.1=0x0044
 
 megaADK.upload.tool=avrdude
 megaADK.upload.protocol=wiring
-megaADK.upload.maximum_size=258048
+megaADK.upload.maximum_size=253952
 megaADK.upload.maximum_data_size=8192
 megaADK.upload.speed=115200
 


### PR DESCRIPTION
This should address issue mentioned here
https://github.com/arduino/Arduino/issues/2277

According to available docs and datasheets, the issue raised is valid, and the max size mentioned on boards.txt is 4Kib more than it should have been.

Signed-off-by: Arnav Gupta championswimmer@gmail.com
