### PR TITLE
Re enable 38400 baud rates

### DIFF
--- a/app/src/processing/app/AbstractMonitor.java
+++ b/app/src/processing/app/AbstractMonitor.java
@@ -111,7 +111,7 @@ public abstract class AbstractMonitor extends JFrame implements MessageConsumer 
 
     String[] serialRateStrings = {
             "300", "1200", "2400", "4800", "9600",
-            "19200", "57600", "115200"
+            "19200", "38400", "57600", "115200"
     };
 
     serialRates = new JComboBox();

--- a/arduino-core/src/processing/app/PreferencesData.java
+++ b/arduino-core/src/processing/app/PreferencesData.java
@@ -80,7 +80,7 @@ public class PreferencesData {
 
   private static void fixPreferences() {
     String baud = get("serial.debug_rate");
-    if ("14400".equals(baud) || "28800".equals(baud) || "38400".equals(baud)) {
+    if ("14400".equals(baud) || "28800".equals(baud)) {
       set("serial.debug_rate", "9600");
     }
   }


### PR DESCRIPTION
Some baud rates had issues with RXTX and linux. With JSSC, they seem to work fine again. Enable them. Fixes #2296
/cc @cmaglie @matthijskooijman @PaulStoffregen 