### PR TITLE
EthernetClient == and != operators

### DIFF
--- a/libraries/Ethernet/src/EthernetClient.h
+++ b/libraries/Ethernet/src/EthernetClient.h
@@ -24,6 +24,8 @@ public:
   virtual void stop();
   virtual uint8_t connected();
   virtual operator bool();
+  virtual bool operator==(const bool value) { return bool() == value; }
+  virtual bool operator!=(const bool value) { return bool() != value; }
   virtual bool operator==(const EthernetClient&);
   virtual bool operator!=(const EthernetClient& rhs) { return !this->operator==(rhs); };
 


### PR DESCRIPTION
Added `virtual bool operator==(const bool value)` and `virtual bool operator!=(const bool value)`.
Fixes #2611
Bug introduced with #1700
@cmaglie @matthijskooijman you're far more expert than me with c++
