### PR TITLE
Correct undefined Serial Buffer Size

### DIFF
--- a/hardware/arduino/avr/cores/arduino/HardwareSerial.h
+++ b/hardware/arduino/avr/cores/arduino/HardwareSerial.h
@@ -34,12 +34,17 @@
 // location from which to read.
 // NOTE: a "power of 2" buffer size is reccomended to dramatically
 //       optimize all the modulo operations for ring buffers.
-#if !(defined(SERIAL_TX_BUFFER_SIZE) && defined(SERIAL_RX_BUFFER_SIZE))
+#if !(defined(SERIAL_TX_BUFFER_SIZE)
 #if (RAMEND < 1000)
 #define SERIAL_TX_BUFFER_SIZE 16
-#define SERIAL_RX_BUFFER_SIZE 16
 #else
 #define SERIAL_TX_BUFFER_SIZE 64
+#endif
+#endif
+#if !defined(SERIAL_RX_BUFFER_SIZE))
+#if (RAMEND < 1000)
+#define SERIAL_RX_BUFFER_SIZE 16
+#else
 #define SERIAL_RX_BUFFER_SIZE 64
 #endif
 #endif

--- a/hardware/arduino/avr/cores/arduino/HardwareSerial.h
+++ b/hardware/arduino/avr/cores/arduino/HardwareSerial.h
@@ -34,14 +34,14 @@
 // location from which to read.
 // NOTE: a "power of 2" buffer size is reccomended to dramatically
 //       optimize all the modulo operations for ring buffers.
-#if !(defined(SERIAL_TX_BUFFER_SIZE)
+#if !defined(SERIAL_TX_BUFFER_SIZE)
 #if (RAMEND < 1000)
 #define SERIAL_TX_BUFFER_SIZE 16
 #else
 #define SERIAL_TX_BUFFER_SIZE 64
 #endif
 #endif
-#if !defined(SERIAL_RX_BUFFER_SIZE))
+#if !defined(SERIAL_RX_BUFFER_SIZE)
 #if (RAMEND < 1000)
 #define SERIAL_RX_BUFFER_SIZE 16
 #else

--- a/hardware/arduino/avr/cores/arduino/USBAPI.h
+++ b/hardware/arduino/avr/cores/arduino/USBAPI.h
@@ -59,10 +59,12 @@ extern USBDevice_ USBDevice;
 
 struct ring_buffer;
 
+#ifndef SERIAL_BUFFER_SIZE
 #if (RAMEND < 1000)
 #define SERIAL_BUFFER_SIZE 16
 #else
 #define SERIAL_BUFFER_SIZE 64
+#endif
 #endif
 
 class Serial_ : public Stream

--- a/hardware/arduino/avr/cores/arduino/USBAPI.h
+++ b/hardware/arduino/avr/cores/arduino/USBAPI.h
@@ -66,6 +66,9 @@ struct ring_buffer;
 #define SERIAL_BUFFER_SIZE 64
 #endif
 #endif
+#if (SERIAL_BUFFER_SIZE>256)
+#error Please lower the CDC Buffer size
+#endif
 
 class Serial_ : public Stream
 {


### PR DESCRIPTION
I split the definition to change the buffers individual. This also applies to the CDC Buffer.
