### PR TITLE
Updated YunClient::connect method'

### DIFF
--- a/libraries/Bridge/src/YunClient.cpp
+++ b/libraries/Bridge/src/YunClient.cpp
@@ -160,7 +160,7 @@ int YunClient::connect(const char *host, uint16_t port) {
   if (connected())
     return 1;
 
-  opened = false;
+  stop();
   handle = 0;
   return 0;
 }


### PR DESCRIPTION
Now the connect method closes the resource on the linux side when the connection fails.

Closes https://github.com/arduino/YunBridge/issues/24

Forum thread: http://forum.arduino.cc/index.php?topic=278104.0