### PR TITLE
Add scaling for themed fonts and graphics (hires displays)

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -99,8 +99,6 @@ public class Base {
 
     BaseNoGui.initParameters(args);
 
-    System.setProperty("swing.aatext", Preferences.get("editor.antialias", "true"));
-
     BaseNoGui.initVersion();
 
 //    if (System.getProperty("mrj.version") != null) {
@@ -149,6 +147,7 @@ public class Base {
 
     // setup the theme coloring fun
     Theme.init();
+    System.setProperty("swing.aatext", Preferences.get("editor.antialias", "true"));
 
     // Set the look and feel before opening the window
     try {
@@ -1525,9 +1524,11 @@ public class Base {
           g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
                               RenderingHints.VALUE_TEXT_ANTIALIAS_OFF);
 
-          g.setFont(new Font("SansSerif", Font.PLAIN, 11));
+          int scale = Theme.getInteger("gui.scalePercent");
+          Font f = new Font("SansSerif", Font.PLAIN, 11 * scale / 100);
+          g.setFont(f);
           g.setColor(Color.white);
-          g.drawString(BaseNoGui.VERSION_NAME, 50, 30);
+          g.drawString(BaseNoGui.VERSION_NAME, 50 * scale / 100, 30 * scale / 100);
         }
       };
     window.addMouseListener(new MouseAdapter() {
@@ -2176,6 +2177,9 @@ public class Base {
     Image image = null;
     Toolkit tk = Toolkit.getDefaultToolkit();
 
+    int scale = Theme.getInteger("gui.scalePercent");
+    // TODO: create high-res enlarged copies and load those if
+    //       the scale is more than 125%
     File imageLocation = new File(getContentFile("lib"), name);
     image = tk.getImage(imageLocation.getAbsolutePath());
     MediaTracker tracker = new MediaTracker(who);
@@ -2183,6 +2187,15 @@ public class Base {
     try {
       tracker.waitForAll();
     } catch (InterruptedException e) { }
+    if (scale != 100) {
+      int width = image.getWidth(null) * scale / 100;
+      int height = image.getHeight(null) * scale / 100;
+      image = image.getScaledInstance(width, height, Image.SCALE_SMOOTH);
+      tracker.addImage(image, 1);
+      try {
+        tracker.waitForAll();
+      } catch (InterruptedException e) { }
+    }
     return image;
   }
 

--- a/app/src/processing/app/EditorHeader.java
+++ b/app/src/processing/app/EditorHeader.java
@@ -69,6 +69,9 @@ public class EditorHeader extends JComponent {
 
   static final int PIECE_WIDTH = 4;
 
+  // value for the size bars, buttons, etc
+  static final int GRID_SIZE = 33 * Theme.getInteger("gui.scalePercent") / 100;
+
   static Image[][] pieces;
 
   //
@@ -383,16 +386,16 @@ public class EditorHeader extends JComponent {
 
   public Dimension getMinimumSize() {
     if (OSUtils.isMacOS()) {
-      return new Dimension(300, Preferences.GRID_SIZE);
+      return new Dimension(300, GRID_SIZE);
     }
-    return new Dimension(300, Preferences.GRID_SIZE - 1);
+    return new Dimension(300, GRID_SIZE - 1);
   }
 
 
   public Dimension getMaximumSize() {
     if (OSUtils.isMacOS()) {
-      return new Dimension(3000, Preferences.GRID_SIZE);
+      return new Dimension(3000, GRID_SIZE);
     }
-    return new Dimension(3000, Preferences.GRID_SIZE - 1);
+    return new Dimension(3000, GRID_SIZE - 1);
   }
 }

--- a/app/src/processing/app/EditorLineStatus.java
+++ b/app/src/processing/app/EditorLineStatus.java
@@ -62,7 +62,7 @@ public class EditorLineStatus extends JComponent {
     background = Theme.getColor("linestatus.bgcolor");
     font = Theme.getFont("linestatus.font");
     foreground = Theme.getColor("linestatus.color");
-    high = Theme.getInteger("linestatus.height");
+    high = Theme.getInteger("linestatus.height") * Theme.getInteger("gui.scalePercent") / 100;
 
     if (OSUtils.isMacOS()) {
       resize = Base.getThemeImage("resize.gif", this);

--- a/app/src/processing/app/EditorStatus.java
+++ b/app/src/processing/app/EditorStatus.java
@@ -56,6 +56,9 @@ public class EditorStatus extends JPanel /*implements ActionListener*/ {
 
   static final String NO_MESSAGE = "";
 
+  // value for the size bars, buttons, etc
+  static final int GRID_SIZE = 33 * Theme.getInteger("gui.scalePercent") / 100;
+
   Editor editor;
 
   int mode;
@@ -524,11 +527,11 @@ public class EditorStatus extends JPanel /*implements ActionListener*/ {
   }
 
   public Dimension getMinimumSize() {
-    return new Dimension(300, Preferences.GRID_SIZE);
+    return new Dimension(300, GRID_SIZE);
   }
 
   public Dimension getMaximumSize() {
-    return new Dimension(3000, Preferences.GRID_SIZE);
+    return new Dimension(3000, GRID_SIZE);
   }
 
 

--- a/app/src/processing/app/EditorToolbar.java
+++ b/app/src/processing/app/EditorToolbar.java
@@ -48,13 +48,13 @@ public class EditorToolbar extends JComponent implements MouseInputListener, Key
 
   static final int BUTTON_COUNT  = title.length;
   /** Width of each toolbar button. */
-  static final int BUTTON_WIDTH  = 27;
+  static final int BUTTON_WIDTH  = 27 * Theme.getInteger("gui.scalePercent") / 100;
   /** Height of each toolbar button. */
-  static final int BUTTON_HEIGHT = 32;
+  static final int BUTTON_HEIGHT = 32 * Theme.getInteger("gui.scalePercent") / 100;
   /** The amount of space between groups of buttons on the toolbar. */
-  static final int BUTTON_GAP    = 5;
+  static final int BUTTON_GAP    = 5 * Theme.getInteger("gui.scalePercent") / 100;
   /** Size of the button image being chopped up. */
-  static final int BUTTON_IMAGE_SIZE = 33;
+  static final int BUTTON_IMAGE_SIZE = 33 * Theme.getInteger("gui.scalePercent") / 100;
 
 
   static final int RUN      = 0;
@@ -393,7 +393,7 @@ public class EditorToolbar extends JComponent implements MouseInputListener, Key
 
 
   public Dimension getMaximumSize() {
-    return new Dimension(3000, BUTTON_HEIGHT);
+    return new Dimension(3000 * Theme.getInteger("gui.scalePercent") / 100, BUTTON_HEIGHT);
   }
 
 

--- a/app/src/processing/app/Preferences.java
+++ b/app/src/processing/app/Preferences.java
@@ -205,7 +205,7 @@ public class Preferences {
 
   // value for the size bars, buttons, etc
 
-  static final int GRID_SIZE     = 33;
+  static final int GRID_SIZE     = 33 * Theme.getInteger("gui.scalePercent") / 100;
 
 
   // indents and spacing standards. these probably need to be modified

--- a/app/src/processing/app/Preferences.java
+++ b/app/src/processing/app/Preferences.java
@@ -203,11 +203,6 @@ public class Preferences {
    */
   static public int BUTTON_HEIGHT = 24;
 
-  // value for the size bars, buttons, etc
-
-  static final int GRID_SIZE     = 33 * Theme.getInteger("gui.scalePercent") / 100;
-
-
   // indents and spacing standards. these probably need to be modified
   // per platform as well, since macosx is so huge, windows is smaller,
   // and linux is all over the map

--- a/app/src/processing/app/Theme.java
+++ b/app/src/processing/app/Theme.java
@@ -101,6 +101,10 @@ public class Theme {
       set(attr, value);
       font = PreferencesHelper.getFont(table, attr);
     }
+    int scale = getInteger("gui.scalePercent");
+    if (scale != 100) {
+      font = font.deriveFont((float)(font.getSize()) * (float)scale / (float)100.0);
+    }
     return font;
   }
 

--- a/build/shared/lib/theme/theme.txt
+++ b/build/shared/lib/theme/theme.txt
@@ -1,3 +1,6 @@
+# GUI - Scaling, edit this to scale to higher dots-per-inch displays
+gui.scalePercent = 100
+
 # GUI - STATUS
 status.notice.fgcolor = #002325
 status.notice.bgcolor = #17A1A5


### PR DESCRIPTION
This pull request adds a "gui.scalePercent" parameter in lib/theme/theme.txt, which can scale most of the currently fixed size graphics and fonts.  This allows adjusting Arduino for 4K and other high res screens.  It should mostly solve issue #2532 .

Forum user "the-fallen" deserves much of the credit for this patch.  He created the original version, posted to the forum.  I added automatic font and graphic scaling, and changed it to percentage for finer control.

Discussion is here:

http://forum.arduino.cc/index.php?topic=263838.0