### PR TITLE
[Ethernet] bunch of bugfix and improvements

### DIFF
--- a/libraries/Ethernet/src/utility/socket.cpp
+++ b/libraries/Ethernet/src/utility/socket.cpp
@@ -362,7 +362,7 @@ uint16_t recvfrom(SOCKET s, uint8_t *buf, uint16_t len, uint8_t *addr, uint16_t 
 /**
  * @brief	Wait for buffered transmission to complete.
  */
-void flush(SOCKET s) {
+void flush(SOCKET /* s */) {
   // TODO
 }
 

--- a/libraries/Ethernet/src/utility/w5100.cpp
+++ b/libraries/Ethernet/src/utility/w5100.cpp
@@ -17,6 +17,7 @@ W5x00Class W5100;
 
 uint8_t W5x00Class::chipset = W5x00Chipset::W5100;
 uint8_t W5x00Class::sockets = 4;
+uint16_t W5x00Class::CH_BASE = 0;
 
 #define TX_RX_MAX_BUF_SIZE 2048
 #define TX_BUF 0x1100
@@ -79,6 +80,7 @@ void W5x00Class::init(void)
   // The default size for the RX and TX buffers is 2 kB
   if (chipset == W5x00Chipset::W5100) {
     sockets = 4;
+    CH_BASE = 0x0400;
     SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
     writeMR(1<<RST);
     SPI.endTransaction();
@@ -91,6 +93,7 @@ void W5x00Class::init(void)
     }
   } else if (chipset == W5x00Chipset::W5200) {
     sockets = 8;
+    CH_BASE = 0x4000;
     SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
     writeMR(1<<RST);
     SPI.endTransaction();
@@ -101,8 +104,9 @@ void W5x00Class::init(void)
       SBASE[i] = TXBUF_BASE + SSIZE * i;
       RBASE[i] = RXBUF_BASE + RSIZE * i;
     }
-  } else {
+  } else { // W5500
     sockets = 8;
+    CH_BASE = 0x0400;
     SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
     writeMR(1<<RST);
     SPI.endTransaction();

--- a/libraries/Ethernet/src/utility/w5100.cpp
+++ b/libraries/Ethernet/src/utility/w5100.cpp
@@ -76,12 +76,11 @@ void W5x00Class::init(void)
   SPI.endTransaction();
 
   // W5x00 reset
+  // The default size for the RX and TX buffers is 2 kB
   if (chipset == W5x00Chipset::W5100) {
     sockets = 4;
     SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
     writeMR(1<<RST);
-    writeTMSR(0x55);
-    writeRMSR(0x55);
     SPI.endTransaction();
 
     const uint16_t TXBUF_BASE = 0x4000;
@@ -94,10 +93,6 @@ void W5x00Class::init(void)
     sockets = 8;
     SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
     writeMR(1<<RST);
-    for (uint8_t i=0; i<sockets; i++) {
-      writeSnRXBUF_SIZE(i, 2);
-      writeSnTXBUF_SIZE(i, 2);
-    }
     SPI.endTransaction();
 
     const uint16_t TXBUF_BASE = 0x8000;
@@ -110,10 +105,6 @@ void W5x00Class::init(void)
     sockets = 8;
     SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
     writeMR(1<<RST);
-    for (uint8_t i=0; i<sockets; i++) {
-      writeSnRXBUF_SIZE(i, 2);
-      writeSnTXBUF_SIZE(i, 2);
-    }
     SPI.endTransaction();
   }
 }

--- a/libraries/Ethernet/src/utility/w5100.cpp
+++ b/libraries/Ethernet/src/utility/w5100.cpp
@@ -91,7 +91,7 @@ void W5x00Class::init(void)
       RBASE[i] = RXBUF_BASE + RSIZE * i;
     }
   } else if (chipset == W5x00Chipset::W5200) {
-    sockets = 4;
+    sockets = 8;
     SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
     writeMR(1<<RST);
     for (uint8_t i=0; i<sockets; i++) {

--- a/libraries/Ethernet/src/utility/w5100.cpp
+++ b/libraries/Ethernet/src/utility/w5100.cpp
@@ -184,21 +184,21 @@ void W5x00Class::recv_data_processing(SOCKET s, uint8_t *data, uint16_t len, uin
   }
 }
 
-void W5x00Class::read_data(SOCKET s, volatile uint16_t src, volatile uint8_t *dst, uint16_t len)
+void W5x00Class::read_data(SOCKET s, uint16_t src, uint8_t *dst, uint16_t len)
 {
   if (chipset != 5) {
     uint16_t src_mask = src & RMASK;
     uint16_t src_ptr = RBASE[s] + src_mask;
     if ((src_mask + len) > RSIZE) {
       uint16_t size = RSIZE - src_mask;
-      read(src_ptr, 0x00, (uint8_t *)dst, size);
+      read(src_ptr, 0x00, dst, size);
       dst += size;
-      read(RBASE[s], 0x00, (uint8_t *) dst, len - size);
+      read(RBASE[s], 0x00, dst, len - size);
     } else {
-      read(src_ptr, 0x00, (uint8_t *) dst, len);
+      read(src_ptr, 0x00, dst, len);
     }
   } else {
-    read((uint16_t)src , (s<<5) + 0x18, (uint8_t *)dst, len);
+    read(src, (s<<5) + 0x18, dst, len);
   }
 }
 

--- a/libraries/Ethernet/src/utility/w5100.cpp
+++ b/libraries/Ethernet/src/utility/w5100.cpp
@@ -12,11 +12,11 @@
 
 #include "w5100.h"
 
-// W5100 controller instance
-W5100Class W5100;
+// W5x00 controller instance
+W5x00Class W5100;
 
-uint8_t W5100Class::chipset = 0;
-uint8_t W5100Class::sockets = 4;
+uint8_t W5x00Class::chipset = 0;
+uint8_t W5x00Class::sockets = 4;
 
 #define TX_RX_MAX_BUF_SIZE 2048
 #define TX_BUF 0x1100
@@ -25,7 +25,7 @@ uint8_t W5100Class::sockets = 4;
 #define TXBUF_BASE 0x4000
 #define RXBUF_BASE 0x6000
 
-void W5100Class::init(void)
+void W5x00Class::init(void)
 {
   delay(300);
 
@@ -106,7 +106,7 @@ void W5100Class::init(void)
   }
 }
 
-uint16_t W5100Class::getTXFreeSize(SOCKET s)
+uint16_t W5x00Class::getTXFreeSize(SOCKET s)
 {
   uint16_t val=0, val1=0;
   do {
@@ -118,7 +118,7 @@ uint16_t W5100Class::getTXFreeSize(SOCKET s)
   return val;
 }
 
-uint16_t W5100Class::getRXReceivedSize(SOCKET s)
+uint16_t W5x00Class::getRXReceivedSize(SOCKET s)
 {
   uint16_t val=0,val1=0;
   do {
@@ -131,13 +131,13 @@ uint16_t W5100Class::getRXReceivedSize(SOCKET s)
 }
 
 
-void W5100Class::send_data_processing(SOCKET s, const uint8_t *data, uint16_t len)
+void W5x00Class::send_data_processing(SOCKET s, const uint8_t *data, uint16_t len)
 {
   // This is same as having no offset in a call to send_data_processing_offset
   send_data_processing_offset(s, 0, data, len);
 }
 
-void W5100Class::send_data_processing_offset(SOCKET s, uint16_t data_offset, const uint8_t *data, uint16_t len)
+void W5x00Class::send_data_processing_offset(SOCKET s, uint16_t data_offset, const uint8_t *data, uint16_t len)
 {
   uint16_t ptr = readSnTX_WR(s);
   ptr += data_offset;
@@ -165,7 +165,7 @@ void W5100Class::send_data_processing_offset(SOCKET s, uint16_t data_offset, con
 }
 
 
-void W5100Class::recv_data_processing(SOCKET s, uint8_t *data, uint16_t len, uint8_t peek)
+void W5x00Class::recv_data_processing(SOCKET s, uint8_t *data, uint16_t len, uint8_t peek)
 {
   uint16_t ptr = readSnRX_RD(s);
   read_data(s, ptr, data, len);
@@ -176,7 +176,7 @@ void W5100Class::recv_data_processing(SOCKET s, uint8_t *data, uint16_t len, uin
   }
 }
 
-void W5100Class::read_data(SOCKET s, volatile uint16_t src, volatile uint8_t *dst, uint16_t len)
+void W5x00Class::read_data(SOCKET s, volatile uint16_t src, volatile uint8_t *dst, uint16_t len)
 {
   if (chipset == 1) {
     uint16_t src_mask = src & RMASK;
@@ -197,7 +197,7 @@ void W5100Class::read_data(SOCKET s, volatile uint16_t src, volatile uint8_t *ds
 }
 
 
-uint8_t W5100Class::write(uint16_t _addr, uint8_t _cb, uint8_t _data)
+uint8_t W5x00Class::write(uint16_t _addr, uint8_t _cb, uint8_t _data)
 {
 #if !defined(SPI_HAS_EXTENDED_CS_PIN_HANDLING)
   setSS();
@@ -233,7 +233,7 @@ uint8_t W5100Class::write(uint16_t _addr, uint8_t _cb, uint8_t _data)
   return 1;
 }
 
-uint16_t W5100Class::write(uint16_t _addr, uint8_t _cb, const uint8_t *_buf, uint16_t _len)
+uint16_t W5x00Class::write(uint16_t _addr, uint8_t _cb, const uint8_t *_buf, uint16_t _len)
 {
 #if !defined(SPI_HAS_EXTENDED_CS_PIN_HANDLING)
   if (chipset == 1) {
@@ -285,7 +285,7 @@ uint16_t W5100Class::write(uint16_t _addr, uint8_t _cb, const uint8_t *_buf, uin
   return _len;
 }
 
-uint8_t W5100Class::read(uint16_t _addr, uint8_t _cb)
+uint8_t W5x00Class::read(uint16_t _addr, uint8_t _cb)
 {
   uint8_t res;
 #if !defined(SPI_HAS_EXTENDED_CS_PIN_HANDLING)
@@ -322,7 +322,7 @@ uint8_t W5100Class::read(uint16_t _addr, uint8_t _cb)
   return res;
 }
 
-uint16_t W5100Class::read(uint16_t _addr, uint8_t _cb, uint8_t *_buf, uint16_t _len)
+uint16_t W5x00Class::read(uint16_t _addr, uint8_t _cb, uint8_t *_buf, uint16_t _len)
 {
 #if !defined(SPI_HAS_EXTENDED_CS_PIN_HANDLING)
   if (chipset == 1) {
@@ -375,7 +375,7 @@ uint16_t W5100Class::read(uint16_t _addr, uint8_t _cb, uint8_t *_buf, uint16_t _
   return _len;
 }
 
-void W5100Class::execCmdSn(SOCKET s, SockCMD _cmd) {
+void W5x00Class::execCmdSn(SOCKET s, SockCMD _cmd) {
   // Send command to socket
   writeSnCR(s, _cmd);
   // Wait for command to complete

--- a/libraries/Ethernet/src/utility/w5100.cpp
+++ b/libraries/Ethernet/src/utility/w5100.cpp
@@ -35,6 +35,49 @@ void W5100Class::init(void)
   SPI.setClockDivider(ETHERNET_SHIELD_SPI_CS, 21);
   SPI.setDataMode(ETHERNET_SHIELD_SPI_CS, SPI_MODE0);
 #endif
+
+  /*
+   * Runtime detection of Wiznet Chip.
+   * Based on code from: https://github.com/jbkim/Differentiate-WIznet-Chip
+   */
+  uint8_t testW5200[] = { 0x00, 0x1F, 0x00, 0x01, 0x00 };
+  uint8_t testW5500[] = { 0x00, 0x39, 0x00, 0x00 };
+  SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+#if !defined(SPI_HAS_EXTENDED_CS_PIN_HANDLING)
+  // Check for W5200
+  setSS();
+  SPI.transfer(testW5200, 5);
+  resetSS();
+  if (testW5200[4] == 0x03) {
+    chipset = 2;
+  } else {
+    // Check for W5500
+    setSS();
+    SPI.transfer(testW5500, 4);
+    resetSS();
+    if (testW5500[3] == 0x04) {
+      chipset = 5;
+    } else {
+      chipset = 1;
+    }
+  }
+#else
+  // Check for W5200
+  SPI.transfer(ETHERNET_SHIELD_SPI_CS, testW5200, 5);
+  if (testW5200[4] == 0x03) {
+    chipset = 2;
+  } else {
+    // Check for W5500
+    SPI.transfer(ETHERNET_SHIELD_SPI_CS, testW5500, 4);
+    if (testW5500[3] == 0x04) {
+      chipset = 5;
+    } else {
+      chipset = 1;
+    }
+  }
+#endif
+  SPI.endTransaction();
+
   SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
   writeMR(1<<RST);
   writeTMSR(0x55);

--- a/libraries/Ethernet/src/utility/w5100.cpp
+++ b/libraries/Ethernet/src/utility/w5100.cpp
@@ -31,9 +31,6 @@ void W5x00Class::init(void)
   initSS();
 #else
   SPI.begin(ETHERNET_SHIELD_SPI_CS);
-  // Set clock to 4Mhz (W5100 should support up to about 14Mhz)
-  SPI.setClockDivider(ETHERNET_SHIELD_SPI_CS, 21);
-  SPI.setDataMode(ETHERNET_SHIELD_SPI_CS, SPI_MODE0);
 #endif
 
   /*

--- a/libraries/Ethernet/src/utility/w5100.h
+++ b/libraries/Ethernet/src/utility/w5100.h
@@ -338,10 +338,9 @@ private:
   uint16_t RBASE[4]; // Rx buffer base address
 
 private:
+  // W5100 supports up to 14Mhz
 #if !defined(SPI_HAS_EXTENDED_CS_PIN_HANDLING)
-  // Set clock to 4Mhz (W5100 should support up to about 14Mhz)
-  // TODO: set SPI clock to maximum allowed for any chipset
-  #define SPI_ETHERNET_SETTINGS SPISettings(4000000, MSBFIRST, SPI_MODE0)
+  #define SPI_ETHERNET_SETTINGS SPISettings(14000000, MSBFIRST, SPI_MODE0)
   #if defined(__ARDUINO_ARC__)
     inline static void initSS()  { pinMode(10, OUTPUT);    }
     inline static void setSS()   { digitalWrite(10, LOW);  }
@@ -352,7 +351,7 @@ private:
     inline static void resetSS() { *portOutputRegister(digitalPinToPort(ETHERNET_SHIELD_SPI_CS)) |=  digitalPinToBitMask(ETHERNET_SHIELD_SPI_CS); }
   #endif
 #else
-  #define SPI_ETHERNET_SETTINGS ETHERNET_SHIELD_SPI_CS,SPISettings(4000000, MSBFIRST, SPI_MODE0)
+  #define SPI_ETHERNET_SETTINGS ETHERNET_SHIELD_SPI_CS,SPISettings(14000000, MSBFIRST, SPI_MODE0)
   // initSS(), setSS(), resetSS() not needed with EXTENDED_CS_PIN_HANDLING
 #endif
 };

--- a/libraries/Ethernet/src/utility/w5100.h
+++ b/libraries/Ethernet/src/utility/w5100.h
@@ -7,8 +7,8 @@
  * published by the Free Software Foundation.
  */
 
-#ifndef	W5100_H_INCLUDED
-#define	W5100_H_INCLUDED
+#ifndef	W5x00_H_INCLUDED
+#define	W5x00_H_INCLUDED
 
 #include <SPI.h>
 
@@ -125,7 +125,7 @@ public:
   static const uint8_t RAW  = 255;
 };
 
-class W5100Class {
+class W5x00Class {
 
 public:
   void init();
@@ -192,7 +192,7 @@ private:
   static uint8_t chipset;
   static uint8_t sockets;
 
-  // W5100 Registers
+  // W5x00 Registers
   // ---------------
 private:
   static uint8_t write(uint16_t _addr, uint8_t _cb, uint8_t _data);
@@ -252,7 +252,7 @@ public:
 #undef __GP_REGISTER16
 #undef __GP_REGISTER_N
 
-  // W5100 Socket registers
+  // W5x00 Socket registers
   // ----------------------
 private:
   static inline uint8_t readSn(SOCKET _s, uint16_t _addr);
@@ -372,9 +372,9 @@ private:
 #endif
 };
 
-extern W5100Class W5100;
+extern W5x00Class W5100;
 
-uint8_t W5100Class::readSn(SOCKET _s, uint16_t _addr) {
+uint8_t W5x00Class::readSn(SOCKET _s, uint16_t _addr) {
   if (chipset == 1)
     return read(CH_BASE + _s * CH_SIZE + _addr, 0x00);
   if (chipset == 2)
@@ -383,7 +383,7 @@ uint8_t W5100Class::readSn(SOCKET _s, uint16_t _addr) {
     return read(_addr, (_s<<5) + 0x08);
 }
 
-uint8_t W5100Class::writeSn(SOCKET _s, uint16_t _addr, uint8_t _data) {
+uint8_t W5x00Class::writeSn(SOCKET _s, uint16_t _addr, uint8_t _data) {
   if (chipset == 1)
     return write(CH_BASE + _s * CH_SIZE + _addr, 0x00, _data);
   if (chipset == 2)
@@ -392,7 +392,7 @@ uint8_t W5100Class::writeSn(SOCKET _s, uint16_t _addr, uint8_t _data) {
     return write(_addr, (_s<<5) + 0x0C, _data);
 }
 
-uint16_t W5100Class::readSn(SOCKET _s, uint16_t _addr, uint8_t *_buf, uint16_t _len) {
+uint16_t W5x00Class::readSn(SOCKET _s, uint16_t _addr, uint8_t *_buf, uint16_t _len) {
   if (chipset == 1)
     return read(CH_BASE + _s * CH_SIZE + _addr, 0x00, _buf, _len);
   if (chipset == 2)
@@ -401,7 +401,7 @@ uint16_t W5100Class::readSn(SOCKET _s, uint16_t _addr, uint8_t *_buf, uint16_t _
     return read(_addr, (_s<<5) + 0x08, _buf, _len);
 }
 
-uint16_t W5100Class::writeSn(SOCKET _s, uint16_t _addr, uint8_t *_buf, uint16_t _len) {
+uint16_t W5x00Class::writeSn(SOCKET _s, uint16_t _addr, uint8_t *_buf, uint16_t _len) {
   if (chipset == 1)
     return write(CH_BASE + _s * CH_SIZE + _addr, 0x00, _buf, _len);
   if (chipset == 2)
@@ -410,39 +410,39 @@ uint16_t W5100Class::writeSn(SOCKET _s, uint16_t _addr, uint8_t *_buf, uint16_t 
     return write(_addr, (_s<<5) + 0x0C, _buf, _len);
 }
 
-void W5100Class::getGatewayIp(uint8_t *_addr) {
+void W5x00Class::getGatewayIp(uint8_t *_addr) {
   readGAR(_addr);
 }
 
-void W5100Class::setGatewayIp(uint8_t *_addr) {
+void W5x00Class::setGatewayIp(uint8_t *_addr) {
   writeGAR(_addr);
 }
 
-void W5100Class::getSubnetMask(uint8_t *_addr) {
+void W5x00Class::getSubnetMask(uint8_t *_addr) {
   readSUBR(_addr);
 }
 
-void W5100Class::setSubnetMask(uint8_t *_addr) {
+void W5x00Class::setSubnetMask(uint8_t *_addr) {
   writeSUBR(_addr);
 }
 
-void W5100Class::getMACAddress(uint8_t *_addr) {
+void W5x00Class::getMACAddress(uint8_t *_addr) {
   readSHAR(_addr);
 }
 
-void W5100Class::setMACAddress(uint8_t *_addr) {
+void W5x00Class::setMACAddress(uint8_t *_addr) {
   writeSHAR(_addr);
 }
 
-void W5100Class::getIPAddress(uint8_t *_addr) {
+void W5x00Class::getIPAddress(uint8_t *_addr) {
   readSIPR(_addr);
 }
 
-void W5100Class::setIPAddress(uint8_t *_addr) {
+void W5x00Class::setIPAddress(uint8_t *_addr) {
   writeSIPR(_addr);
 }
 
-void W5100Class::setRetransmissionTime(uint16_t _timeout) {
+void W5x00Class::setRetransmissionTime(uint16_t _timeout) {
   if (chipset == 1) {
     writeRTR_W5100(_timeout);
   } else if (chipset == 2) {
@@ -452,7 +452,7 @@ void W5100Class::setRetransmissionTime(uint16_t _timeout) {
   }
 }
 
-void W5100Class::setRetransmissionCount(uint8_t _retry) {
+void W5x00Class::setRetransmissionCount(uint8_t _retry) {
   if (chipset == 1) {
     writeRCR_W5100(_retry);
   } else if (chipset == 2) {

--- a/libraries/Ethernet/src/utility/w5100.h
+++ b/libraries/Ethernet/src/utility/w5100.h
@@ -336,8 +336,8 @@ public:
   static const uint16_t SSIZE = 2048; // Max Tx buffer size
 private:
   static const uint16_t RSIZE = 2048; // Max Rx buffer size
-  uint16_t SBASE[4]; // Tx buffer base address
-  uint16_t RBASE[4]; // Rx buffer base address
+  uint16_t SBASE[8]; // Tx buffer base address
+  uint16_t RBASE[8]; // Rx buffer base address
 
 private:
   // W5100 supports up to 14Mhz

--- a/libraries/Ethernet/src/utility/w5100.h
+++ b/libraries/Ethernet/src/utility/w5100.h
@@ -195,6 +195,8 @@ public:
   uint16_t getTXFreeSize(SOCKET s);
   uint16_t getRXReceivedSize(SOCKET s);
   
+  inline uint8_t getMaxSockets() { return sockets; }
+
 private:
   static uint8_t chipset;
   static uint8_t sockets;

--- a/libraries/Ethernet/src/utility/w5100.h
+++ b/libraries/Ethernet/src/utility/w5100.h
@@ -344,9 +344,9 @@ private:
 #if !defined(SPI_HAS_EXTENDED_CS_PIN_HANDLING)
   #define SPI_ETHERNET_SETTINGS SPISettings(14000000, MSBFIRST, SPI_MODE0)
   #if defined(__ARDUINO_ARC__)
-    inline static void initSS()  { pinMode(10, OUTPUT);    }
-    inline static void setSS()   { digitalWrite(10, LOW);  }
-    inline static void resetSS() { digitalWrite(10, HIGH); }
+    inline static void initSS()  { pinMode(ETHERNET_SHIELD_SPI_CS, OUTPUT);    }
+    inline static void setSS()   { digitalWrite(ETHERNET_SHIELD_SPI_CS, LOW);  }
+    inline static void resetSS() { digitalWrite(ETHERNET_SHIELD_SPI_CS, HIGH); }
   #else
     inline static void initSS()  { pinMode(ETHERNET_SHIELD_SPI_CS, OUTPUT); }
     inline static void setSS()   { *portOutputRegister(digitalPinToPort(ETHERNET_SHIELD_SPI_CS)) &= ~digitalPinToBitMask(ETHERNET_SHIELD_SPI_CS); }

--- a/libraries/Ethernet/src/utility/w5100.h
+++ b/libraries/Ethernet/src/utility/w5100.h
@@ -342,38 +342,14 @@ private:
   // Set clock to 4Mhz (W5100 should support up to about 14Mhz)
   // TODO: set SPI clock to maximum allowed for any chipset
   #define SPI_ETHERNET_SETTINGS SPISettings(4000000, MSBFIRST, SPI_MODE0)
-  #if defined(ARDUINO_ARCH_AVR)
-    #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
-      inline static void initSS()    { DDRB  |=  _BV(4); };
-      inline static void setSS()     { PORTB &= ~_BV(4); };
-      inline static void resetSS()   { PORTB |=  _BV(4); };
-    #elif defined(__AVR_ATmega32U4__)
-      inline static void initSS()    { DDRB  |=  _BV(6); };
-      inline static void setSS()     { PORTB &= ~_BV(6); };
-      inline static void resetSS()   { PORTB |=  _BV(6); };
-    #elif defined(__AVR_AT90USB1286__) || defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB162__)
-      inline static void initSS()    { DDRB  |=  _BV(0); };
-      inline static void setSS()     { PORTB &= ~_BV(0); };
-      inline static void resetSS()   { PORTB |=  _BV(0); };
-    #else
-      inline static void initSS()    { DDRB  |=  _BV(2); };
-      inline static void setSS()     { PORTB &= ~_BV(2); };
-      inline static void resetSS()   { PORTB |=  _BV(2); };
-    #endif
-  #elif defined(__ARDUINO_ARC__)
-	inline static void initSS() { pinMode(10, OUTPUT); };
-	inline static void setSS() { digitalWrite(10, LOW); };
-	inline static void resetSS() { digitalWrite(10, HIGH); };
+  #if defined(__ARDUINO_ARC__)
+    inline static void initSS()  { pinMode(10, OUTPUT);    }
+    inline static void setSS()   { digitalWrite(10, LOW);  }
+    inline static void resetSS() { digitalWrite(10, HIGH); }
   #else
-    inline static void initSS() {
-      *portModeRegister(digitalPinToPort(ETHERNET_SHIELD_SPI_CS)) |= digitalPinToBitMask(ETHERNET_SHIELD_SPI_CS);
-    }
-    inline static void setSS()   {
-      *portOutputRegister(digitalPinToPort(ETHERNET_SHIELD_SPI_CS)) &= ~digitalPinToBitMask(ETHERNET_SHIELD_SPI_CS);
-    }
-    inline static void resetSS() {
-      *portOutputRegister(digitalPinToPort(ETHERNET_SHIELD_SPI_CS)) |= digitalPinToBitMask(ETHERNET_SHIELD_SPI_CS);
-    }
+    inline static void initSS()  { pinMode(ETHERNET_SHIELD_SPI_CS, OUTPUT); }
+    inline static void setSS()   { *portOutputRegister(digitalPinToPort(ETHERNET_SHIELD_SPI_CS)) &= ~digitalPinToBitMask(ETHERNET_SHIELD_SPI_CS); }
+    inline static void resetSS() { *portOutputRegister(digitalPinToPort(ETHERNET_SHIELD_SPI_CS)) |=  digitalPinToBitMask(ETHERNET_SHIELD_SPI_CS); }
   #endif
 #else
   #define SPI_ETHERNET_SETTINGS ETHERNET_SHIELD_SPI_CS,SPISettings(4000000, MSBFIRST, SPI_MODE0)

--- a/libraries/Ethernet/src/utility/w5100.h
+++ b/libraries/Ethernet/src/utility/w5100.h
@@ -190,6 +190,8 @@ public:
   uint16_t getTXFreeSize(SOCKET s);
   uint16_t getRXReceivedSize(SOCKET s);
   
+private:
+  static uint8_t chipset;
 
   // W5100 Registers
   // ---------------

--- a/libraries/Ethernet/src/utility/w5100.h
+++ b/libraries/Ethernet/src/utility/w5100.h
@@ -226,27 +226,27 @@ private:
   }
 
 public:
-  __GP_REGISTER8 (MR,            0x0000);    // Mode
-  __GP_REGISTER_N(GAR,           0x0001, 4); // Gateway IP address
-  __GP_REGISTER_N(SUBR,          0x0005, 4); // Subnet mask address
-  __GP_REGISTER_N(SHAR,          0x0009, 6); // Source MAC address
-  __GP_REGISTER_N(SIPR,          0x000F, 4); // Source IP address
-  __GP_REGISTER8 (IR,            0x0015);    // Interrupt
-  __GP_REGISTER8 (IMR,           0x0016);    // Interrupt Mask
-  __GP_REGISTER16(RTR_W5100,     0x0017);    // Timeout address
-  __GP_REGISTER16(RTR_W5500,     0x0019);    // Timeout address
-  __GP_REGISTER8 (RCR_W5100,     0x0019);    // Retry count
-  __GP_REGISTER8 (RCR_W5500,     0x001B);    // Retry count
-  __GP_REGISTER8 (RMSR,          0x001A);    // Receive memory size
-  __GP_REGISTER8 (TMSR,          0x001B);    // Transmit memory size
-  __GP_REGISTER8 (PATR,          0x001C);    // Authentication type address in PPPoE mode
-  __GP_REGISTER8 (PTIMER,        0x0028);    // PPP LCP Request Timer
-  __GP_REGISTER8 (PMAGIC,        0x0029);    // PPP LCP Magic Number
-  __GP_REGISTER_N(UIPR_W5100,    0x002A, 4); // Unreachable IP address in UDP mode
-  __GP_REGISTER_N(UIPR_W5500,    0x0028, 4); // Unreachable IP address in UDP mode
-  __GP_REGISTER16(UPORT_W5100,   0x002E);    // Unreachable Port address in UDP mode
-  __GP_REGISTER16(UPORT_W5500,   0x002C);    // Unreachable Port address in UDP mode
-  __GP_REGISTER8 (PHYCFGR_W5500, 0x002E);    // PHY Configuration register, default value: 0b 1011 1xxx
+  __GP_REGISTER8 (MR,                0x0000);    // Mode
+  __GP_REGISTER_N(GAR,               0x0001, 4); // Gateway IP address
+  __GP_REGISTER_N(SUBR,              0x0005, 4); // Subnet mask address
+  __GP_REGISTER_N(SHAR,              0x0009, 6); // Source MAC address
+  __GP_REGISTER_N(SIPR,              0x000F, 4); // Source IP address
+  __GP_REGISTER8 (IR,                0x0015);    // Interrupt
+  __GP_REGISTER8 (IMR,               0x0016);    // Interrupt Mask
+  __GP_REGISTER16(RTR_W5100_W5200,   0x0017);    // Timeout address
+  __GP_REGISTER16(RTR_W5500,         0x0019);    // Timeout address
+  __GP_REGISTER8 (RCR_W5100_W5200,   0x0019);    // Retry count
+  __GP_REGISTER8 (RCR_W5500,         0x001B);    // Retry count
+  __GP_REGISTER8 (RMSR,              0x001A);    // Receive memory size
+  __GP_REGISTER8 (TMSR,              0x001B);    // Transmit memory size
+  __GP_REGISTER8 (PATR,              0x001C);    // Authentication type address in PPPoE mode
+  __GP_REGISTER8 (PTIMER,            0x0028);    // PPP LCP Request Timer
+  __GP_REGISTER8 (PMAGIC,            0x0029);    // PPP LCP Magic Number
+  __GP_REGISTER_N(UIPR_W5100_W5200,  0x002A, 4); // Unreachable IP address in UDP mode
+  __GP_REGISTER_N(UIPR_W5500,        0x0028, 4); // Unreachable IP address in UDP mode
+  __GP_REGISTER16(UPORT_W5100_W5200, 0x002E);    // Unreachable Port address in UDP mode
+  __GP_REGISTER16(UPORT_W5500,       0x002C);    // Unreachable Port address in UDP mode
+  __GP_REGISTER8 (PHYCFGR_W5500,     0x002E);    // PHY Configuration register, default value: 0b 1011 1xxx
 
 #undef __GP_REGISTER8
 #undef __GP_REGISTER16
@@ -375,38 +375,30 @@ private:
 extern W5x00Class W5100;
 
 uint8_t W5x00Class::readSn(SOCKET _s, uint16_t _addr) {
-  if (chipset == 1)
+  if (chipset != 5)
     return read(CH_BASE + _s * CH_SIZE + _addr, 0x00);
-  if (chipset == 2)
-    return 0; // XXX: TODO
-  if (chipset == 5)
+  else
     return read(_addr, (_s<<5) + 0x08);
 }
 
 uint8_t W5x00Class::writeSn(SOCKET _s, uint16_t _addr, uint8_t _data) {
-  if (chipset == 1)
+  if (chipset != 5)
     return write(CH_BASE + _s * CH_SIZE + _addr, 0x00, _data);
-  if (chipset == 2)
-    return 0; // XXX: TODO
-  if (chipset == 5)
+  else
     return write(_addr, (_s<<5) + 0x0C, _data);
 }
 
 uint16_t W5x00Class::readSn(SOCKET _s, uint16_t _addr, uint8_t *_buf, uint16_t _len) {
-  if (chipset == 1)
+  if (chipset != 5)
     return read(CH_BASE + _s * CH_SIZE + _addr, 0x00, _buf, _len);
-  if (chipset == 2)
-    return 0; // XXX: TODO
-  if (chipset == 5)
+  else
     return read(_addr, (_s<<5) + 0x08, _buf, _len);
 }
 
 uint16_t W5x00Class::writeSn(SOCKET _s, uint16_t _addr, uint8_t *_buf, uint16_t _len) {
-  if (chipset == 1)
+  if (chipset != 5)
     return write(CH_BASE + _s * CH_SIZE + _addr, 0x00, _buf, _len);
-  if (chipset == 2)
-    return 0; // XXX: TODO
-  if (chipset == 5)
+  else
     return write(_addr, (_s<<5) + 0x0C, _buf, _len);
 }
 
@@ -443,23 +435,17 @@ void W5x00Class::setIPAddress(uint8_t *_addr) {
 }
 
 void W5x00Class::setRetransmissionTime(uint16_t _timeout) {
-  if (chipset == 1) {
-    writeRTR_W5100(_timeout);
-  } else if (chipset == 2) {
-    // XXX: TODO
-  } else {
+  if (chipset != 5)
+    writeRTR_W5100_W5200(_timeout);
+  else
     writeRTR_W5500(_timeout);
-  }
 }
 
 void W5x00Class::setRetransmissionCount(uint8_t _retry) {
-  if (chipset == 1) {
-    writeRCR_W5100(_retry);
-  } else if (chipset == 2) {
-    // XXX: TODO
-  } else {
+  if (chipset != 5)
+    writeRCR_W5100_W5200(_retry);
+  else
     writeRCR_W5500(_retry);
-  }
 }
 
 #endif

--- a/libraries/Ethernet/src/utility/w5100.h
+++ b/libraries/Ethernet/src/utility/w5100.h
@@ -125,6 +125,13 @@ public:
   static const uint8_t RAW  = 255;
 };
 
+class W5x00Chipset {
+public:
+  static const uint8_t W5100 = 0;
+  static const uint8_t W5200 = 1;
+  static const uint8_t W5500 = 2;
+};
+
 class W5x00Class {
 
 public:
@@ -377,28 +384,28 @@ private:
 extern W5x00Class W5100;
 
 uint8_t W5x00Class::readSn(SOCKET _s, uint16_t _addr) {
-  if (chipset != 5)
+  if (chipset != W5x00Chipset::W5500)
     return read(CH_BASE + _s * CH_SIZE + _addr, 0x00);
   else
     return read(_addr, (_s<<5) + 0x08);
 }
 
 uint8_t W5x00Class::writeSn(SOCKET _s, uint16_t _addr, uint8_t _data) {
-  if (chipset != 5)
+  if (chipset != W5x00Chipset::W5500)
     return write(CH_BASE + _s * CH_SIZE + _addr, 0x00, _data);
   else
     return write(_addr, (_s<<5) + 0x0C, _data);
 }
 
 uint16_t W5x00Class::readSn(SOCKET _s, uint16_t _addr, uint8_t *_buf, uint16_t _len) {
-  if (chipset != 5)
+  if (chipset != W5x00Chipset::W5500)
     return read(CH_BASE + _s * CH_SIZE + _addr, 0x00, _buf, _len);
   else
     return read(_addr, (_s<<5) + 0x08, _buf, _len);
 }
 
 uint16_t W5x00Class::writeSn(SOCKET _s, uint16_t _addr, uint8_t *_buf, uint16_t _len) {
-  if (chipset != 5)
+  if (chipset != W5x00Chipset::W5500)
     return write(CH_BASE + _s * CH_SIZE + _addr, 0x00, _buf, _len);
   else
     return write(_addr, (_s<<5) + 0x0C, _buf, _len);
@@ -437,14 +444,14 @@ void W5x00Class::setIPAddress(uint8_t *_addr) {
 }
 
 void W5x00Class::setRetransmissionTime(uint16_t _timeout) {
-  if (chipset != 5)
+  if (chipset != W5x00Chipset::W5500)
     writeRTR_W5100_W5200(_timeout);
   else
     writeRTR_W5500(_timeout);
 }
 
 void W5x00Class::setRetransmissionCount(uint8_t _retry) {
-  if (chipset != 5)
+  if (chipset != W5x00Chipset::W5500)
     writeRCR_W5100_W5200(_retry);
   else
     writeRCR_W5500(_retry);

--- a/libraries/Ethernet/src/utility/w5100.h
+++ b/libraries/Ethernet/src/utility/w5100.h
@@ -137,7 +137,7 @@ public:
    * the data from Receive buffer. Here also take care of the condition while it exceed
    * the Rx memory uper-bound of socket.
    */
-  void read_data(SOCKET s, volatile uint16_t src, volatile uint8_t * dst, uint16_t len);
+  void read_data(SOCKET s, uint16_t src, uint8_t *dst, uint16_t len);
   
   /**
    * @brief	 This function is being called by send() and sendto() function also. 
@@ -146,6 +146,7 @@ public:
    * register. User should read upper byte first and lower byte later to get proper value.
    */
   void send_data_processing(SOCKET s, const uint8_t *data, uint16_t len);
+
   /**
    * @brief A copy of send_data_processing that uses the provided ptr for the
    *        write offset.  Only needed for the "streaming" UDP API, where
@@ -156,7 +157,6 @@ public:
    *        in from TX_WR
    * @return New value for ptr, to be used in the next call
    */
-// FIXME Update documentation
   void send_data_processing_offset(SOCKET s, uint16_t data_offset, const uint8_t *data, uint16_t len);
 
   /**

--- a/libraries/Ethernet/src/utility/w5100.h
+++ b/libraries/Ethernet/src/utility/w5100.h
@@ -269,7 +269,7 @@ private:
   static inline uint16_t readSn(SOCKET _s, uint16_t _addr, uint8_t *_buf, uint16_t len);
   static inline uint16_t writeSn(SOCKET _s, uint16_t _addr, uint8_t *_buf, uint16_t len);
 
-  static const uint16_t CH_BASE = 0x0400;
+  static uint16_t CH_BASE;
   static const uint16_t CH_SIZE = 0x0100;
 
 #define __SOCKET_REGISTER8(name, address)                    \

--- a/libraries/Ethernet/src/utility/w5100.h
+++ b/libraries/Ethernet/src/utility/w5100.h
@@ -332,6 +332,8 @@ private:
 
 private:
 #if !defined(SPI_HAS_EXTENDED_CS_PIN_HANDLING)
+  // Set clock to 4Mhz (W5100 should support up to about 14Mhz)
+  // TODO: set SPI clock to maximum allowed for any chipset
   #define SPI_ETHERNET_SETTINGS SPISettings(4000000, MSBFIRST, SPI_MODE0)
   #if defined(ARDUINO_ARCH_AVR)
     #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)


### PR DESCRIPTION
Version 1.1 of the Ethernet library brings the following improvements:
- support for W5500 and W5200 Wiznet chipsets
- automatic detection of the Wiznet chipset
- SPI speed set to 14MHz, maximum allowed by the W5100 chipset
- generalized SPI_CS pin handling functions
- added getMaxSockets() method
- improved 3rd party compatibility using the SPI Extended API as a criterion of choice 
- removed redundant configurations and useless variable modifiers 
