### PR TITLE
trivial: actually include the empty yield placeholder

### DIFF
--- a/hardware/arduino/cores/arduino/Arduino.h
+++ b/hardware/arduino/cores/arduino/Arduino.h
@@ -34,7 +34,7 @@
 extern "C"{
 #endif
 
-void yield(void);
+#include "hooks.c"
 
 #define HIGH 0x1
 #define LOW  0x0


### PR DESCRIPTION
fixing the following build failure:

In function `init':
/usr/share/gnoduino/hardware/arduino/cores/arduino/wiring.c:228: undefined reference to `yield'
collect2: error: ld returned 1 exit status

original commit introducing yield in master:
6ecb174c40fb880ac555182f918048b0050b3c98