### PR TITLE
Made swap a function to prevent awful error messages from macros.

### DIFF
--- a/libraries/Robot_Control/utility/Adafruit_GFX.h
+++ b/libraries/Robot_Control/utility/Adafruit_GFX.h
@@ -25,7 +25,7 @@
 
 //#include "PImage.h"
 
-#define swap(a, b) { int16_t t = a; a = b; b = t; }
+inline void swap(int16_t &a, int16_t &b) { int16_t t = a; a = b; b = t; }
 
 /* TODO
 enum RectMode {

--- a/libraries/TFT/utility/Adafruit_GFX.h
+++ b/libraries/TFT/utility/Adafruit_GFX.h
@@ -60,7 +60,7 @@
 #  warning "The SD library was not found. loadImage() and image() won't be supported."
 #endif
 
-#define swap(a, b) { int16_t t = a; a = b; b = t; }
+inline void swap(int16_t &a, int16_t &b) { int16_t t = a; a = b; b = t; }
 
 /* TODO
 enum RectMode {


### PR DESCRIPTION
This macro causes a lot of grief for poor students who aren't yet familiar with gcc's dreadful error messages. Unfortunately "swap" is a common name for functions, and if people aren't careful and declare their own functions when including Adafruit_GFX.h you get a misleading error, as opposed to a duplicate declaration one.
