### PR TITLE
Move the flush method from Stream to Print

### DIFF
--- a/hardware/arduino/avr/cores/arduino/Print.h
+++ b/hardware/arduino/avr/cores/arduino/Print.h
@@ -79,6 +79,8 @@ class Print
     size_t println(double, int = 2);
     size_t println(const Printable&);
     size_t println(void);
+
+    virtual void flush() { /* Empty implementation for backward compatibility */ }
 };
 
 #endif

--- a/hardware/arduino/avr/cores/arduino/Stream.h
+++ b/hardware/arduino/avr/cores/arduino/Stream.h
@@ -48,7 +48,6 @@ class Stream : public Print
     virtual int available() = 0;
     virtual int read() = 0;
     virtual int peek() = 0;
-    virtual void flush() = 0;
 
     Stream() {_timeout=1000;}
 

--- a/hardware/arduino/sam/cores/arduino/Print.h
+++ b/hardware/arduino/sam/cores/arduino/Print.h
@@ -79,6 +79,8 @@ class Print
     size_t println(double, int = 2);
     size_t println(const Printable&);
     size_t println(void);
+
+    virtual void flush() { /* Empty implementation for backward compatibility */ }
 };
 
 #endif

--- a/hardware/arduino/sam/cores/arduino/Stream.h
+++ b/hardware/arduino/sam/cores/arduino/Stream.h
@@ -48,7 +48,6 @@ class Stream : public Print
     virtual int available() = 0;
     virtual int read() = 0;
     virtual int peek() = 0;
-    virtual void flush() = 0;
 
     Stream() {_timeout=1000;}
 


### PR DESCRIPTION
This method originally flushed pending input bytes, which makes sense in
Stream. At some point it was changed to flush output bytes instead, but
it was never moved to Print to reflect this.

Since Stream inherits from Print, this should not really affect any
users of the Stream or Print classes. However to prevent problems with
existing implementations of the Print class that do not provide a
flush() implementation, a default implementation is provided. We should
probably remove this at some point in the future, though.
