### PR TITLE
GSM Library fix for Galileo

### DIFF
--- a/libraries/GSM/examples/GsmWebClient/GsmWebClient.ino
+++ b/libraries/GSM/examples/GsmWebClient/GsmWebClient.ino
@@ -23,7 +23,7 @@
 #define PINNUMBER ""
 
 // APN data
-#define GPRS_APN       "GPRS_APN" // replace your GPRS APN
+#define GPRS_APN       "gprs_apn" // replace your GPRS APN
 #define GPRS_LOGIN     "login"    // replace with your GPRS login
 #define GPRS_PASSWORD  "password" // replace with your GPRS password
 

--- a/libraries/GSM/src/GSM3MobileCellManagement.h
+++ b/libraries/GSM/src/GSM3MobileCellManagement.h
@@ -36,13 +36,32 @@ https://github.com/BlueVia/Official-Arduino
 
 #include <Arduino.h>
 
+struct Cell
+{
+	char mcc[6];
+	char mnc[6];
+	char lac[6];
+	char cellId[8];
+	char dbm[6];
+};
+
 class GSM3MobileCellManagement
 {
 	public:
 		
-		virtual inline int getLocation() {return 0;};
+		virtual inline uint8_t updateLocation(bool) {return 0;};
 		
-		virtual inline int getICCID() {return 0;};
+		virtual inline int8_t getICCID() {return 0;};
+		
+		virtual inline int8_t getIMEI() {return 0;};
+		
+		virtual inline int8_t getPowerData() {return 0;};
+		
+		virtual inline Cell* getCells(){return NULL;};
+		
+		virtual inline bool getNeighboursActivated(){return 0;};
+		
+		virtual inline uint8_t getNumberCells(){return 0;};
 		
 		/** Get last command status
 			@return returns 0 if last command is still executing, 1 success, >1 error

--- a/libraries/GSM/src/GSM3ShieldV1.cpp
+++ b/libraries/GSM/src/GSM3ShieldV1.cpp
@@ -59,7 +59,7 @@ void GSM3ShieldV1::manageResponse(byte from, byte to)
 {
 	switch(theGSM3ShieldV1ModemCore.getOngoingCommand())
 	{
-		case NONE:
+		case GSM_NONE:
 			theGSM3ShieldV1ModemCore.gss.cb.deleteToTheEnd(from);
 			break;
 

--- a/libraries/GSM/src/GSM3ShieldV1AccessProvider.cpp
+++ b/libraries/GSM/src/GSM3ShieldV1AccessProvider.cpp
@@ -57,7 +57,11 @@ GSM3_NetworkStatus_t GSM3ShieldV1AccessProvider::begin(char* pin, bool restart, 
 	{
 		// if we shorten this delay, the command fails
 		while(ready()==0) 
-			delay(1000); 
+		#ifdef __ARDUINO_X86__
+			delay(100);  // This could run with delay 1000, but as we use no interrupts it is slower
+		#else
+			delay(1000); // delay 100 makes the program fail, an answer from the modem is lost. Mistery.
+		#endif
 	}
 	return getStatus();
 }

--- a/libraries/GSM/src/GSM3ShieldV1BaseProvider.h
+++ b/libraries/GSM/src/GSM3ShieldV1BaseProvider.h
@@ -36,10 +36,11 @@ https://github.com/BlueVia/Official-Arduino
 
 #include <GSM3SoftSerial.h>
 
-enum GSM3_commandType_e { XON, NONE, MODEMCONFIG, ALIVETEST, BEGINSMS, ENDSMS, AVAILABLESMS, FLUSHSMS,
+enum GSM3_commandType_e { XON, GSM_NONE, MODEMCONFIG, ALIVETEST, BEGINSMS, ENDSMS, AVAILABLESMS, FLUSHSMS,
 	VOICECALL, ANSWERCALL, HANGCALL, RETRIEVECALLINGNUMBER, 
 	ATTACHGPRS, DETACHGPRS, CONNECTTCPCLIENT, DISCONNECTTCP, BEGINWRITESOCKET, ENDWRITESOCKET, 
-	AVAILABLESOCKET, FLUSHSOCKET, CONNECTSERVER, GETIP, GETCONNECTSTATUS, GETLOCATION, GETICCID}; 
+	AVAILABLESOCKET, FLUSHSOCKET, CONNECTSERVER, GETIP, GETCONNECTSTATUS, GETLOCATION, GETICCID, UPDATELOCATION,
+	GETPOWERDATA, GETIMEI}; 
 
 class GSM3ShieldV1BaseProvider
 {
@@ -60,7 +61,7 @@ class GSM3ShieldV1BaseProvider
 		@param from 		Initial byte of buffer
 		@param to 			Final byte of buffer
 	*/
-	virtual void manageResponse(byte from, byte to);
+	virtual void manageResponse(byte from, byte to){};
 	
 	/** Recognize URC
 		@param from		

--- a/libraries/GSM/src/GSM3ShieldV1CellManagement.cpp
+++ b/libraries/GSM/src/GSM3ShieldV1CellManagement.cpp
@@ -1,7 +1,42 @@
 #include <GSM3ShieldV1CellManagement.h>
+#include <util/delay.h>
 
 GSM3ShieldV1CellManagement::GSM3ShieldV1CellManagement()
 {
+	memset(cells, 0, sizeof(Cell) * 7);
+	cellsLength = 0;
+	neighboursActivated = false;
+}
+
+bool GSM3ShieldV1CellManagement::parseCBC_available(bool& rsp)
+{
+	char c;
+	bool powerDataFound = false;
+	int i = 0;
+	
+	if (!(theGSM3ShieldV1ModemCore.theBuffer().chopUntil("+CBC", true)))
+		rsp = false;
+	else 
+		rsp = true;
+	
+	while(((c = theGSM3ShieldV1ModemCore.theBuffer().read()) != 0) && (i < 12))
+	{
+		if((c < 58) && (c > 47))
+			powerDataFound = true;
+			
+		if(powerDataFound)
+		{
+			if(c == 13 || c == 10)
+				break;
+		
+			powerData[i] = c;
+			i++;
+		}
+	}
+	
+	powerData[i]=0;
+	
+	return true;
 }
 
 bool GSM3ShieldV1CellManagement::parseQCCID_available(bool& rsp)
@@ -10,9 +45,9 @@ bool GSM3ShieldV1CellManagement::parseQCCID_available(bool& rsp)
 	bool iccidFound = false;
 	int i = 0;
 	
-	while(((c = theGSM3ShieldV1ModemCore.theBuffer().read()) != 0) & (i < 19))
+	while(((c = theGSM3ShieldV1ModemCore.theBuffer().read()) != 0) && (i < 19))
 	{
-		if((c < 58) & (c > 47))
+		if((c < 58) && (c > 47))
 			iccidFound = true;
 		
 		if(iccidFound)
@@ -24,108 +59,339 @@ bool GSM3ShieldV1CellManagement::parseQCCID_available(bool& rsp)
 	bufferICCID[i]=0;
 	
 	return true;
-}			
+}
+
+bool GSM3ShieldV1CellManagement::parseGSN_available(bool& rsp)
+{
+	char c;
+	bool imeiFound = false;
+	int i = 0;
+	
+	while(((c = theGSM3ShieldV1ModemCore.theBuffer().read()) != 0) && (i < 15))
+	{
+		if((c < 58) && (c > 47))
+			imeiFound = true;
+		
+		if(imeiFound)
+		{
+			bufferIMEI[i] = c;
+			i++;
+		}
+	}
+	
+	bufferIMEI[i]=0;
+	
+	return true;
+}
 
 bool GSM3ShieldV1CellManagement::parseQENG_available(bool& rsp)
 {
 	char c;
-	char location[50] = "";
-	int i = 0;
+	bool readingCell = true;
 	
-	if (!(theGSM3ShieldV1ModemCore.theBuffer().chopUntil("+QENG: ", true)))
-		rsp = false;
-	else 
-		rsp = true;
+	rsp = false;
 	
-	if (!(theGSM3ShieldV1ModemCore.theBuffer().chopUntil("+QENG:", true)))
-		rsp = false;
-	else 
-		rsp = true;
+	// Ignore response until '+QENG: 1,0' or '+QENG: 1,1'
+	if (!(theGSM3ShieldV1ModemCore.theBuffer().chopUntil("+QENG: 1,0", true)) && !(theGSM3ShieldV1ModemCore.theBuffer().chopUntil("+QENG: 1,1", true)))
+		return rsp;
+		
+	// Ignore response until first '+QENG: 0,'
+	if (!theGSM3ShieldV1ModemCore.theBuffer().chopUntil("+QENG: 0,", true))
+		return rsp;
 	
-	while(((c = theGSM3ShieldV1ModemCore.theBuffer().read()) != 0) & (i < 50))
+	int selectField = 0;
+	int fieldIndex = 0;
+	
+	// Read all characters of response and save cell info into 'struct'
+	while(((c = readCompleteResponse()) != 0) && (readingCell))
 	{
-		location[i] = c;
-		i++;
+		if(c == ',') // fields separator
+		{
+			if(selectField == 6)
+				readingCell = false;
+			else
+				selectField++;
+			
+			fieldIndex = 0;
+		}
+		else
+		{
+			// Switch between different fields of response to save
+			// Fields: <mcc>,<mnc>,<lac>,<cellid>,<bcch>,<bsic>,<dbm>,<c1>,<c2>,<txp>,<rla>,<tch>,<ts>,<maio>,<hsn>,<ta>,<rxq_sub>,<rxq_full> - See M95 manual.
+			switch(selectField)
+			{
+				// MCC
+				case 0:
+					if(fieldIndex < 6) cells[0].mcc[fieldIndex] = c;
+					break;
+					
+				// MNC
+				case 1:
+					if(fieldIndex < 6) cells[0].mnc[fieldIndex] = c;
+					break;
+					
+				// LOCATION AREA
+				case 2:
+					if(fieldIndex < 6) cells[0].lac[fieldIndex] = c;
+					break;
+				
+				// CELL ID
+				case 3:
+					if(fieldIndex < 8) cells[0].cellId[fieldIndex] = c;
+					break;
+				
+				// BCCH
+				case 4:
+					break;
+				
+				// BSIC
+				case 5:
+					break;
+					
+				// DBM
+				case 6:
+					if(fieldIndex < 6) cells[0].dbm[fieldIndex] = c;
+					break;
+			}
+			
+			fieldIndex++;
+		}
 	}
-	location[i]=0;
-	
-	char* res_tok = strtok(location, ",");
-	res_tok=strtok(NULL, ",");
-	strcpy(countryCode, res_tok);
-	res_tok=strtok(NULL, ",");
-	strcpy(networkCode, res_tok);
-	res_tok=strtok(NULL, ",");
-	strcpy(locationArea, res_tok);
-	res_tok=strtok(NULL, ",");
-	strcpy(cellId, res_tok);
-	
-	return true;
-}			
 
-int GSM3ShieldV1CellManagement::getLocation(char *country, char *network, char *area, char *cell)
+	cellsLength = 1;
+	rsp = true;
+	
+	if(neighboursActivated)
+		extractNeighbours(rsp);
+		
+	return rsp;
+}
+
+bool GSM3ShieldV1CellManagement::extractNeighbours(bool &rsp)
 {
-	if((theGSM3ShieldV1ModemCore.getStatus() != GSM_READY) && (theGSM3ShieldV1ModemCore.getStatus() != GPRS_READY))
-		return 2;
+	char c;
+	bool readingCell = true;
 	
-	countryCode=country;
-	networkCode=network;
-	locationArea=area;
-	cellId=cell;
+	rsp = false;
 	
-	theGSM3ShieldV1ModemCore.openCommand(this,GETLOCATION);
-	getLocationContinue();
+	// Ignore response until first '+QENG: 1,'
+	if (!theGSM3ShieldV1ModemCore.theBuffer().chopUntil("+QENG: 1,", true))
+		return rsp;
 	
-	unsigned long timeOut = millis();
-	while(((millis() - timeOut) < 5000) & (ready() == 0));
+	int selectField = 0;
+	int fieldIndex = 0;
+	
+	// Read all characters of response and save cell info into 'struct'
+	while(((c = readCompleteResponse()) != 0) && (readingCell))
+	{	
+		if(c == ',') // fields separator
+		{
+			if(selectField == 9)
+				if(cellsLength > 6)
+					readingCell = false;
+				else
+				{
+					cellsLength++;
+					selectField = 0;
+				}
+			else
+				selectField++;
+			
+			fieldIndex = 0;
+		}
+		else if(((c == 'x' || c == ' ') || c == '\n') || c == '\r')
+		{
+			readingCell = false;
+			if(c == 'x') cellsLength--;
+		}
+		else
+		{
+			// Switch between different fields of response to save
+			// Fields: <ncell>,<bcch>,<dbm>,<bsic>,<c1>,<c2>,<mcc>,<mnc>,<lac>,<cellid> - See M95 manual.
+			switch(selectField)
+			{
+				// NUMBER OF CELL
+				case 0:
+					break;
+					
+				// BCCH
+				case 1:
+					break;
+					
+				// DBM
+				case 2:
+					if(fieldIndex < 6) cells[cellsLength].dbm[fieldIndex] = c;
+					break;
+				
+				// BSIC
+				case 3:
+					break;
+				
+				// C1
+				case 4:
+					break;
+				
+				// C2
+				case 5:
+					break;
+					
+				// MCC
+				case 6:
+					if(fieldIndex < 6) cells[cellsLength].mcc[fieldIndex] = c;
+					break;
+				
+				// MNC
+				case 7:
+					if(fieldIndex < 6) cells[cellsLength].mnc[fieldIndex] = c;
+					break;
+				
+				// LAC
+				case 8:
+					if(fieldIndex < 6) cells[cellsLength].lac[fieldIndex] = c;
+					break;
+				
+				// CELL ID
+				case 9:
+					if(fieldIndex < 8) cells[cellsLength].cellId[fieldIndex] = c;
+					break;
+			}
+			
+			fieldIndex++;
+		}
+	}
 
+	while((c = readCompleteResponse()) != 0);
+	
+	cellsLength++;	
+	
+	rsp = true;
+	
+	return rsp;
+}
+
+uint8_t GSM3ShieldV1CellManagement::updateLocation(bool neighbours)
+{	
+	memset(cells, 0, sizeof(Cell) * 7);
+	cellsLength = 0;
+	
+	neighboursActivated = neighbours;
+	
+	theGSM3ShieldV1ModemCore.openCommand(this, UPDATELOCATION);
+	updateLocationContinue();
+	
+	while(ready() == 0)
+		delay(1000);
+	
+	return cellsLength;
+}
+
+void GSM3ShieldV1CellManagement::updateLocationContinue()
+{
+	bool resp;
+
+	switch(theGSM3ShieldV1ModemCore.getCommandCounter())
+	{
+		case 1:
+			theGSM3ShieldV1ModemCore.setCommandCounter(2);
+			
+			// Select between two commands if we want get neighbours cells
+			if(neighboursActivated)
+				theGSM3ShieldV1ModemCore.genericCommand_rq(PSTR("AT+QENG=1,1"), false);
+			else
+				theGSM3ShieldV1ModemCore.genericCommand_rq(PSTR("AT+QENG=1"), false);
+				
+			theGSM3ShieldV1ModemCore.print('\r');
+			break;
+		
+		case 2:
+			if (theGSM3ShieldV1ModemCore.genericParse_rsp(resp))
+			{
+				// Get neighbours cells requires more time 
+				if(neighboursActivated)
+					_delay_ms(15000);
+				else
+					_delay_ms(600);
+					
+				theGSM3ShieldV1ModemCore.setCommandCounter(3);
+				theGSM3ShieldV1ModemCore.genericCommand_rq(PSTR("AT+QENG?"));
+			}
+			else theGSM3ShieldV1ModemCore.closeCommand(1);
+			break;
+		
+		case 3:
+			if (resp)
+			{
+				if(parseQENG_available(resp))
+					theGSM3ShieldV1ModemCore.closeCommand(3);
+				else
+					theGSM3ShieldV1ModemCore.closeCommand(2);
+			}
+			else theGSM3ShieldV1ModemCore.closeCommand(2);
+			break;
+	}
+}
+
+int8_t GSM3ShieldV1CellManagement::getPowerData(char *info)
+{
+	powerData = info;
+	theGSM3ShieldV1ModemCore.openCommand(this, GETPOWERDATA);
+	getPowerDataContinue();
+	
+	while(ready() == 0)
+		delay(1000);
+		
 	return theGSM3ShieldV1ModemCore.getCommandError();
 }
 
-void GSM3ShieldV1CellManagement::getLocationContinue()
+void GSM3ShieldV1CellManagement::getPowerDataContinue()
 {
 	bool resp;
 	
-	switch (theGSM3ShieldV1ModemCore.getCommandCounter()) {
-    case 1:
-		theGSM3ShieldV1ModemCore.gss.tunedDelay(3000);
-		delay(3000);
-		theGSM3ShieldV1ModemCore.setCommandCounter(2);
-		theGSM3ShieldV1ModemCore.genericCommand_rq(PSTR("AT+QENG=1"), false);
-		theGSM3ShieldV1ModemCore.print("\r");
-		break;
-	case 2:
-		if (theGSM3ShieldV1ModemCore.genericParse_rsp(resp))
-		{
-			theGSM3ShieldV1ModemCore.gss.tunedDelay(3000);
-			delay(3000);
-			theGSM3ShieldV1ModemCore.setCommandCounter(3);
-			theGSM3ShieldV1ModemCore.genericCommand_rq(PSTR("AT+QENG?"), false);
+	switch (theGSM3ShieldV1ModemCore.getCommandCounter())
+	{
+		case 1:
+			
+			theGSM3ShieldV1ModemCore.setCommandCounter(2);
+			theGSM3ShieldV1ModemCore.genericCommand_rq(PSTR("AT+CBC"), false);
 			theGSM3ShieldV1ModemCore.print("\r");
-		}
-		else theGSM3ShieldV1ModemCore.closeCommand(1);
-		break;
-	case 3:
-		if (resp)
-		{
-			parseQENG_available(resp);
-			theGSM3ShieldV1ModemCore.closeCommand(3);
-		}
-		else theGSM3ShieldV1ModemCore.closeCommand(2);
-		break;
+			
+			break;
+			
+		case 2:
+			
+			if (theGSM3ShieldV1ModemCore.genericParse_rsp(resp))
+			{
+				parseCBC_available(resp);
+				if(resp)
+					theGSM3ShieldV1ModemCore.closeCommand(2);
+			}
+			else
+				theGSM3ShieldV1ModemCore.closeCommand(1);
+			
+			break;
 	}
 }
 
-int GSM3ShieldV1CellManagement::getICCID(char *iccid)
+int8_t GSM3ShieldV1CellManagement::getICCID(char *iccid)
 {
-	if((theGSM3ShieldV1ModemCore.getStatus() != GSM_READY) && (theGSM3ShieldV1ModemCore.getStatus() != GPRS_READY))
-		return 2;
-	
-	bufferICCID=iccid;
-	theGSM3ShieldV1ModemCore.openCommand(this,GETICCID);
+	bufferICCID = iccid;
+	theGSM3ShieldV1ModemCore.openCommand(this, GETICCID);
 	getICCIDContinue();
 	
-	unsigned long timeOut = millis();
-	while(((millis() - timeOut) < 5000) & (ready() == 0));
+	while(ready() == 0)
+		delay(1000);
+		
+	return theGSM3ShieldV1ModemCore.getCommandError();
+}
+
+int8_t GSM3ShieldV1CellManagement::getIMEI(char *imei)
+{
+	bufferIMEI = imei;
+	theGSM3ShieldV1ModemCore.openCommand(this, GETIMEI);
+	getIMEIContinue();
+	
+	while(ready() == 0)
+		delay(1000);
 		
 	return theGSM3ShieldV1ModemCore.getCommandError();
 }
@@ -134,20 +400,49 @@ void GSM3ShieldV1CellManagement::getICCIDContinue()
 {
 	bool resp;
 	
-	switch (theGSM3ShieldV1ModemCore.getCommandCounter()) {
-    case 1:
-		theGSM3ShieldV1ModemCore.setCommandCounter(2);
-		theGSM3ShieldV1ModemCore.genericCommand_rq(PSTR("AT+QCCID"), false);
-		theGSM3ShieldV1ModemCore.print("\r");
-		break;
-	case 2:
-		if (theGSM3ShieldV1ModemCore.genericParse_rsp(resp))
-		{
-			parseQCCID_available(resp);
-			theGSM3ShieldV1ModemCore.closeCommand(2);
-		}
-		else theGSM3ShieldV1ModemCore.closeCommand(1);
-		break;
+	switch (theGSM3ShieldV1ModemCore.getCommandCounter())
+	{
+		case 1:
+			theGSM3ShieldV1ModemCore.setCommandCounter(2);
+			_delay_ms(500);
+			theGSM3ShieldV1ModemCore.genericCommand_rq(PSTR("AT+QCCID"), false);
+			theGSM3ShieldV1ModemCore.print("\r");
+			break;
+			
+		case 2:
+			if(theGSM3ShieldV1ModemCore.genericParse_rsp(resp))
+			{
+				parseQCCID_available(resp);
+				if(resp)
+					theGSM3ShieldV1ModemCore.closeCommand(2);
+			}
+			else theGSM3ShieldV1ModemCore.closeCommand(1);
+			break;
+	}
+}
+
+void GSM3ShieldV1CellManagement::getIMEIContinue()
+{
+	bool resp;
+	
+	switch (theGSM3ShieldV1ModemCore.getCommandCounter())
+	{
+		case 1:
+			theGSM3ShieldV1ModemCore.setCommandCounter(2);
+			_delay_ms(500);
+			theGSM3ShieldV1ModemCore.genericCommand_rq(PSTR("AT+GSN"), false);
+			theGSM3ShieldV1ModemCore.print("\r");
+			break;
+			
+		case 2:
+			if(theGSM3ShieldV1ModemCore.genericParse_rsp(resp))
+			{
+				parseGSN_available(resp);
+				if(resp)
+					theGSM3ShieldV1ModemCore.closeCommand(2);
+			}
+			else theGSM3ShieldV1ModemCore.closeCommand(1);
+			break;
 	}
 }
 
@@ -155,14 +450,38 @@ void GSM3ShieldV1CellManagement::manageResponse(byte from, byte to)
 {
 	switch(theGSM3ShieldV1ModemCore.getOngoingCommand())
 	{
-		case NONE:
+		default:
+			// For remove enum switch warnings
+			break;
+		case GSM_NONE:
 			theGSM3ShieldV1ModemCore.gss.cb.deleteToTheEnd(from);
 			break;
-		case GETLOCATION:
-			getLocationContinue();
+		case UPDATELOCATION:
+			updateLocationContinue();
 			break;
 		case GETICCID:
 			getICCIDContinue();
 			break;
+		case GETIMEI:
+			getIMEIContinue();
+			break;
+		case GETPOWERDATA:
+			getPowerDataContinue();
+			break;
 	}
+}
+
+int GSM3ShieldV1CellManagement::readCompleteResponse()
+{
+	char charResponse;
+		
+	if(theGSM3ShieldV1ModemCore.theBuffer().availableBytes()==0)
+		return 0;
+	
+	charResponse = theGSM3ShieldV1ModemCore.theBuffer().read(); 
+	
+	if(theGSM3ShieldV1ModemCore.theBuffer().availableBytes()==100)
+		theGSM3ShieldV1ModemCore.gss.spaceAvailable();
+
+	return charResponse;
 }

--- a/libraries/GSM/src/GSM3ShieldV1CellManagement.h
+++ b/libraries/GSM/src/GSM3ShieldV1CellManagement.h
@@ -41,52 +41,128 @@ https://github.com/BlueVia/Official-Arduino
 class GSM3ShieldV1CellManagement : public GSM3MobileCellManagement, public GSM3ShieldV1BaseProvider
 {		
 	public:
-	
-		/** Constructor
+		
+		/** 
+			Constructor
 		*/
 		GSM3ShieldV1CellManagement();
 
-		/** Manages modem response
+		/** 
+			Manages modem response
+			
 			@param from 		Initial byte of buffer
 			@param to 			Final byte of buffer
 		 */
 		void manageResponse(byte from, byte to);
 		
-		/** getLocation
-		 @return current cell location
+		/**
+			Update cells attribute with the last information.
+		 
+			@param set if includes 1 to 6 neighbours or only current cell
+			@return number of cells included in cells attribute
 		*/		
-		int getLocation(char *country, char *network, char *area, char *cell);
+		uint8_t updateLocation(bool neighbours = false);
 		
-		/** getICCID
-		*/
-		int getICCID(char *iccid);
+		/**
+			Return the cells array pointer
+			
+			@return the pointer to cells struct
+		 */
+		Cell* getCells(){return cells;};
 		
-		/** Get last command status
+		/**
+			Return the cells array pointer
+			
+			@return the pointer to cells struct
+		 */
+		uint8_t getNumberCells(){return cellsLength;};
+		
+		/**
+			Return if neighbours mode is active
+			
+			@return true if neighbours mode was activated, false if was not
+		 */
+		bool getNeighboursActivated(){return neighboursActivated;};
+		
+		/**
+			getICCID
+		 */
+		int8_t getICCID(char *iccid);
+		
+		/**
+			getIMEI
+		 */
+		int8_t getIMEI(char *imei);
+		
+		/**
+			getPowerData
+		 */
+		int8_t getPowerData(char *info);
+		
+		/** 
+			Get last command status
+			
 			@return returns 0 if last command is still executing, 1 success, >1 error
 		 */
 		int ready(){return GSM3ShieldV1BaseProvider::ready();};
 
 	private:	
 	
-		char *countryCode;
-		char *networkCode;
-		char *locationArea;
-		char *cellId;
+		// Location variables
+		uint8_t cellsLength;
+		Cell cells[7];
+		bool neighboursActivated;
 		
+		// Pointer to save ICCID
 		char *bufferICCID;
-	
-		/** Continue to getLocation function
-		 */
-		void getLocationContinue();
 		
-		/** Continue to getICCID function
+		// Pointer to save IMEI
+		char *bufferIMEI;
+		
+		// Pointer to save power data
+		char *powerData;
+	
+		/**
+			Continue to updateLocation function
+			
+			@param set if includes 1 to 6 neighbours or only current cell
+		 */
+		void updateLocationContinue();
+		
+		/**
+			Continue to getICCID function
 		 */
 		void getICCIDContinue();
 		
+		/**
+			Continue to getIMEI function
+		 */
+		void getIMEIContinue();
+		
+		/**
+			Continue to getPowerData function
+		 */
+		void getPowerDataContinue();
+		
+		/**
+			Parsers for AT commands
+		 */
 		bool parseQENG_available(bool& rsp);
-		
 		bool parseQCCID_available(bool& rsp);
+		bool parseGSN_available(bool& rsp);
+		bool parseCBC_available(bool& rsp);
 		
+		/**
+			Special parser for neighbours cells
+		 */
+		bool extractNeighbours(bool &rsp);
+		
+		/**
+			Special reader from buffer for neighbours response
+			
+			@return each character of buffer
+		 */
+		int readCompleteResponse();
 };
 
 #endif

--- a/libraries/GSM/src/GSM3ShieldV1ClientProvider.cpp
+++ b/libraries/GSM/src/GSM3ShieldV1ClientProvider.cpp
@@ -11,7 +11,7 @@ void GSM3ShieldV1ClientProvider::manageResponse(byte from, byte to)
 {
 	switch(theGSM3ShieldV1ModemCore.getOngoingCommand())
 	{
-		case NONE:
+		case GSM_NONE:
 			theGSM3ShieldV1ModemCore.gss.cb.deleteToTheEnd(from);
 			break;
 		case CONNECTTCPCLIENT:

--- a/libraries/GSM/src/GSM3ShieldV1DataNetworkProvider.cpp
+++ b/libraries/GSM/src/GSM3ShieldV1DataNetworkProvider.cpp
@@ -144,6 +144,9 @@ void GSM3ShieldV1DataNetworkProvider::attachGPRSContinue()
 			if(resp)
 			{
 				// AT+QIACT	
+				#ifdef __ARDUINO_X86__
+				delay(1000);
+				#endif
 				theGSM3ShieldV1ModemCore.genericCommand_rq(PSTR("AT+QIACT"));
 				theGSM3ShieldV1ModemCore.setCommandCounter(10);
 			}
@@ -291,6 +294,8 @@ int GSM3ShieldV1DataNetworkProvider::inet_aton(const char* aIPAddrString, IPAddr
 {
     // See if we've been given a valid IP address
     const char* p =aIPAddrString;
+	uint8_t theAddr[4];
+	
     while (*p &&
            ( (*p == '.') || (*p >= '0') || (*p <= '9') ))
     {
@@ -315,7 +320,9 @@ int GSM3ShieldV1DataNetworkProvider::inet_aton(const char* aIPAddrString, IPAddr
                 }
                 else
                 {
-                    aResult[segment] = (byte)segmentValue;
+					// This doesn't run on Galileo
+					// aResult[segment] = (byte)segmentValue;
+					theAddr[segment]=(uint8_t)segmentValue;
                     segment++;
                     segmentValue = 0;
                 }
@@ -336,8 +343,11 @@ int GSM3ShieldV1DataNetworkProvider::inet_aton(const char* aIPAddrString, IPAddr
             return 0;
         }
         else
-        {
-            aResult[segment] = (byte)segmentValue;
+        {	
+			// This doesn't run on Galileo
+            //aResult[segment] = (byte)segmentValue;
+			theAddr[segment]=(uint8_t)segmentValue;
+			aResult=theAddr;
             return 1;
         }
     }

--- a/libraries/GSM/src/GSM3ShieldV1ModemCore.cpp
+++ b/libraries/GSM/src/GSM3ShieldV1ModemCore.cpp
@@ -12,9 +12,8 @@ GSM3ShieldV1ModemCore::GSM3ShieldV1ModemCore() : gss()
 	_dataInBufferTo=0;
 	commandError=1;
 	commandCounter=0;
-	ongoingCommand=NONE;
+	ongoingCommand=GSM_NONE;
 	takeMilliseconds();
-	
 	for(int i=0;i<UMPROVIDERS;i++)
 		UMProvider[i]=0;
 }
@@ -69,7 +68,7 @@ void GSM3ShieldV1ModemCore::closeCommand(int code)
 		theGSM3ShieldV1ModemCore.setStatus(ERROR);
 
 	setCommandError(code);
-	ongoingCommand=NONE;
+	ongoingCommand=GSM_NONE;
 	activeProvider=0;
 	commandCounter=1;
 }
@@ -107,6 +106,11 @@ void GSM3ShieldV1ModemCore::manageMsg(byte from, byte to)
 
 void GSM3ShieldV1ModemCore::manageReceivedData()
 {
+	// Para Galileo
+#ifdef __ARDUINO_X86__
+	gss.checkModemInput();
+#endif
+
 	if(_debug)
 	{
 /*		Serial.print(theBuffer().getHead());
@@ -184,11 +188,17 @@ size_t GSM3ShieldV1ModemCore::write(uint8_t c)
 
 unsigned long GSM3ShieldV1ModemCore::takeMilliseconds()
 {
+#ifndef __ARDUINO_X86__
 	unsigned long now=millis();
 	unsigned long delta;
 	delta=now-milliseconds;
 	milliseconds=now;
 	return delta;
+#else
+	return 0;
+#endif
+
+
 }
 
 void GSM3ShieldV1ModemCore::delayInsideInterrupt(unsigned long milliseconds)

--- a/libraries/GSM/src/GSM3ShieldV1MultiClientProvider.cpp
+++ b/libraries/GSM/src/GSM3ShieldV1MultiClientProvider.cpp
@@ -22,9 +22,9 @@ void GSM3ShieldV1MultiClientProvider::manageResponse(byte from, byte to)
 //					flagReadingSocket = 0;
 					fullBufferSocket = (theGSM3ShieldV1ModemCore.theBuffer().availableBytes()<3);
 				}
-			else theGSM3ShieldV1ModemCore.setOngoingCommand(NONE);
+			else theGSM3ShieldV1ModemCore.setOngoingCommand(GSM_NONE);
 			break;
-		case NONE:
+		case GSM_NONE:
 			theGSM3ShieldV1ModemCore.gss.cb.deleteToTheEnd(from);
 			break;
 		case CONNECTTCPCLIENT:

--- a/libraries/GSM/src/GSM3ShieldV1MultiServerProvider.cpp
+++ b/libraries/GSM/src/GSM3ShieldV1MultiServerProvider.cpp
@@ -19,7 +19,7 @@ void GSM3ShieldV1MultiServerProvider::manageResponse(byte from, byte to)
 {
 	switch(theGSM3ShieldV1ModemCore.getOngoingCommand())
 	{
-		case NONE:
+		case GSM_NONE:
 			theGSM3ShieldV1ModemCore.gss.cb.deleteToTheEnd(from);
 			break;
 		case CONNECTSERVER:

--- a/libraries/GSM/src/GSM3ShieldV1SMSProvider.cpp
+++ b/libraries/GSM/src/GSM3ShieldV1SMSProvider.cpp
@@ -273,9 +273,9 @@ void GSM3ShieldV1SMSProvider::manageResponse(byte from, byte to)
 //					flagReadingSocket = 0;
 					fullBufferSocket = (theGSM3ShieldV1ModemCore.theBuffer().availableBytes()<3);
 				}
-			else theGSM3ShieldV1ModemCore.openCommand(this,NONE);
+			else theGSM3ShieldV1ModemCore.openCommand(this,GSM_NONE);
 			break;
-*/		case NONE:
+*/		case GSM_NONE:
 			theGSM3ShieldV1ModemCore.gss.cb.deleteToTheEnd(from);
 			break;
 		case BEGINSMS:

--- a/libraries/GSM/src/GSM3ShieldV1ServerProvider.cpp
+++ b/libraries/GSM/src/GSM3ShieldV1ServerProvider.cpp
@@ -12,7 +12,7 @@ void GSM3ShieldV1ServerProvider::manageResponse(byte from, byte to)
 {
 	switch(theGSM3ShieldV1ModemCore.getOngoingCommand())
 	{
-		case NONE:
+		case GSM_NONE:
 			theGSM3ShieldV1ModemCore.gss.cb.deleteToTheEnd(from);
 			break;
 		case CONNECTSERVER:

--- a/libraries/GSM/src/GSM3SoftSerial.h
+++ b/libraries/GSM/src/GSM3SoftSerial.h
@@ -169,6 +169,9 @@ class GSM3SoftSerial : public GSM3CircularBufferManager
 		/** Close serial connection
 		 */
 		void close();
+		
+		// For Galileo
+        void checkModemInput(){recv();};
 };
 
 #endif


### PR DESCRIPTION
Adapted so the same library runs for Galileo. Tested also on 1.0.6 and 1.5.8.
NONE state is renamed GSM_NONE
When in Intel, the SoftwareSerial is not used, but Serial1 is called.
checkModemInput is included and executed to look for modem comms.
manageResponse gets a void implementation, so it compiles.
GSM3ShieldV1DataNetworkProvider::inet_aton uses an intermediate value to generate the IP address
A small change in WebClient that makes for us easier the automatic testing.