### PR TITLE
Bugfix DNSClient::getHostByName()

### DIFF
--- a/libraries/Ethernet/src/Dns.cpp
+++ b/libraries/Ethernet/src/Dns.cpp
@@ -60,7 +60,7 @@ int DNSClient::inet_aton(const char* aIPAddrString, IPAddress& aResult)
     // See if we've been given a valid IP address
     const char* p =aIPAddrString;
     while (*p &&
-           ( (*p == '.') || (*p >= '0') || (*p <= '9') ))
+           ( (*p == '.') || ((*p >= '0') && (*p <= '9')) ))
     {
         p++;
     }
@@ -97,10 +97,10 @@ int DNSClient::inet_aton(const char* aIPAddrString, IPAddress& aResult)
         }
         // We've reached the end of address, but there'll still be the last
         // segment to deal with
-        if ((segmentValue > 255) || (segment > 3))
+        if ((segmentValue > 255) || (segment != 3))
         {
             // You can't have IP address segments that don't fit in a byte,
-            // or more than four segments
+            // or other than four segments
             return 0;
         }
         else


### PR DESCRIPTION
I found a bug in DNSClient::getHostByName() and fixed it. 

I'm trying to connect to a local server, called 'htpc'. The hostname is resolved by DNSClient::getHostByName(). The first thing this function does is "See if it's a numeric IP address" by calling inet_aton(). It returns falsely 1 (=yes, it's a numeric IP address) for hostname 'htpc'

For most (longer) hostnames it will accidentally return 0. This is probably why it hasn't been discovered before. 

- valid IP address digits have to be >= 0 AND <= 9
- valid IP addresses must have 4 segments