### PR TITLE
Fix SPI transaction mismatch errors

### DIFF
--- a/libraries/SD/src/utility/Sd2Card.cpp
+++ b/libraries/SD/src/utility/Sd2Card.cpp
@@ -157,16 +157,24 @@ uint32_t Sd2Card::cardSize(void) {
   }
 }
 //------------------------------------------------------------------------------
+static uint8_t chip_select_asserted = 0;
+
 void Sd2Card::chipSelectHigh(void) {
   digitalWrite(chipSelectPin_, HIGH);
 #ifdef USE_SPI_LIB
-  SPI.endTransaction();
+  if (chip_select_asserted) {
+    chip_select_asserted = 0;
+    SPI.endTransaction();
+  }
 #endif
 }
 //------------------------------------------------------------------------------
 void Sd2Card::chipSelectLow(void) {
 #ifdef USE_SPI_LIB
-  SPI.beginTransaction(settings);
+  if (!chip_select_asserted) {
+    chip_select_asserted = 1;
+    SPI.beginTransaction(settings);
+  }
 #endif
   digitalWrite(chipSelectPin_, LOW);
 }


### PR DESCRIPTION
While testing with Adafruit nRF8001, I discovered a bug with my previous attempt to add SPI transactions to SD.  The SD library calls chipSelectLow() repeatedly, even when the chip select is already low.  This tiny change is needed to make SPI transactions match properly.
