### PR TITLE
Fix findUntil and general timeouts in Stream library

### DIFF
--- a/hardware/arduino/avr/cores/arduino/Stream.h
+++ b/hardware/arduino/avr/cores/arduino/Stream.h
@@ -41,8 +41,14 @@ class Stream : public Print
     unsigned long _timeout;      // number of milliseconds to wait for the next char before aborting timed read
     unsigned long _startMillis;  // used for timeout measurement
     int timedRead();    // private method to read stream with timeout
+    int _timedRead();   // timedRead() but assumes clock already started
     int timedPeek();    // private method to peek stream with timeout
+    int _timedPeek();   // timedPeak() but assumes clock already started
     int peekNextDigit(); // returns the next numeric digit in the stream or -1 if timeout
+    int _peekNextDigit(); // peekNextDigit() but assumes clock already started
+    void startClock();  // helper, used for all of the timed read routines
+    bool checkClock();  // helper, consistent check if we've timed out
+
 
   public:
     virtual int available() = 0;
@@ -88,6 +94,7 @@ class Stream : public Print
   // returns the number of characters placed in the buffer (0 means no valid data found)
 
   // Arduino String functions to be added here
+
   String readString();
   String readStringUntil(char terminator);
 
@@ -97,6 +104,20 @@ class Stream : public Print
   // this allows format characters (typically commas) in values to be ignored
 
   float parseFloat(char skipChar);  // as above but the given skipChar is ignored
+
+  public:
+  struct MultiTarget {
+    const char *str;  // string you're searching for
+    size_t len;       // length of string you're searching for
+    size_t index;     // index used by the search routine.
+  };
+
+  // This allows you to search for an arbitrary number of strings.
+  // Returns index of the target that is found first or -1 if timeout occurs.
+  int findMulti(struct MultiTarget *targets, int tCount);
+
+
 };
+
 
 #endif

--- a/hardware/arduino/sam/cores/arduino/Stream.h
+++ b/hardware/arduino/sam/cores/arduino/Stream.h
@@ -41,8 +41,14 @@ class Stream : public Print
     unsigned long _timeout;      // number of milliseconds to wait for the next char before aborting timed read
     unsigned long _startMillis;  // used for timeout measurement
     int timedRead();    // private method to read stream with timeout
+    int _timedRead();   // timedRead() but assumes clock already started
     int timedPeek();    // private method to peek stream with timeout
+    int _timedPeek();   // timedPeak() but assumes clock already started
     int peekNextDigit(); // returns the next numeric digit in the stream or -1 if timeout
+    int _peekNextDigit(); // peekNextDigit() but assumes clock already started
+    void startClock();  // helper, used for all of the timed read routines
+    bool checkClock();  // helper, consistent check if we've timed out
+
 
   public:
     virtual int available() = 0;
@@ -88,6 +94,7 @@ class Stream : public Print
   // returns the number of characters placed in the buffer (0 means no valid data found)
 
   // Arduino String functions to be added here
+
   String readString();
   String readStringUntil(char terminator);
 
@@ -97,6 +104,20 @@ class Stream : public Print
   // this allows format characters (typically commas) in values to be ignored
 
   float parseFloat(char skipChar);  // as above but the given skipChar is ignored
+
+  public:
+  struct MultiTarget {
+    const char *str;  // string you're searching for
+    size_t len;       // length of string you're searching for
+    size_t index;     // index used by the search routine.
+  };
+
+  // This allows you to search for an arbitrary number of strings.
+  // Returns index of the target that is found first or -1 if timeout occurs.
+  int findMulti(struct MultiTarget *targets, int tCount);
+
+
 };
+
 
 #endif


### PR DESCRIPTION
This is my proposed fix to issue 2591 https://github.com/arduino/Arduino/issues/2591 .  Primarily this fixes two things:  The most important is that searching for something like "1112" in the stream "11112" now works.  The second thing is that timeouts on stream reads are properly respected.  In the previous version of the code, if you set a timeout of 1000 millisecs and your stream produced a single character every 500 milliseconds, a read would never time out since the clock would be reset every time the program entered timed read.  I had to add a handful of private methods to keep all of the other methods intact but I believe that all of the public and protected methods are maintained as before minus the two bugs I described.  I also added a low level find routine that would support an arbitrary number of target strings since it's not uncommon to be searching for more than one good string and one error string indistinguishable in the interface from a timeout.  This last routine, findMulti() is not very Arduino library like (requiring you to pass in an array of structs) but you need one integer of scratch space per find target* and I felt that dynamically allocating that in the function was a greater sin with only 2k of ram.  Everything else uses a constant amount of stack space.

* Alternately a different algorithm could be used that requires a buffer space at least as large as the largest search target.  When searching for lots of different short strings this other algorithm would be more space efficient.  It's possible to write an routine that will do this in constant space and I'm sure I could write it but it is ugly and more inefficient than what I've written here to get away with only using one extra int per search target.