### PR TITLE
Make Wire library error safe

### DIFF
--- a/app/build.xml
+++ b/app/build.xml
@@ -37,7 +37,7 @@
     <echo message="override ${env.JAVA_HOME}/lib/tools.jar" />
     <fail />
 -->
-    <javac target="1.5" 
+    <javac target="1.6" 
 	   srcdir="src" 
 	   destdir="bin" 
 	   excludes="**/tools/format/**" 

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -49,12 +49,16 @@ class TwoWire : public Stream
     void begin();
     void begin(uint8_t);
     void begin(int);
+	void begin_timeout(uint32_t);
+	void begin_timeout(uint8_t, uint32_t);
     void beginTransmission(uint8_t);
     void beginTransmission(int);
     uint8_t endTransmission(void);
     uint8_t endTransmission(uint8_t);
+	uint8_t endTransmission_timeout(uint8_t, uint32_t);
     uint8_t requestFrom(uint8_t, uint8_t);
     uint8_t requestFrom(uint8_t, uint8_t, uint8_t);
+	uint8_t requestFrom_timeout(uint8_t, uint8_t, uint8_t, uint32_t);
     uint8_t requestFrom(int, int);
     uint8_t requestFrom(int, int, int);
     virtual size_t write(uint8_t);

--- a/libraries/Wire/examples/timeout_digital_potentiometer/timeout_digital_potentiometer.ino
+++ b/libraries/Wire/examples/timeout_digital_potentiometer/timeout_digital_potentiometer.ino
@@ -1,0 +1,42 @@
+// I2C Digital Potentiometer
+// by Nicholas Zambetti <http://www.zambetti.com>
+// and Shawn Bonkowski <http://people.interaction-ivrea.it/s.bonkowski/>
+
+// Demonstrates use of the Wire library
+// Controls AD5171 digital potentiometer via I2C/TWI
+
+// Created 31 March 2006
+// Edited 7 december 2014 by Mauro Mombelli
+
+// This example code is in the public domain.
+
+// This example code is in the public domain.
+
+
+#include <Wire.h>
+
+const unsigned long default_wire_timeout_us = 1000UL;
+
+void setup()
+{
+  Wire.begin_timeout(default_wire_timeout_us); // join i2c bus (address optional for master)
+}
+
+byte val = 0;
+
+void loop()
+{
+  Wire.beginTransmission(44); // transmit to device #44 (0x2c)
+                              // device address is specified in datasheet
+  Wire.write(byte(0x00));            // sends instruction byte  
+  Wire.write(val);             // sends potentiometer value byte  
+  Wire.endTransmission_timeout(true, default_wire_timeout_us);     // stop transmitting
+
+  val++;        // increment value
+  if(val == 64) // if reached 64th position (max)
+  {
+    val = 0;    // start over from lowest value
+  }
+  delay(500);
+}
+

--- a/libraries/Wire/examples/timeout_master_reader/timeout_master_reader.ino
+++ b/libraries/Wire/examples/timeout_master_reader/timeout_master_reader.ino
@@ -6,6 +6,7 @@
 // Refer to the "Wire Slave Sender" example for use with this
 
 // Created 29 March 2006
+// Edited 7 december 2014 by Mauro Mombelli
 
 // This example code is in the public domain.
 

--- a/libraries/Wire/examples/timeout_master_reader/timeout_master_reader.ino
+++ b/libraries/Wire/examples/timeout_master_reader/timeout_master_reader.ino
@@ -1,0 +1,34 @@
+// Wire Master Reader
+// by Nicholas Zambetti <http://www.zambetti.com>
+
+// Demonstrates use of the Wire library
+// Reads data from an I2C/TWI slave device
+// Refer to the "Wire Slave Sender" example for use with this
+
+// Created 29 March 2006
+
+// This example code is in the public domain.
+
+
+#include <Wire.h>
+
+const unsigned long default_timeout_us = 1000UL;
+
+void setup()
+{
+  Wire.begin_timeout(default_timeout_us);        // join i2c bus (address optional for master)
+  Serial.begin(9600);  // start serial for output
+}
+
+void loop()
+{
+  Wire.requestFrom_timeout(2, 6, true, default_timeout_us);    // request 6 bytes from slave device #2
+
+  while(Wire.available())    // slave may send less than requested
+  { 
+    char c = Wire.read(); // receive a byte as character
+    Serial.print(c);         // print the character
+  }
+
+  delay(500);
+}

--- a/libraries/Wire/examples/timeout_slave_receiver/.directory
+++ b/libraries/Wire/examples/timeout_slave_receiver/.directory
@@ -1,0 +1,6 @@
+[Dolphin]
+Timestamp=2014,12,7,15,37,21
+Version=3
+
+[Settings]
+HiddenFilesShown=true

--- a/libraries/Wire/examples/timeout_slave_receiver/timeout_slave_receiver.ino
+++ b/libraries/Wire/examples/timeout_slave_receiver/timeout_slave_receiver.ino
@@ -6,6 +6,7 @@
 // Refer to the "Wire Master Writer" example for use with this
 
 // Created 29 March 2006
+// Edited 7 december 2014 by Mauro Mombelli
 
 // This example code is in the public domain.
 

--- a/libraries/Wire/examples/timeout_slave_receiver/timeout_slave_receiver.ino
+++ b/libraries/Wire/examples/timeout_slave_receiver/timeout_slave_receiver.ino
@@ -1,0 +1,40 @@
+// Wire Slave Receiver
+// by Nicholas Zambetti <http://www.zambetti.com>
+
+// Demonstrates use of the Wire library
+// Receives data as an I2C/TWI slave device
+// Refer to the "Wire Master Writer" example for use with this
+
+// Created 29 March 2006
+
+// This example code is in the public domain.
+
+
+#include <Wire.h>
+
+const unsigned long default_timeout_us = 1000UL;
+
+void setup()
+{
+  Wire.begin_timeout(4, default_timeout_us);                // join i2c bus with address #4
+  Wire.onReceive(receiveEvent); // register event
+  Serial.begin(9600);           // start serial for output
+}
+
+void loop()
+{
+  delay(100);
+}
+
+// function that executes whenever data is received from master
+// this function is registered as an event, see setup()
+void receiveEvent(int howMany)
+{
+  while(1 < Wire.available()) // loop through all but the last
+  {
+    char c = Wire.read(); // receive byte as a character
+    Serial.print(c);         // print the character
+  }
+  int x = Wire.read();    // receive byte as an integer
+  Serial.println(x);         // print the integer
+}

--- a/libraries/Wire/utility/twi.c
+++ b/libraries/Wire/utility/twi.c
@@ -103,7 +103,7 @@ void twi_setAddress(uint8_t address)
 }
 
 uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sendStop){
-  return twi_readFrom(address, data, length, sendStop, 0); /* for retrocompatibility */
+  return twi_readFrom_timeout(address, data, length, sendStop, 0); /* for retrocompatibility */
 }
 /* 
  * Function twi_readFrom
@@ -116,7 +116,7 @@ uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sen
  *          timeout_us: number of microseconds to wait for answr, 0 = no timeout
  * Output   number of bytes read
  */
-uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sendStop, uint32_t timeout_us)
+uint8_t twi_readFrom_timeout(uint8_t address, uint8_t* data, uint8_t length, uint8_t sendStop, uint32_t timeout_us)
 {
   uint8_t i;
 
@@ -191,7 +191,7 @@ uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sen
 }
 
 uint8_t twi_writeTo(uint8_t address, uint8_t* data, uint8_t length, uint8_t wait, uint8_t sendStop, uint32_t timeout_us){
-  return twi_writeTo(address, data, length, wait, sendStop, 0);  /* for retrocompatibility */
+  return twi_writeTo_timeout(address, data, length, wait, sendStop, 0);  /* for retrocompatibility */
 }
 /* 
  * Function twi_writeTo
@@ -210,7 +210,7 @@ uint8_t twi_writeTo(uint8_t address, uint8_t* data, uint8_t length, uint8_t wait
  *          4 .. other twi error (lost bus arbitration, bus error, ..)
  *          5 .. timeout
  */
-uint8_t twi_writeTo(uint8_t address, uint8_t* data, uint8_t length, uint8_t wait, uint8_t sendStop, uint32_t timeout_us)
+uint8_t twi_writeTo_timeout(uint8_t address, uint8_t* data, uint8_t length, uint8_t wait, uint8_t sendStop, uint32_t timeout_us)
 {
   uint8_t i;
 
@@ -361,7 +361,7 @@ void twi_reply(uint8_t ack)
 }
 
 void twi_stop(void){
-  twi_stop(0);
+  twi_stop_timeout(0);
 }
 /* 
  * Function twi_stop
@@ -369,7 +369,7 @@ void twi_stop(void){
  * Input    timeout_us: number of microseconds to wait for answr, 0 = no timeout
  * Output   none
  */
-void twi_stop(uint32_t timeout_us)
+void twi_stop_timeout(uint32_t timeout_us)
 {
   // send stop condition
   TWCR = _BV(TWEN) | _BV(TWIE) | _BV(TWEA) | _BV(TWINT) | _BV(TWSTO);

--- a/libraries/Wire/utility/twi.c
+++ b/libraries/Wire/utility/twi.c
@@ -128,7 +128,7 @@ uint8_t twi_readFrom_timeout(uint8_t address, uint8_t* data, uint8_t length, uin
   // wait until twi is ready, become master receiver, or timeout
   uint32_t start_us = micros();
   while(TWI_READY != twi_state){
-    if (timeout){
+    if (timeout_us){
       if (micros() - start_us > timeout_us){
       	twi_state = TWI_ERROR;
         return 0;
@@ -169,9 +169,9 @@ uint8_t twi_readFrom_timeout(uint8_t address, uint8_t* data, uint8_t length, uin
     TWCR = _BV(TWEN) | _BV(TWIE) | _BV(TWEA) | _BV(TWINT) | _BV(TWSTA);
 
   // wait for read operation to complete, or timeout
-  uint32_t start_us = micros();
+  start_us = micros();
   while(TWI_MRX != twi_state){
-    if (timeout){
+    if (timeout_us){
       if (micros() - start_us > timeout_us){
       	twi_state = TWI_ERROR;
         return 0;
@@ -222,7 +222,7 @@ uint8_t twi_writeTo_timeout(uint8_t address, uint8_t* data, uint8_t length, uint
   // wait until twi is ready, become master transmitter, or timeout
   uint32_t start_us = micros();
   while(TWI_READY != twi_state){
-    if (timeout){
+    if (timeout_us){
       if (micros() - start_us > timeout_us){
       	twi_state = TWI_ERROR;
         return 5;
@@ -268,9 +268,9 @@ uint8_t twi_writeTo_timeout(uint8_t address, uint8_t* data, uint8_t length, uint
     TWCR = _BV(TWINT) | _BV(TWEA) | _BV(TWEN) | _BV(TWIE) | _BV(TWSTA);	// enable INTs
 
   // wait for write operation to complete, or timeout
-  uint32_t start_us = micros();
+  start_us = micros();
   while( wait && (TWI_MTX != twi_state) ){
-    if (timeout){
+    if (timeout_us){
       if (micros() - start_us > timeout_us){
       	twi_state = TWI_ERROR;
         return 5;
@@ -377,7 +377,7 @@ void twi_stop_timeout(uint32_t timeout_us)
   // wait for stop condition to be exectued on bus, or timeout
   // TWINT is not set after a stop condition!
   while( TWCR & _BV(TWSTO) ){
-    if (timeout){
+    if (timeout_us){
       if (micros() - start_us > timeout_us){
       	twi_state = TWI_ERROR;
         return;

--- a/libraries/Wire/utility/twi.c
+++ b/libraries/Wire/utility/twi.c
@@ -190,7 +190,7 @@ uint8_t twi_readFrom_timeout(uint8_t address, uint8_t* data, uint8_t length, uin
   return length;
 }
 
-uint8_t twi_writeTo(uint8_t address, uint8_t* data, uint8_t length, uint8_t wait, uint8_t sendStop, uint32_t timeout_us){
+uint8_t twi_writeTo(uint8_t address, uint8_t* data, uint8_t length, uint8_t wait, uint8_t sendStop){
   return twi_writeTo_timeout(address, data, length, wait, sendStop, 0);  /* for retrocompatibility */
 }
 /* 
@@ -376,6 +376,7 @@ void twi_stop_timeout(uint32_t timeout_us)
 
   // wait for stop condition to be exectued on bus, or timeout
   // TWINT is not set after a stop condition!
+  uint32_t start_us = micros();
   while( TWCR & _BV(TWSTO) ){
     if (timeout_us){
       if (micros() - start_us > timeout_us){

--- a/libraries/Wire/utility/twi.h
+++ b/libraries/Wire/utility/twi.h
@@ -42,12 +42,15 @@
   void twi_init(void);
   void twi_setAddress(uint8_t);
   uint8_t twi_readFrom(uint8_t, uint8_t*, uint8_t, uint8_t);
+  uint8_t twi_readFrom(uint8_t, uint8_t*, uint8_t, uint8_t, uint32_t);
   uint8_t twi_writeTo(uint8_t, uint8_t*, uint8_t, uint8_t, uint8_t);
+  uint8_t twi_writeTo(uint8_t, uint8_t*, uint8_t, uint8_t, uint8_t, uint32_t);
   uint8_t twi_transmit(const uint8_t*, uint8_t);
   void twi_attachSlaveRxEvent( void (*)(uint8_t*, int) );
   void twi_attachSlaveTxEvent( void (*)(void) );
   void twi_reply(uint8_t);
   void twi_stop(void);
+  void twi_stop(uint32_t);
   void twi_releaseBus(void);
 
 #endif

--- a/libraries/Wire/utility/twi.h
+++ b/libraries/Wire/utility/twi.h
@@ -39,17 +39,18 @@
   #define TWI_STX   4
   #define TWI_ERROR 5
   
-  void twi_init(void);
+  //void twi_init(void);
+  void twi_init_timeout(uint32_t);
   void twi_setAddress(uint8_t);
-  uint8_t twi_readFrom(uint8_t, uint8_t*, uint8_t, uint8_t);
+  //uint8_t twi_readFrom(uint8_t, uint8_t*, uint8_t, uint8_t);
   uint8_t twi_readFrom_timeout(uint8_t, uint8_t*, uint8_t, uint8_t, uint32_t);
-  uint8_t twi_writeTo(uint8_t, uint8_t*, uint8_t, uint8_t, uint8_t);
+  //uint8_t twi_writeTo(uint8_t, uint8_t*, uint8_t, uint8_t, uint8_t);
   uint8_t twi_writeTo_timeout(uint8_t, uint8_t*, uint8_t, uint8_t, uint8_t, uint32_t);
   uint8_t twi_transmit(const uint8_t*, uint8_t);
   void twi_attachSlaveRxEvent( void (*)(uint8_t*, int) );
   void twi_attachSlaveTxEvent( void (*)(void) );
   void twi_reply(uint8_t);
-  void twi_stop(void);
+  //void twi_stop(void);
   void twi_stop_timeout(uint32_t);
   void twi_releaseBus(void);
 

--- a/libraries/Wire/utility/twi.h
+++ b/libraries/Wire/utility/twi.h
@@ -42,15 +42,15 @@
   void twi_init(void);
   void twi_setAddress(uint8_t);
   uint8_t twi_readFrom(uint8_t, uint8_t*, uint8_t, uint8_t);
-  uint8_t twi_readFrom(uint8_t, uint8_t*, uint8_t, uint8_t, uint32_t);
+  uint8_t twi_readFrom_timeout(uint8_t, uint8_t*, uint8_t, uint8_t, uint32_t);
   uint8_t twi_writeTo(uint8_t, uint8_t*, uint8_t, uint8_t, uint8_t);
-  uint8_t twi_writeTo(uint8_t, uint8_t*, uint8_t, uint8_t, uint8_t, uint32_t);
+  uint8_t twi_writeTo_timeout(uint8_t, uint8_t*, uint8_t, uint8_t, uint8_t, uint32_t);
   uint8_t twi_transmit(const uint8_t*, uint8_t);
   void twi_attachSlaveRxEvent( void (*)(uint8_t*, int) );
   void twi_attachSlaveTxEvent( void (*)(void) );
   void twi_reply(uint8_t);
   void twi_stop(void);
-  void twi_stop(uint32_t);
+  void twi_stop_timeout(uint32_t);
   void twi_releaseBus(void);
 
 #endif

--- a/libraries/Wire/utility/twi.h
+++ b/libraries/Wire/utility/twi.h
@@ -37,6 +37,7 @@
   #define TWI_MTX   2
   #define TWI_SRX   3
   #define TWI_STX   4
+  #define TWI_ERROR 5
   
   void twi_init(void);
   void twi_setAddress(uint8_t);


### PR DESCRIPTION
by adding timeout into twi and giving the user a way to use them.

Full retrocompatible.
