### PR TITLE
Fixed duplicate definitions of File when using SD and Bridge libraries together

### DIFF
--- a/libraries/Bridge/examples/Bridge/Bridge.ino
+++ b/libraries/Bridge/examples/Bridge/Bridge.ino
@@ -23,12 +23,12 @@
  */
 
 #include <Bridge.h>
-#include <YunServer.h>
-#include <YunClient.h>
+#include <BridgeServer.h>
+#include <BridgeClient.h>
 
 // Listen on default port 5555, the webserver on the Yún
 // will forward there all the HTTP requests for us.
-YunServer server;
+BridgeServer server;
 
 void setup() {
   // Bridge startup
@@ -45,7 +45,7 @@ void setup() {
 
 void loop() {
   // Get clients coming from server
-  YunClient client = server.accept();
+  BridgeClient client = server.accept();
 
   // There is a new client?
   if (client) {
@@ -59,7 +59,7 @@ void loop() {
   delay(50); // Poll every 50ms
 }
 
-void process(YunClient client) {
+void process(BridgeClient client) {
   // read the command
   String command = client.readStringUntil('/');
 
@@ -79,7 +79,7 @@ void process(YunClient client) {
   }
 }
 
-void digitalCommand(YunClient client) {
+void digitalCommand(BridgeClient client) {
   int pin, value;
 
   // Read pin number
@@ -107,7 +107,7 @@ void digitalCommand(YunClient client) {
   Bridge.put(key, String(value));
 }
 
-void analogCommand(YunClient client) {
+void analogCommand(BridgeClient client) {
   int pin, value;
 
   // Read pin number
@@ -148,7 +148,7 @@ void analogCommand(YunClient client) {
   }
 }
 
-void modeCommand(YunClient client) {
+void modeCommand(BridgeClient client) {
   int pin;
 
   // Read pin number

--- a/libraries/Bridge/examples/TemperatureWebPanel/TemperatureWebPanel.ino
+++ b/libraries/Bridge/examples/TemperatureWebPanel/TemperatureWebPanel.ino
@@ -36,12 +36,12 @@
  */
 
 #include <Bridge.h>
-#include <YunServer.h>
-#include <YunClient.h>
+#include <BridgeServer.h>
+#include <BridgeClient.h>
 
 // Listen on default port 5555, the webserver on the Yún
 // will forward there all the HTTP requests for us.
-YunServer server;
+BridgeServer server;
 String startString;
 long hits = 0;
 
@@ -76,7 +76,7 @@ void setup() {
 
 void loop() {
   // Get clients coming from server
-  YunClient client = server.accept();
+  BridgeClient client = server.accept();
 
   // There is a new client?
   if (client) {

--- a/libraries/Bridge/keywords.txt
+++ b/libraries/Bridge/keywords.txt
@@ -42,6 +42,7 @@ connected	KEYWORD2
 
 # FileIO Class
 File	KEYWORD2
+BridgeFile	KEYWORD2
 seek	KEYWORD2
 position	KEYWORD2
 size	KEYWORD2

--- a/libraries/Bridge/keywords.txt
+++ b/libraries/Bridge/keywords.txt
@@ -15,6 +15,8 @@ Mailbox	KEYWORD3
 HttpClient	KEYWORD3
 YunServer	KEYWORD3
 YunClient	KEYWORD3
+BridgeServer	KEYWORD3
+BridgeClient	KEYWORD3
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -72,7 +74,7 @@ getAsynchronously	KEYWORD2
 ready	KEYWORD2
 getResult	KEYWORD2
 
-# YunServer Class
+# BridgeServer Class
 accept	KEYWORD2
 stop	KEYWORD2
 connect	KEYWORD2

--- a/libraries/Bridge/library.properties
+++ b/libraries/Bridge/library.properties
@@ -1,5 +1,5 @@
 name=Bridge
-version=1.0
+version=1.1
 author=Arduino
 maintainer=Arduino <info@arduino.cc>
 sentence=Enables the communication between the Linux processor and the AVR. For Arduino Yún and TRE only.

--- a/libraries/Bridge/src/BridgeClient.cpp
+++ b/libraries/Bridge/src/BridgeClient.cpp
@@ -16,26 +16,26 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 */
 
-#include <YunClient.h>
+#include <BridgeClient.h>
 
-YunClient::YunClient(int _h, BridgeClass &_b) :
+BridgeClient::BridgeClient(int _h, BridgeClass &_b) :
   bridge(_b), handle(_h), opened(true), buffered(0) {
 }
 
-YunClient::YunClient(BridgeClass &_b) :
+BridgeClient::BridgeClient(BridgeClass &_b) :
   bridge(_b), handle(0), opened(false), buffered(0) {
 }
 
-YunClient::~YunClient() {
+BridgeClient::~BridgeClient() {
 }
 
-YunClient& YunClient::operator=(const YunClient &_x) {
+BridgeClient& BridgeClient::operator=(const BridgeClient &_x) {
   opened = _x.opened;
   handle = _x.handle;
   return *this;
 }
 
-void YunClient::stop() {
+void BridgeClient::stop() {
   if (opened) {
     uint8_t cmd[] = {'j', handle};
     bridge.transfer(cmd, 2);
@@ -43,7 +43,7 @@ void YunClient::stop() {
   opened = false;
 }
 
-void YunClient::doBuffer() {
+void BridgeClient::doBuffer() {
   // If there are already char in buffer exit
   if (buffered > 0)
     return;
@@ -54,13 +54,13 @@ void YunClient::doBuffer() {
   buffered = bridge.transfer(cmd, 3, buffer, sizeof(buffer));
 }
 
-int YunClient::available() {
+int BridgeClient::available() {
   // Look if there is new data available
   doBuffer();
   return buffered;
 }
 
-int YunClient::read() {
+int BridgeClient::read() {
   doBuffer();
   if (buffered == 0)
     return -1; // no chars available
@@ -70,7 +70,7 @@ int YunClient::read() {
   }
 }
 
-int YunClient::read(uint8_t *buff, size_t size) {
+int BridgeClient::read(uint8_t *buff, size_t size) {
   int readed = 0;
   do {
     if (buffered == 0) {
@@ -84,7 +84,7 @@ int YunClient::read(uint8_t *buff, size_t size) {
   return readed;
 }
 
-int YunClient::peek() {
+int BridgeClient::peek() {
   doBuffer();
   if (buffered == 0)
     return -1; // no chars available
@@ -92,7 +92,7 @@ int YunClient::peek() {
     return buffer[readPos];
 }
 
-size_t YunClient::write(uint8_t c) {
+size_t BridgeClient::write(uint8_t c) {
   if (!opened)
     return 0;
   uint8_t cmd[] = {'l', handle, c};
@@ -100,7 +100,7 @@ size_t YunClient::write(uint8_t c) {
   return 1;
 }
 
-size_t YunClient::write(const uint8_t *buf, size_t size) {
+size_t BridgeClient::write(const uint8_t *buf, size_t size) {
   if (!opened)
     return 0;
   uint8_t cmd[] = {'l', handle};
@@ -108,10 +108,10 @@ size_t YunClient::write(const uint8_t *buf, size_t size) {
   return size;
 }
 
-void YunClient::flush() {
+void BridgeClient::flush() {
 }
 
-uint8_t YunClient::connected() {
+uint8_t BridgeClient::connected() {
   if (!opened)
     return false;
   uint8_t cmd[] = {'L', handle};
@@ -120,7 +120,7 @@ uint8_t YunClient::connected() {
   return (res[0] == 1);
 }
 
-int YunClient::connect(IPAddress ip, uint16_t port) {
+int BridgeClient::connect(IPAddress ip, uint16_t port) {
   String address;
   address.reserve(18);
   address += ip[0];
@@ -133,7 +133,7 @@ int YunClient::connect(IPAddress ip, uint16_t port) {
   return connect(address.c_str(), port);
 }
 
-int YunClient::connect(const char *host, uint16_t port) {
+int BridgeClient::connect(const char *host, uint16_t port) {
   uint8_t tmp[] = {
     'C',
     (port >> 8) & 0xFF,

--- a/libraries/Bridge/src/BridgeClient.h
+++ b/libraries/Bridge/src/BridgeClient.h
@@ -16,18 +16,18 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 */
 
-#ifndef _YUN_CLIENT_H_
-#define _YUN_CLIENT_H_
+#ifndef _BRIDGE_CLIENT_H_
+#define _BRIDGE_CLIENT_H_
 
 #include <Bridge.h>
 #include <Client.h>
 
-class YunClient : public Client {
+class BridgeClient : public Client {
   public:
     // Constructor with a user provided BridgeClass instance
-    YunClient(int _h, BridgeClass &_b = Bridge);
-    YunClient(BridgeClass &_b = Bridge);
-    ~YunClient();
+    BridgeClient(int _h, BridgeClass &_b = Bridge);
+    BridgeClient(BridgeClass &_b = Bridge);
+    ~BridgeClient();
 
     // Stream methods
     // (read message)
@@ -45,7 +45,7 @@ class YunClient : public Client {
       return opened;
     }
 
-    YunClient& operator=(const YunClient &_x);
+    BridgeClient& operator=(const BridgeClient &_x);
 
     virtual void stop();
     virtual uint8_t connected();
@@ -67,4 +67,4 @@ class YunClient : public Client {
 
 };
 
-#endif // _YUN_CLIENT_H_
+#endif // _BRIDGE_CLIENT_H_

--- a/libraries/Bridge/src/BridgeServer.cpp
+++ b/libraries/Bridge/src/BridgeServer.cpp
@@ -16,14 +16,14 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 */
 
-#include <YunServer.h>
-#include <YunClient.h>
+#include <BridgeServer.h>
+#include <BridgeClient.h>
 
-YunServer::YunServer(uint16_t _p, BridgeClass &_b) :
+BridgeServer::BridgeServer(uint16_t _p, BridgeClass &_b) :
   bridge(_b), port(_p), listening(false), useLocalhost(false) {
 }
 
-void YunServer::begin() {
+void BridgeServer::begin() {
   uint8_t tmp[] = {
     'N',
     (port >> 8) & 0xFF,
@@ -37,16 +37,16 @@ void YunServer::begin() {
   listening = (res[0] == 1);
 }
 
-YunClient YunServer::accept() {
+BridgeClient BridgeServer::accept() {
   uint8_t cmd[] = {'k'};
   uint8_t res[1];
   unsigned int l = bridge.transfer(cmd, 1, res, 1);
   if (l == 0)
-    return YunClient();
-  return YunClient(res[0]);
+    return BridgeClient();
+  return BridgeClient(res[0]);
 }
 
-size_t YunServer::write(uint8_t c) {
+size_t BridgeServer::write(uint8_t c) {
   uint8_t cmd[] = { 'b', c };
   bridge.transfer(cmd, 2);
   return 1;

--- a/libraries/Bridge/src/BridgeServer.h
+++ b/libraries/Bridge/src/BridgeServer.h
@@ -16,21 +16,21 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 */
 
-#ifndef _YUN_SERVER_H_
-#define _YUN_SERVER_H_
+#ifndef _BRIDGE_SERVER_H_
+#define _BRIDGE_SERVER_H_
 
 #include <Bridge.h>
 #include <Server.h>
 
-class YunClient;
+class BridgeClient;
 
-class YunServer : public Server {
+class BridgeServer : public Server {
   public:
     // Constructor with a user provided BridgeClass instance
-    YunServer(uint16_t port = 5555, BridgeClass &_b = Bridge);
+    BridgeServer(uint16_t port = 5555, BridgeClass &_b = Bridge);
 
     void begin();
-    YunClient accept();
+    BridgeClient accept();
 
     virtual size_t write(uint8_t c);
 
@@ -48,4 +48,4 @@ class YunServer : public Server {
     BridgeClass &bridge;
 };
 
-#endif // _YUN_SERVER_H_
+#endif // _BRIDGE_SERVER_H_

--- a/libraries/Bridge/src/FileIO.cpp
+++ b/libraries/Bridge/src/FileIO.cpp
@@ -18,7 +18,7 @@
 
 #include <FileIO.h>
 
-
+namespace BridgeLib {
 
 File::File(BridgeClass &b) : mode(255), bridge(b) {
   // Empty
@@ -278,3 +278,5 @@ boolean FileSystemClass::rmdir(const char *filepath) {
 }
 
 FileSystemClass FileSystem;
+
+}

--- a/libraries/Bridge/src/FileIO.h
+++ b/libraries/Bridge/src/FileIO.h
@@ -25,6 +25,8 @@
 #define FILE_WRITE 1
 #define FILE_APPEND 2
 
+namespace BridgeLib {
+
 class File : public Stream {
 
   public:
@@ -99,5 +101,20 @@ class FileSystemClass {
 };
 
 extern FileSystemClass FileSystem;
+
+};
+
+// We enclose File and FileSystem classes in namespace BridgeLib to avoid
+// conflicts with legacy SD library.
+
+// This ensure compatibility with older sketches that uses only Bridge lib
+// (the user can still use File instead of BridgeFile)
+using namespace BridgeLib;
+
+// This allows sketches to use BridgeLib::File together with SD library
+// (you must use BridgeFile instead of File when needed to disambiguate)
+typedef BridgeLib::File            BridgeFile;
+typedef BridgeLib::FileSystemClass BridgeFileSystemClass;
+#define BridgeFileSystem           BridgeLib::FileSystem
 
 #endif

--- a/libraries/Bridge/src/YunClient.h
+++ b/libraries/Bridge/src/YunClient.h
@@ -1,0 +1,27 @@
+/*
+  Copyright (c) 2014 Arduino LLC. All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#ifndef _YUN_CLIENT_H_
+#define _YUN_CLIENT_H_
+
+#include <BridgeClient.h>
+
+#warning "The use of YunClient is deprecated. Use BridgeClient instead!"
+typedef BridgeClient YunClient;
+
+#endif // _YUN_CLIENT_H_

--- a/libraries/Bridge/src/YunServer.h
+++ b/libraries/Bridge/src/YunServer.h
@@ -1,0 +1,27 @@
+/*
+  Copyright (c) 2014 Arduino LLC. All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#ifndef _YUN_SERVER_H_
+#define _YUN_SERVER_H_
+
+#include <BridgeServer.h>
+
+#warning "The use of YunServer is deprecated. Use BridgeServer instead!"
+typedef BridgeServer YunServer;
+
+#endif // _YUN_SERVER_H_

--- a/libraries/SD/keywords.txt
+++ b/libraries/SD/keywords.txt
@@ -8,6 +8,7 @@
 
 SD	KEYWORD1
 File	KEYWORD1
+SDFile	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)

--- a/libraries/SD/src/SD.cpp
+++ b/libraries/SD/src/SD.cpp
@@ -52,6 +52,8 @@
 
 #include "SD.h"
 
+namespace SDLib {
+
 // Used by `getNextPathComponent`
 #define MAX_COMPONENT_LEN 12 // What is max length?
 #define PATH_COMPONENT_BUFFER_LEN MAX_COMPONENT_LEN+1
@@ -614,3 +616,5 @@ void File::rewindDirectory(void) {
 }
 
 SDClass SD;
+
+};

--- a/libraries/SD/src/SD.h
+++ b/libraries/SD/src/SD.h
@@ -23,6 +23,8 @@
 #define FILE_READ O_READ
 #define FILE_WRITE (O_READ | O_WRITE | O_CREAT)
 
+namespace SDLib {
+
 class File : public Stream {
  private:
   char _name[13]; // our name
@@ -98,5 +100,19 @@ private:
 };
 
 extern SDClass SD;
+
+};
+
+// We enclose File and SD classes in namespace SDLib to avoid conflicts
+// with others legacy libraries that redefines File class.
+
+// This ensure compatibility with sketches that uses only SD library
+using namespace SDLib;
+
+// This allows sketches to use SDLib::File with other libraries (in the
+// sketch you must use SDFile instead of File to disambiguate)
+typedef SDLib::File    SDFile;
+typedef SDLib::SDClass SDFileSystemClass;
+#define SDFileSystem   SDLib::SD
 
 #endif


### PR DESCRIPTION
The two `File` classes have been enclosed into different namespaces.

An additional:

```C++
using namespace xxxxx;
```

has been added to guarantee compatibility with sketches that uses only one of
the two libraries.

`BridgeLib::File` and `SDLib::File` classes have been aliased to `YunFile` and `SDFile` respectively,
users are encouraged to use that instead of `File`.
