### PR TITLE
Enable Keyboard library to send key scancodes.

### DIFF
--- a/hardware/arduino/avr/cores/arduino/HID.cpp
+++ b/hardware/arduino/avr/cores/arduino/HID.cpp
@@ -494,6 +494,61 @@ size_t Keyboard_::release(uint8_t k)
 	return 1;
 }
 
+// press() adds the specified key scancode
+// to the persistent key report and sends the report.  Because of the way
+// USB HID works, the host acts like the key remains pressed until we
+// call release(), releaseAll(), or otherwise clear the report and resend.
+size_t Keyboard_::press_sc(uint8_t k)
+{
+	uint8_t i;
+
+	if (k >= 224 && k <= 231) {
+		_keyReport.modifiers |= (1 << (k - 224));
+	}
+	// Add k to the key report only if it's not already present
+	// and if there is an empty slot.
+	else if (_keyReport.keys[0] != k && _keyReport.keys[1] != k &&
+		_keyReport.keys[2] != k && _keyReport.keys[3] != k &&
+		_keyReport.keys[4] != k && _keyReport.keys[5] != k) {
+
+		for (i=0; i<6; i++) {
+			if (_keyReport.keys[i] == 0x00) {
+				_keyReport.keys[i] = k;
+				break;
+			}
+		}
+		if (i == 6) {
+			setWriteError();
+			return 0;
+		}
+	}
+	sendReport(&_keyReport);
+	return 1;
+}
+
+// release() takes the specified key out of the persistent key report and
+// sends the report.  This tells the OS the key is no longer pressed and that
+// it shouldn't be repeated any more.
+size_t Keyboard_::release_sc(uint8_t k)
+{
+	uint8_t i;
+
+	if (k >= 224 && k <= 231) {
+		_keyReport.modifiers &= ~(1 << (k - 224));
+	}
+	// Test the key report to see if k is present.  Clear it if it exists.
+	// Check all positions in case the key is present more than once (which it shouldn't be)
+	else {
+		for (i=0; i<6; i++) {
+			if (0 != k && _keyReport.keys[i] == k) {
+				_keyReport.keys[i] = 0x00;
+			}
+		}
+	}
+	sendReport(&_keyReport);
+	return 1;
+}
+
 void Keyboard_::releaseAll(void)
 {
 	_keyReport.keys[0] = 0;

--- a/hardware/arduino/avr/cores/arduino/USBAPI.h
+++ b/hardware/arduino/avr/cores/arduino/USBAPI.h
@@ -179,6 +179,8 @@ public:
 	virtual size_t write(uint8_t k);
 	virtual size_t press(uint8_t k);
 	virtual size_t release(uint8_t k);
+	virtual size_t press_sc(uint8_t k);
+	virtual size_t release_sc(uint8_t k);
 	virtual void releaseAll(void);
 };
 extern Keyboard_ Keyboard;


### PR DESCRIPTION
This gives more flexibility to the library and allows the development of keyboard driver.