### PR TITLE
TFT ST7735: Fixed length bug in drawFastHLine and drawFastVLine

### DIFF
--- a/libraries/TFT/src/utility/Adafruit_ST7735.cpp
+++ b/libraries/TFT/src/utility/Adafruit_ST7735.cpp
@@ -444,6 +444,9 @@ void Adafruit_ST7735::drawPixel(int16_t x, int16_t y, uint16_t color) {
 void Adafruit_ST7735::drawFastVLine(int16_t x, int16_t y, int16_t h,
  uint16_t color) {
 
+  // Needed to achieve correct line length
+  h++;
+
   // Rudimentary clipping
   if((x >= _width) || (y >= _height)) return;
   if((y+h-1) >= _height) h = _height-y;
@@ -464,6 +467,9 @@ void Adafruit_ST7735::drawFastVLine(int16_t x, int16_t y, int16_t h,
 
 void Adafruit_ST7735::drawFastHLine(int16_t x, int16_t y, int16_t w,
   uint16_t color) {
+
+  // Needed to achieve correct line length
+  w++;
 
   // Rudimentary clipping
   if((x >= _width) || (y >= _height)) return;


### PR DESCRIPTION
Hi,
I noticed a bug in the ST7735 TFT library in drawFastHLine and drawFastVLine functions. The drawn line is one pixel shorter than it should be. The issue can be reproduced by the following setup function.
Without this commit, the horizontal line (drawn using drawFastHLine) is one pixel shorter than the 45° line.
This is explained by the while (w--) loop preceding the spiwrite call.
With this commit both lines are 2 pixels long.

void setup() {
        TFTscreen.begin();
        TFTscreen.background(0, 0, 0);
        TFTscreen.stroke(255, 0, 0);
        TFTscreen.line(0, 0,  1, 1);    // 45° line, OK (pixels [0,0] and [1,1] are filled
        TFTscreen.line(0, 10, 1, 10);   // Horiz. line, NOK (only pixel [0,10] is filled)
}
