### PR TITLE
Update license.txt for 1.6.0+ directory structure

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -1,12 +1,18 @@
-this file includes licensing information for parts of arduino.
+This file includes licensing information for parts of arduino.
 
-first, the gnu general public license, which covers the main body 
-of the processing/arduino code (in general, all the stuff inside the 'app'
-and 'core' subfolders).
+Unless otherwise explicitly stated in a file or directory:
 
-next, the gnu lesser general public license that covers the arduino core
-and libraries.
+1) Files in hardware/ and libraries/ are licensed unde the GNU Lesser
+General Public License Version 2.1 (or later).
 
+2) Reference documentation, available for download from this repository
+or https://github.com/arduino/reference-en, is licensed CC-BY-SA-3.0.
+
+3) Example files (e.g., */examples/*) are freely released into the
+public domain.
+
+4) All other files are licensed under the GNU General Public License
+Version 2 (or later).
 
 .....................................................................
 


### PR DESCRIPTION
This is just to clarify the license since the folders were renamed. Also removes all ambiguity while allowing individual files and folders to be licensed appropriately (e.g., the catch-all GPL license covers all the scripts in build/).