### PR TITLE
Added multi address slave

### DIFF
--- a/hardware/arduino/avr/libraries/Wire/Wire.cpp
+++ b/hardware/arduino/avr/libraries/Wire/Wire.cpp
@@ -17,6 +17,8 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  
   Modified 2012 by Todd Krein (todd@krein.org) to implement repeated starts
+  Modified 2014 by Nicola Corna (nicola@corna.info)
+    Moved pullups enable from twi.c to Wire.cpp
 */
 
 extern "C" {
@@ -27,6 +29,8 @@ extern "C" {
 }
 
 #include "Wire.h"
+#include "Arduino.h" // for digitalWrite
+#include "pins_arduino.h"
 
 // Initialize Class Variables //////////////////////////////////////////////////
 
@@ -59,6 +63,10 @@ void TwoWire::begin(void)
   txBufferIndex = 0;
   txBufferLength = 0;
 
+  // activate internal pullups for twi.
+  digitalWrite(SDA, 1);
+  digitalWrite(SCL, 1);
+  
   twi_init();
 }
 

--- a/hardware/arduino/avr/libraries/Wire/Wire.cpp
+++ b/hardware/arduino/avr/libraries/Wire/Wire.cpp
@@ -19,6 +19,7 @@
   Modified 2012 by Todd Krein (todd@krein.org) to implement repeated starts
   Modified 2014 by Nicola Corna (nicola@corna.info)
     Moved pullups enable from twi.c to Wire.cpp
+    Added multi address slave
 */
 
 extern "C" {
@@ -81,6 +82,32 @@ void TwoWire::begin(uint8_t address)
 void TwoWire::begin(int address)
 {
   begin((uint8_t)address);
+}
+
+void TwoWire::begin(uint8_t address, uint8_t mask)
+{
+#ifdef TWAMR
+  twi_setAddressAndMask(address, mask);
+#else
+  twi_setAddress(address);      //Just to show the function warning only once
+#endif
+  twi_attachSlaveTxEvent(onRequestService);
+  twi_attachSlaveRxEvent(onReceiveService);
+  begin();
+}
+
+void TwoWire::begin(int address, int mask)
+{
+#ifdef TWAMR
+  begin((uint8_t)address, (uint8_t)mask);
+#else
+  begin((uint8_t)address);            //Just to show the function warning only once
+#endif
+}
+
+uint8_t TwoWire::slaveAddress()
+{
+  return twi_slaveAddress();
 }
 
 void TwoWire::setClock(uint32_t frequency)

--- a/hardware/arduino/avr/libraries/Wire/Wire.h
+++ b/hardware/arduino/avr/libraries/Wire/Wire.h
@@ -17,6 +17,8 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
   Modified 2012 by Todd Krein (todd@krein.org) to implement repeated starts
+  Modified 2014 by Nicola Corna (nicola@corna.info)
+    Added multi address slave
 */
 
 #ifndef TwoWire_h
@@ -49,6 +51,14 @@ class TwoWire : public Stream
     void begin();
     void begin(uint8_t);
     void begin(int);
+#ifdef TWAMR
+    void begin(uint8_t, uint8_t);
+    void begin(int, int);
+#else
+    void begin(uint8_t, uint8_t) __attribute__((warning("I2C address masking is unsupported on this microcontroller. Mask 0x00 will be used.")));
+    void begin(int, int) __attribute__((warning("I2C address masking is unsupported on this microcontroller. Mask 0x00 will be used.")));
+#endif
+    uint8_t slaveAddress();
     void setClock(uint32_t);
     void beginTransmission(uint8_t);
     void beginTransmission(int);

--- a/hardware/arduino/avr/libraries/Wire/keywords.txt
+++ b/hardware/arduino/avr/libraries/Wire/keywords.txt
@@ -11,6 +11,7 @@
 #######################################
 
 begin	KEYWORD2
+slaveAddress	KEYWORD2
 setClock	KEYWORD2
 beginTransmission	KEYWORD2
 endTransmission	KEYWORD2

--- a/hardware/arduino/avr/libraries/Wire/utility/twi.c
+++ b/hardware/arduino/avr/libraries/Wire/utility/twi.c
@@ -17,15 +17,17 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
   Modified 2012 by Todd Krein (todd@krein.org) to implement repeated starts
+  Modified 2014 by Nicola Corna (nicola@corna.info)
+    Moved pullups enable from twi.c to Wire.cpp
 */
 
 #include <math.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <inttypes.h>
 #include <avr/io.h>
 #include <avr/interrupt.h>
 #include <compat/twi.h>
-#include "Arduino.h" // for digitalWrite
 
 #ifndef cbi
 #define cbi(sfr, bit) (_SFR_BYTE(sfr) &= ~_BV(bit))
@@ -35,7 +37,6 @@
 #define sbi(sfr, bit) (_SFR_BYTE(sfr) |= _BV(bit))
 #endif
 
-#include "pins_arduino.h"
 #include "twi.h"
 
 static volatile uint8_t twi_state;
@@ -71,10 +72,6 @@ void twi_init(void)
   twi_state = TWI_READY;
   twi_sendStop = true;		// default value
   twi_inRepStart = false;
-  
-  // activate internal pullups for twi.
-  digitalWrite(SDA, 1);
-  digitalWrite(SCL, 1);
 
   // initialize twi prescaler and bit rate
   cbi(TWSR, TWPS0);

--- a/hardware/arduino/avr/libraries/Wire/utility/twi.c
+++ b/hardware/arduino/avr/libraries/Wire/utility/twi.c
@@ -19,6 +19,7 @@
   Modified 2012 by Todd Krein (todd@krein.org) to implement repeated starts
   Modified 2014 by Nicola Corna (nicola@corna.info)
     Moved pullups enable from twi.c to Wire.cpp
+    Updated deprecated include <compat/twi.c>
 */
 
 #include <math.h>
@@ -27,7 +28,7 @@
 #include <inttypes.h>
 #include <avr/io.h>
 #include <avr/interrupt.h>
-#include <compat/twi.h>
+#include <util/twi.h>
 
 #ifndef cbi
 #define cbi(sfr, bit) (_SFR_BYTE(sfr) &= ~_BV(bit))

--- a/hardware/arduino/avr/libraries/Wire/utility/twi.c
+++ b/hardware/arduino/avr/libraries/Wire/utility/twi.c
@@ -20,13 +20,13 @@
   Modified 2014 by Nicola Corna (nicola@corna.info)
     Moved pullups enable from twi.c to Wire.cpp
     Updated deprecated include <compat/twi.c>
+    Added multi address slave
 */
 
 #include <math.h>
 #include <stdlib.h>
 #include <stdbool.h>
 #include <inttypes.h>
-#include <avr/io.h>
 #include <avr/interrupt.h>
 #include <util/twi.h>
 
@@ -61,6 +61,10 @@ static volatile uint8_t twi_rxBufferIndex;
 
 static volatile uint8_t twi_error;
 
+#ifdef TWAMR
+static volatile uint8_t twi_lastSlaveAddress;
+#endif
+
 /* 
  * Function twi_init
  * Desc     readys twi pins and sets twi bitrate
@@ -86,11 +90,16 @@ void twi_init(void)
 
   // enable twi module, acks, and twi interrupt
   TWCR = _BV(TWEN) | _BV(TWIE) | _BV(TWEA);
+  
+#ifdef TWAMR
+  // initialize to 0
+  twi_lastSlaveAddress = 0x00;
+#endif
 }
 
 /* 
- * Function twi_slaveInit
- * Desc     sets slave address and enables interrupt
+ * Function twi_setAddress
+ * Desc     set the slave address
  * Input    none
  * Output   none
  */
@@ -98,6 +107,40 @@ void twi_setAddress(uint8_t address)
 {
   // set twi slave address (skip over TWGCE bit)
   TWAR = address << 1;
+}
+
+/* 
+ * Function twi_setAddressAndMask
+ * Desc     sets slave address and slave address mask
+ * Input    address: slave address
+ * 	    mask: slave address mask
+ * Output   none
+ */
+void twi_setAddressAndMask(uint8_t address, uint8_t mask)
+{
+  // set twi slave address (skip over TWGCE bit)
+  TWAR = address << 1;
+#ifdef TWAMR
+  //set twi slave address mask
+  TWAMR = mask << 1;
+#endif
+}
+
+/* 
+ * Function twi_slaveAddress
+ * Desc     return the last called slave address
+ * Input    none
+ * Output   the slave address
+ */
+uint8_t twi_slaveAddress(void)
+{
+  //If address masking is not supported, returns the only address
+  //supported (saved in TWAR)
+#ifdef TWAMR
+  return twi_lastSlaveAddress;
+#else
+  return TWAR >> 1;
+#endif
 }
 
 /* 
@@ -441,6 +484,10 @@ ISR(TWI_vect)
     case TW_SR_ARB_LOST_GCALL_ACK: // lost arbitration, returned ack
       // enter slave receiver mode
       twi_state = TWI_SRX;
+#ifdef TWAMR
+      // save the current TWDR (slave address)
+      twi_lastSlaveAddress = TWDR >> 1;
+#endif
       // indicate that rx buffer can be overwritten and ack
       twi_rxBufferIndex = 0;
       twi_reply(1);
@@ -482,6 +529,10 @@ ISR(TWI_vect)
     case TW_ST_ARB_LOST_SLA_ACK: // arbitration lost, returned ack
       // enter slave transmitter mode
       twi_state = TWI_STX;
+#ifdef TWAMR
+      // save the current TWDR (slave address)
+      twi_lastSlaveAddress = TWDR >> 1;
+#endif
       // ready the tx buffer index for iteration
       twi_txBufferIndex = 0;
       // set tx buffer length to be zero, to verify if user changes it

--- a/hardware/arduino/avr/libraries/Wire/utility/twi.h
+++ b/hardware/arduino/avr/libraries/Wire/utility/twi.h
@@ -15,13 +15,17 @@
   You should have received a copy of the GNU Lesser General Public
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+  
+  Modified 2014 by Nicola Corna (nicola@corna.info)
+    Added multi address slave
 */
 
 #ifndef twi_h
 #define twi_h
 
   #include <inttypes.h>
-
+  #include <avr/io.h>
+  
   //#define ATMEGA8
 
   #ifndef TWI_FREQ
@@ -40,6 +44,12 @@
   
   void twi_init(void);
   void twi_setAddress(uint8_t);
+#ifdef TWAMR
+  void twi_setAddressAndMask(uint8_t, uint8_t);
+#else
+  void twi_setAddressAndMask(uint8_t, uint8_t) __attribute__((warning("I2C address masking is unsupported on this microcontroller. Mask 0x00 will be used.")));
+#endif
+  uint8_t twi_slaveAddress(void);
   uint8_t twi_readFrom(uint8_t, uint8_t*, uint8_t, uint8_t);
   uint8_t twi_writeTo(uint8_t, uint8_t*, uint8_t, uint8_t, uint8_t);
   uint8_t twi_transmit(const uint8_t*, uint8_t);


### PR DESCRIPTION
I've removed the pullups enable in twi.c and I've moved it in Wire.cpp in order to make twi.h/twi.c usable in pure avr-libc projects
I've also added the multi address slave capability; the device can now respond multiple addresses (when configured as slave), and know which one was called thanks to twi_slaveAddress (in twi.c) or TwoWire::slaveAddress (in Wire.cpp). This feature is not supported on uCs without the TWAMR (two wire address mask register), like the ATMega8, and it is disabled with an #ifdef
These boards are:
 - Serial Arduino
 - Arduino USB
 - Arduino Extreme
 - Arduino NG (first version)