### PR TITLE
windows binary product version within exe file

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -502,8 +502,8 @@
       <fileset dir="windows/launcher"
 	       includes="about.bmp, application.ico, config.xml, config_debug.xml"/>
     </copy>
-    <launch4j configFile="windows/work/config.xml" />
-    <launch4j configFile="windows/work/config_debug.xml" />
+    <launch4j configFile="windows/work/config.xml" productVersion="${version}.0" txtProductVersion="${version}" />
+    <launch4j configFile="windows/work/config_debug.xml" productVersion="${version}.0" txtProductVersion="${version}" />
     <delete dir="windows/work"
 	    includes="about.bmp, application.ico, config.xml, config_debug.xml" />
 


### PR DESCRIPTION
Mac OS X executable contains product version, Windows version doesn't. Please add it.

more info:
http://launch4j.sourceforge.net/docs.html#Ant_task
http://msdn.microsoft.com/en-us/library/windows/desktop/aa381058(v=vs.85).aspx