### PR TITLE
Fix typo in KeyboardLogout.ino

### DIFF
--- a/build/shared/examples/09.USB/Keyboard/KeyboardLogout/KeyboardLogout.ino
+++ b/build/shared/examples/09.USB/Keyboard/KeyboardLogout/KeyboardLogout.ino
@@ -65,7 +65,7 @@ void loop() {
     Keyboard.press(KEY_DELETE);
     delay(100);
     Keyboard.releaseAll();
-    //ALT-s:
+    //ALT-l:
     delay(2000);
     Keyboard.press(KEY_LEFT_ALT);
     Keyboard.press('l');


### PR DESCRIPTION
Comment says ALT+s, code says ALT+l. This remedies that difference.
