### PR TITLE
(Mac OSX) Add Exported UTI for ino files, 

### DIFF
--- a/build/macosx/template.app/Contents/Info.plist
+++ b/build/macosx/template.app/Contents/Info.plist
@@ -58,6 +58,24 @@
         <string>Editor</string>
       </dict>
     </array>
+    <key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.c-plus-plus-source</string>
+			</array>
+			<key>UTTypeIdentifier</key>
+			<string>cc.arduino.Arduino.source</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>ino</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
     <key>Java</key>
     <dict>
       <key>VMOptions</key>

--- a/build/shared/revisions.txt
+++ b/build/shared/revisions.txt
@@ -5,6 +5,7 @@ ARDUINO 1.5.9
 * Sketch build process: fixed full rebuild on windows even if not needed
 * Sketch build process: core.a rebuild only if needed (Matthijs Kooijman)
 * Updated AStyle formatter to v2.04: http://astyle.sourceforge.net/notes.html
+* (Mac OSX) Add Exported UTI for ino files, allows quick look to view the content of the file and external editors to syntax highlight as C++ (Matt Lloyd)
 
 [core]
 * sam: added -MMD flag to let gcc produce dependency files (full rebuild on Arduino Due is now triggered only if needed)


### PR DESCRIPTION
This will allow external editors (like Xcode) to automatically syntax highlight .ino files as C++ source
