### PR TITLE
'Uncertified' warning should be removed

### DIFF
--- a/hardware/arduino/avr/boards.txt
+++ b/hardware/arduino/avr/boards.txt
@@ -16,7 +16,7 @@ yun.pid.2=0x0041
 yun.vid.3=0x2A03
 yun.pid.3=0x8041
 
-yun.vid.0x2A03.warning=Uncertified
+#yun.vid.0x2A03.warning=Uncertified
 
 yun.upload.tool=avrdude
 yun.upload.protocol=avr109
@@ -56,7 +56,7 @@ uno.pid.1=0x0001
 uno.vid.2=0x2A03
 uno.pid.2=0x0043
 
-uno.vid.0x2A03.warning=Uncertified
+#uno.vid.0x2A03.warning=Uncertified
 
 uno.upload.tool=avrdude
 uno.upload.protocol=arduino
@@ -182,7 +182,7 @@ mega.pid.2=0x0010
 mega.vid.3=0x2A03
 mega.pid.3=0x0042
 
-mega.vid.0x2A03.warning=Uncertified
+#mega.vid.0x2A03.warning=Uncertified
 
 mega.upload.tool=avrdude
 mega.upload.maximum_data_size=8192
@@ -241,7 +241,7 @@ megaADK.pid.2=0x003f
 megaADK.vid.3=0x2A03
 megaADK.pid.3=0x0044
 
-megaADK.vid.0x2A03.warning=Uncertified
+#megaADK.vid.0x2A03.warning=Uncertified
 
 megaADK.upload.tool=avrdude
 megaADK.upload.protocol=wiring
@@ -275,7 +275,7 @@ leonardo.pid.2=0x0036
 leonardo.vid.3=0x2A03
 leonardo.pid.3=0x8036
 
-leonardo.vid.0x2A03.warning=Uncertified
+#leonardo.vid.0x2A03.warning=Uncertified
 
 leonardo.upload.tool=avrdude
 leonardo.upload.protocol=avr109
@@ -316,7 +316,7 @@ micro.pid.2=0x0037
 micro.vid.3=0x2A03
 micro.pid.3=0x8037
 
-micro.vid.0x2A03.warning=Uncertified
+#micro.vid.0x2A03.warning=Uncertified
 
 micro.upload.tool=avrdude
 micro.upload.protocol=avr109
@@ -357,7 +357,7 @@ esplora.pid.2=0x003C
 esplora.vid.3=0x2A03
 esplora.pid.3=0x803C
 
-esplora.vid.0x2A03.warning=Uncertified
+#esplora.vid.0x2A03.warning=Uncertified
 
 esplora.upload.tool=avrdude
 esplora.upload.protocol=avr109
@@ -739,7 +739,7 @@ robotControl.pid.2=0x0038
 robotControl.vid.3=0x2A03
 robotControl.pid.3=0x8038
 
-robotControl.vid.0x2A03.warning=Uncertified
+#robotControl.vid.0x2A03.warning=Uncertified
 
 robotControl.upload.tool=avrdude
 robotControl.upload.protocol=avr109
@@ -780,7 +780,7 @@ robotMotor.pid.2=0x0039
 robotMotor.vid.3=0x2A03
 robotMotor.pid.3=0x8039
 
-robotMotor.vid.0x2A03.warning=Uncertified
+#robotMotor.vid.0x2A03.warning=Uncertified
 
 robotMotor.upload.tool=avrdude
 robotMotor.upload.protocol=avr109


### PR DESCRIPTION
The warning message just confuses users and have no other benefits.

**Who are you all working for?** I would like to work for users and community. **DO NOT INVOLVE INNOCENT USERS WITH YOUR INTERNAL CONFLICT.** Additionally, do you recognize that the trademark is effective for the LLC only in the US? Do you know it is **illegal** in certain countries to claim any products with legal registered trademark as "fake" or something? @ffissore 

Arduino IDE is now world wide popular software product. You have to remove the message or release such version of IDE only in the US.