### PR TITLE
do not trust received msg length to read forever

### DIFF
--- a/libraries/Bridge/src/Bridge.cpp
+++ b/libraries/Bridge/src/Bridge.cpp
@@ -191,12 +191,13 @@ uint16_t BridgeClass::transfer(const uint8_t *buff1, uint16_t len1,
 
     // Recv data
     for (uint16_t i = 0; i < l; i++) {
+      // Cut received data if rxbuffer is too small
+      if (i >= rxlen)
+          break;
       int c = timedRead(5);
       if (c < 0)
         continue;
-      // Cut received data if rxbuffer is too small
-      if (i < rxlen)
-        rxbuff[i] = c;
+      rxbuff[i] = c;
       crcUpdate(c);
     }
 


### PR DESCRIPTION
The bridge will read up to 2^8 bytes of data, no matter what `rxlen` is fed to `BridgeClass::transfer`. This will hang the bridge upon erroneous communication (as when Yun boots #2351). This PR fixes this. It breaks out of the read loop (when trying to further read and discard bytes) beyond what the read buffer can hold.

Might also want to check out #2353, which also adds a check for the bridge, so that one can restart the bridge from the arduino side.