### PR TITLE
Correcting Value Declaration For ACCEL_Y_PIN

### DIFF
--- a/libraries/Esplora/src/Esplora.cpp
+++ b/libraries/Esplora/src/Esplora.cpp
@@ -51,7 +51,7 @@ const byte BUZZER_PIN = 6;
 // Led 13: D13
 
 const byte ACCEL_X_PIN = A5;
-const byte ACCEL_Y_PIN = A11;
+const byte ACCEL_Y_PIN = A7;
 const byte ACCEL_Z_PIN = A6;
 
 const byte LED_PIN     = 13;

--- a/libraries/Esplora/src/Esplora.cpp
+++ b/libraries/Esplora/src/Esplora.cpp
@@ -44,14 +44,15 @@ const byte GREEN_PIN  = 10;
 const byte BUZZER_PIN = 6;
 
 // non-multiplexer Esplora pins: 
-// Accelerometer: x-A5, y-A7, z-A6
+// Accelerometer: x-A5, y-A11, z-A6
 // External outputs: D3, D11
 // Buzzer: A8
+// The pin definition for the following green LED is incorrect in it's reference to A11. Needs corrected.
 // RGB Led: red-D5, green-D10/A11, blue-D9/A10
 // Led 13: D13
 
 const byte ACCEL_X_PIN = A5;
-const byte ACCEL_Y_PIN = A7;
+const byte ACCEL_Y_PIN = A11;
 const byte ACCEL_Z_PIN = A6;
 
 const byte LED_PIN     = 13;


### PR DESCRIPTION
The following definition of the accelerometer's Y axis is incorrect based on the preceding comments:

const byte ACCEL_Y_PIN = A11;

The following would be the correct definition based on the preceding comments:

const byte ACCEL_Y_PIN = A7;