### PR TITLE
Macosx: filter out /dev/cu* ports

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -1000,6 +1000,8 @@ public class Editor extends JFrame implements RunnerListener {
 
     List<BoardPort> ports = Base.getDiscoveryManager().discovery();
 
+    ports = Base.getPlatform().filterPorts(ports, Preferences.getBoolean("serial.ports.showall"));
+
     Collections.sort(ports, new Comparator<BoardPort>() {
       @Override
       public int compare(BoardPort o1, BoardPort o2) {

--- a/arduino-core/src/processing/app/Platform.java
+++ b/arduino-core/src/processing/app/Platform.java
@@ -30,6 +30,7 @@ import java.util.Map;
 
 import javax.swing.UIManager;
 
+import cc.arduino.packages.BoardPort;
 import com.sun.jna.Library;
 import com.sun.jna.Native;
 import processing.app.debug.TargetBoard;
@@ -216,5 +217,9 @@ public class Platform {
     BaseNoGui.showWarning(_("No launcher available"), 
                           _("Unspecified platform, no launcher available.\nTo enable opening URLs or folders, add a \n\"launcher=/path/to/app\" line to preferences.txt"),
                           null);
+  }
+
+  public List<BoardPort> filterPorts(List<BoardPort> ports, boolean aBoolean) {
+    return new LinkedList<BoardPort>(ports);
   }
 }

--- a/arduino-core/src/processing/app/macosx/Platform.java
+++ b/arduino-core/src/processing/app/macosx/Platform.java
@@ -22,6 +22,7 @@
 
 package processing.app.macosx;
 
+import cc.arduino.packages.BoardPort;
 import com.apple.eio.FileManager;
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.Executor;
@@ -35,7 +36,8 @@ import java.awt.*;
 import java.io.*;
 import java.lang.reflect.Method;
 import java.net.URI;
-import java.util.Map;
+import java.util.*;
+import java.util.List;
 
 
 /**
@@ -238,5 +240,21 @@ public class Platform extends processing.app.Platform {
     } catch (Throwable e) {
       return super.preListAllCandidateDevices();
     }
+  }
+
+  @Override
+  public java.util.List<BoardPort> filterPorts(java.util.List<BoardPort> ports, boolean showAll) {
+    if (showAll) {
+      return super.filterPorts(ports, true);
+    }
+
+    List<BoardPort> filteredPorts = new LinkedList<BoardPort>();
+    for (BoardPort port : ports) {
+      if (!port.getAddress().startsWith("/dev/cu.")) {
+        filteredPorts.add(port);
+      }
+    }
+
+    return filteredPorts;
   }
 }


### PR DESCRIPTION
Filter out /dev/cu* ports, can be re-enabled manually adding `serial.ports.showall=true` into preferences.txt file

Closes #2624