### PR TITLE
Fix for issue #2402

### DIFF
--- a/app/src/processing/app/FindReplace.java
+++ b/app/src/processing/app/FindReplace.java
@@ -421,8 +421,9 @@ public class FindReplace extends JFrame implements ActionListener {
   public void replaceAll() {
     if (findField.getText().length() == 0)
       return;
-    // move to the beginning
-    editor.setSelection(0, 0);
+    
+    editor.getSketch().setCurrentCode(0); // select the first tab
+    editor.setSelection(0, 0); // move to the beginning
 
     boolean foundAtLeastOne = false;
     while (true) {


### PR DESCRIPTION
Fix for #2402 

To test simply create a series of tabs with content you want to replace, select a tab to the right of the first tab. Go to Edit->Find, enter text to replace and what to replace it with, select Search all Sketch Tabs, then press Replace All.

Result: search will start from the first tab and precede along the list. 

Before it would just search every tab to the right of the selected tab, now it does every tab.