### PR TITLE
rename hex -> output

### DIFF
--- a/arduino-core/src/processing/app/debug/Compiler.java
+++ b/arduino-core/src/processing/app/debug/Compiler.java
@@ -405,7 +405,7 @@ public class Compiler implements MessageConsumer {
 
     // 6. build the .hex file
     progressListener.progress(80);
-    runRecipe("recipe.objcopy.hex.pattern");
+    runRecipe("recipe.objcopy.output.pattern");
 
     progressListener.progress(90);
     return true;

--- a/hardware/arduino/avr/platform.txt
+++ b/hardware/arduino/avr/platform.txt
@@ -65,7 +65,7 @@ recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.f
 recipe.objcopy.eep.pattern="{compiler.path}{compiler.objcopy.cmd}" {compiler.objcopy.eep.flags} {compiler.objcopy.eep.extra_flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.eep"
 
 ## Create hex
-recipe.objcopy.hex.pattern="{compiler.path}{compiler.elf2hex.cmd}" {compiler.elf2hex.flags} {compiler.elf2hex.extra_flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.hex"
+recipe.objcopy.output.pattern="{compiler.path}{compiler.elf2hex.cmd}" {compiler.elf2hex.flags} {compiler.elf2hex.extra_flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.hex"
 
 ## Compute size
 recipe.size.pattern="{compiler.path}{compiler.size.cmd}" -A "{build.path}/{build.project_name}.elf"

--- a/hardware/arduino/sam/platform.txt
+++ b/hardware/arduino/sam/platform.txt
@@ -69,7 +69,7 @@ recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.f
 recipe.objcopy.eep.pattern=
 
 ## Create hex
-recipe.objcopy.hex.pattern="{compiler.path}{compiler.elf2hex.cmd}" {compiler.elf2hex.flags} {compiler.elf2hex.extra_flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.bin"
+recipe.objcopy.output.pattern="{compiler.path}{compiler.elf2hex.cmd}" {compiler.elf2hex.flags} {compiler.elf2hex.extra_flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.bin"
 
 ## Compute size
 recipe.size.pattern="{compiler.path}{compiler.size.cmd}" -A "{build.path}/{build.project_name}.elf"


### PR DESCRIPTION
using generic term 'output', because for samx32,
output is .bin format and not .hex

Signed-off-by: Arnav Gupta <championswimmer@gmail.com>