### PR TITLE
Fix Saveas method to prevent saving sketch into itself error

### DIFF
--- a/app/src/processing/app/Sketch.java
+++ b/app/src/processing/app/Sketch.java
@@ -641,7 +641,14 @@ public class Sketch {
       fd.setSelectedFile(new File(Base.getSketchbookFolder().getAbsolutePath(), data.getFolder().getName()));
     } else {
       // default to the parent folder of where this was
-      fd.setSelectedFile(data.getFolder());
+      // on macs a .getParentFile() method is required
+        
+      if (OSUtils.isMacOS()) {
+            fd.setSelectedFile(data.getFolder().getParentFile());
+      } else {
+          fd.setSelectedFile(data.getFolder());
+      }
+        
     }
 
     int returnVal = fd.showSaveDialog(editor);


### PR DESCRIPTION
Simple fix that should solve issue [#2655](https://github.com/arduino/Arduino/issues/2655)
Added .getParentFile() to the saveas method, such that it actually uses the parent folder of the sketch, and no longer the sketch itself. Only does this for macs, as the problem does not occur on windows computers.
Prevents the saving sketch into itself error