### PR TITLE
Using tabulation instead of white spaces for ide-1.5.x.

### DIFF
--- a/app/src/processing/app/EditorListener.java
+++ b/app/src/processing/app/EditorListener.java
@@ -230,6 +230,10 @@ public class EditorListener {
         event.consume();
         return true;
 
+      } else if (!tabsExpand) {
+        textarea.setSelectedText("\t");
+        event.consume();
+        return true;
       } else if (tabsIndent) {
         // this code is incomplete
 


### PR DESCRIPTION
Tabulator fix to preserve lifetime of backspace key.
ô.Ô