### PR TITLE
Added close method to PImage

### DIFF
--- a/libraries/TFT/src/utility/PImage.h
+++ b/libraries/TFT/src/utility/PImage.h
@@ -23,6 +23,7 @@ public:
   
   static PImage loadImage(const char * fileName);
   
+  void close() { _bmpFile.close(); }
   
   bool isValid() { return _valid; }
   


### PR DESCRIPTION
Now it is possible to close the image file descriptor after using it, this avoid memory leak. Closes #2311 
