### PR TITLE
Fixed parsing of dependency files (.d) to improve sketch build speed

### DIFF
--- a/app/src/processing/app/debug/Compiler.java
+++ b/app/src/processing/app/debug/Compiler.java
@@ -275,6 +275,23 @@ public class Compiler implements MessageConsumer {
     return objectPaths;
   }
 
+  /**
+   * Strip escape sequences used in makefile dependency files (.d)
+   * https://github.com/arduino/Arduino/issues/2255#issuecomment-57645845
+   *
+   * @param dep
+   * @return
+   */
+  protected static String unescapeDepFile(String line) {
+    // Replaces: "\\" -> "\"
+    // Replaces: "\ " -> " "
+    // Replaces: "\#" -> "#"
+    line = line.replaceAll("\\\\([ #\\\\])", "$1");
+    // Replaces: "$$" -> "$"
+    line = line.replace("$$", "$");
+    return line;
+  }
+
   private boolean isAlreadyCompiled(File src, File obj, File dep, Map<String, String> prefs) {
     boolean ret=true;
     try {
@@ -293,9 +310,7 @@ public class Compiler implements MessageConsumer {
           line = line.substring(0, line.length() - 1);
         }
         line = line.trim();
-        // Strip backslash escape sequences. This replaces \\ with \ and
-        // removes all other backslashes
-        line = line.replaceAll("\\\\(.)", "$1");
+        line = unescapeDepFile(line);
         if (line.length() == 0) continue; // ignore blank lines
         if (need_obj_parse) {
           // line is supposed to be the object file - make sure it really is!

--- a/app/test/processing/app/debug/CompilerTest.java
+++ b/app/test/processing/app/debug/CompilerTest.java
@@ -1,0 +1,22 @@
+package processing.app.debug;
+
+import static org.junit.Assert.assertEquals;
+import static processing.app.debug.Compiler.unescapeDepFile;
+
+import org.junit.Test;
+
+import processing.app.AbstractWithPreferencesTest;
+
+public class CompilerTest extends AbstractWithPreferencesTest {
+
+  @Test
+  public void makeDepUnescapeTest() throws Exception {
+    assertEquals("C:\\Arduino\\hardware\\arduino\\avr\\cores\\arduino\\Stream.cpp",
+                 unescapeDepFile("C:\\Arduino\\hardware\\arduino\\avr\\cores\\arduino\\Stream.cpp"));
+    assertEquals("C:\\Arduino 1.5.3\\hardware\\arduino\\avr\\cores\\arduino\\Stream.cpp",
+                 unescapeDepFile("C:\\Arduino\\ 1.5.3\\hardware\\arduino\\avr\\cores\\arduino\\Stream.cpp"));
+    assertEquals("C:\\Ard$ui#\\\\ no 1.5.3\\hardware\\arduino\\avr\\cores\\arduino\\Stream.cpp",
+                 unescapeDepFile("C:\\Ard$$ui\\#\\\\\\\\\\ no 1.5.3\\hardware\\arduino\\avr\\cores\\arduino\\Stream.cpp"));
+  }
+
+}


### PR DESCRIPTION
Tested on Windows, this should fix issue #2255.
To be tested on Linux and Mac.

/cc @matthijskooijman 
