### PR TITLE
add save when verifyng and uploading (round 2)

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -1887,7 +1887,7 @@ public class Editor extends JFrame implements RunnerListener {
    */
   public void handleRun(final boolean verbose) {
     internalCloseRunner();
-    if (Preferences.getBoolean("save.verifyUpload")) {
+    if (Preferences.getBoolean("editor.save_on_verify")) {
       if (sketch.isModified() && !sketch.isReadOnly()) {
         handleSave(true);
       }
@@ -2374,7 +2374,7 @@ public class Editor extends JFrame implements RunnerListener {
    * hitting export twice, quickly, and horking things up.
    */
   synchronized public void handleExport(final boolean usingProgrammer) {
-    if (Preferences.getBoolean("save.verifyUpload")) {
+    if (Preferences.getBoolean("editor.save_on_verify")) {
       if (sketch.isModified() && !sketch.isReadOnly()) {
         handleSave(true);
       }

--- a/app/src/processing/app/Preferences.java
+++ b/app/src/processing/app/Preferences.java
@@ -630,7 +630,7 @@ public class Preferences {
     setBoolean("upload.verbose", verboseUploadBox.isSelected());
     setBoolean("editor.linenumbers", displayLineNumbersBox.isSelected());
     setBoolean("upload.verify", verifyUploadBox.isSelected());
-    setBoolean("save.verifyUpload", saveVerifyUploadBox.isSelected());
+    setBoolean("editor.save_on_verify", saveVerifyUploadBox.isSelected());
 
 //    setBoolean("sketchbook.closing_last_window_quits",
 //               closingLastQuitsBox.isSelected());
@@ -653,7 +653,7 @@ public class Preferences {
 
     setBoolean("editor.external", externalEditorBox.isSelected());
     setBoolean("update.check", checkUpdatesBox.isSelected());
-    setBoolean("save.verifyUpload", saveVerifyUploadBox.isSelected());
+    setBoolean("editor.save_on_verify", saveVerifyUploadBox.isSelected());
 
     /*
       // was gonna use this to check memory settings,
@@ -716,7 +716,7 @@ public class Preferences {
     checkUpdatesBox.
       setSelected(getBoolean("update.check"));
     saveVerifyUploadBox.
-      setSelected(getBoolean("save.verifyUpload"));
+      setSelected(getBoolean("editor.save_on_verify"));
 
     if (autoAssociateBox != null) {
       autoAssociateBox.

--- a/build/shared/lib/preferences.txt
+++ b/build/shared/lib/preferences.txt
@@ -149,6 +149,9 @@ editor.divider.size = 0
 # but keeps it from being annoyingly obtrusive
 editor.divider.size.windows = 2
 
+# automatically save sketch when verifying or uploading
+editor.save_on_verify = true
+
 # any additional java options when running externally
 # (for applets that are run external to the environment...
 # those with a code folder, or using any libraries)


### PR DESCRIPTION
As discussed on #2214:
- Disable auto-save if the sketch is read-only (i.e. on examples) as suggested by @agdl and @GregWoods
- Fix spelling and minor adjustment on commits as suggested by @matthijskooijman 

This pull request close #1934
