### PR TITLE
Fix auto-reset on Leonardo-derived boards from Linux hosts

### DIFF
--- a/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
+++ b/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
@@ -116,7 +116,7 @@ public class SerialUploader extends Uploader {
           if (verbose)
             System.out.println(
               I18n.format(_("Forcing reset using 1200bps open/close on port {0}"), uploadPort));
-          Serial.touchPort(uploadPort, 1200);
+          Serial.touchForCDCReset(uploadPort);
         }
         Thread.sleep(400);
         if (waitForUploadPort) {

--- a/arduino-core/src/processing/app/Serial.java
+++ b/arduino-core/src/processing/app/Serial.java
@@ -80,11 +80,12 @@ public class Serial implements SerialPortEventListener {
             new Float(PreferencesData.get("serial.stopbits")).floatValue());
   }
 
-  public static boolean touchPort(String iname, int irate) throws SerialException {
+  public static boolean touchForCDCReset(String iname) throws SerialException {
     SerialPort serialPort = new SerialPort(iname);
     try {
       serialPort.openPort();
-      serialPort.setParams(irate, 8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
+      serialPort.setParams(1200, 8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
+      serialPort.setDTR(false);
       serialPort.closePort();
       return true;
     } catch (SerialPortException e) {


### PR DESCRIPTION
I noticed auto-reset for catarina/atmega32u4 baords wasn't working in 1.6.0 on my Linux computer, and traced it back to the change from librxtx to JSSC.

Technical details in the commit message. I haven't tested this on other platforms, I expect it would probably not break anything but I guess you can never really tell. :)

Hoping I'm not too late to miss the boat for 1.6.1.