### PR TITLE
Faster isr

### DIFF
--- a/hardware/arduino/avr/cores/arduino/WInterrupts.c
+++ b/hardware/arduino/avr/cores/arduino/WInterrupts.c
@@ -32,7 +32,24 @@
 
 #include "wiring_private.h"
 
-static volatile voidFuncPtr intFunc[EXTERNAL_NUM_INTERRUPTS];
+static void nothing(void) {
+}
+
+static volatile voidFuncPtr intFunc[EXTERNAL_NUM_INTERRUPTS] = {
+#if defined(__AVR_ATmega32U4__) 
+    nothing, // 3
+    nothing, // 4
+#elif (defined(EICRA) && defined(EICRB) && defined(EIMSK))
+    nothing, // 3
+    nothing, // 4
+    nothing, // 5
+    nothing, // 6
+    nothing, // 7
+#endif
+    nothing, // 0
+    nothing, // 1
+    nothing  // 2
+};
 // volatile static voidFuncPtr twiIntFunc;
 
 void attachInterrupt(uint8_t interruptNum, void (*userFunc)(void), int mode) {
@@ -226,7 +243,7 @@ void detachInterrupt(uint8_t interruptNum) {
 #endif
     }
       
-    intFunc[interruptNum] = 0;
+    intFunc[interruptNum] = nothing;
   }
 }
 
@@ -238,87 +255,71 @@ void attachInterruptTwi(void (*userFunc)(void) ) {
 
 #if defined(__AVR_ATmega32U4__)
 ISR(INT0_vect) {
-	if(intFunc[EXTERNAL_INT_0])
-		intFunc[EXTERNAL_INT_0]();
+    intFunc[EXTERNAL_INT_0]();
 }
 
 ISR(INT1_vect) {
-	if(intFunc[EXTERNAL_INT_1])
-		intFunc[EXTERNAL_INT_1]();
+    intFunc[EXTERNAL_INT_1]();
 }
 
 ISR(INT2_vect) {
-    if(intFunc[EXTERNAL_INT_2])
-		intFunc[EXTERNAL_INT_2]();
+    intFunc[EXTERNAL_INT_2]();
 }
 
 ISR(INT3_vect) {
-    if(intFunc[EXTERNAL_INT_3])
-		intFunc[EXTERNAL_INT_3]();
+    intFunc[EXTERNAL_INT_3]();
 }
 
 ISR(INT6_vect) {
-    if(intFunc[EXTERNAL_INT_4])
-		intFunc[EXTERNAL_INT_4]();
+    intFunc[EXTERNAL_INT_4]();
 }
 
 #elif defined(EICRA) && defined(EICRB)
 
 ISR(INT0_vect) {
-  if(intFunc[EXTERNAL_INT_2])
     intFunc[EXTERNAL_INT_2]();
 }
 
 ISR(INT1_vect) {
-  if(intFunc[EXTERNAL_INT_3])
     intFunc[EXTERNAL_INT_3]();
 }
 
 ISR(INT2_vect) {
-  if(intFunc[EXTERNAL_INT_4])
     intFunc[EXTERNAL_INT_4]();
 }
 
 ISR(INT3_vect) {
-  if(intFunc[EXTERNAL_INT_5])
     intFunc[EXTERNAL_INT_5]();
 }
 
 ISR(INT4_vect) {
-  if(intFunc[EXTERNAL_INT_0])
     intFunc[EXTERNAL_INT_0]();
 }
 
 ISR(INT5_vect) {
-  if(intFunc[EXTERNAL_INT_1])
     intFunc[EXTERNAL_INT_1]();
 }
 
 ISR(INT6_vect) {
-  if(intFunc[EXTERNAL_INT_6])
     intFunc[EXTERNAL_INT_6]();
 }
 
 ISR(INT7_vect) {
-  if(intFunc[EXTERNAL_INT_7])
     intFunc[EXTERNAL_INT_7]();
 }
 
 #else
 
 ISR(INT0_vect) {
-  if(intFunc[EXTERNAL_INT_0])
     intFunc[EXTERNAL_INT_0]();
 }
 
 ISR(INT1_vect) {
-  if(intFunc[EXTERNAL_INT_1])
     intFunc[EXTERNAL_INT_1]();
 }
 
 #if defined(EICRA) && defined(ISC20)
 ISR(INT2_vect) {
-  if(intFunc[EXTERNAL_INT_2])
     intFunc[EXTERNAL_INT_2]();
 }
 #endif


### PR DESCRIPTION
Before:
```
Sketch uses 3,606 bytes (11%) of program storage space. Maximum is 32,256 bytes.

   text    data     bss     dec     hex filename
   3496     110    1169    4775    12a7 /tmp/build3790807526441479191.tmp/spi_speed_test.cpp.elf
```
After:

```
Sketch uses 3,606 bytes (11%) of program storage space. Maximum is 32,256 bytes.

   text    data     bss     dec     hex filename
   3496     110    1169    4775    12a7 /tmp/build3790807526441479191.tmp/spi_speed_test.cpp.elf
```
The checking if the target ISR is set is removed
and traded in for setting the initial array values and an empty function.
This gives you a speed gain when an ISR comes in, without increasing the size of the binary.

