### PR TITLE
Due: modify ADC enable/disable sequence

### DIFF
--- a/hardware/arduino/sam/cores/arduino/wiring_analog.c
+++ b/hardware/arduino/sam/cores/arduino/wiring_analog.c
@@ -148,9 +148,9 @@ uint32_t analogRead(uint32_t ulPin)
 		case ADC11 :
 
 			// Enable the corresponding channel
-			if (ulChannel != latestSelectedChannel) {
+			if (adc_get_channel_status(ADC, ulChannel) != 1) {
 				adc_enable_channel( ADC, ulChannel );
-				if ( latestSelectedChannel != (uint32_t)-1 )
+				if ( latestSelectedChannel != (uint32_t)-1 && ulChannel != latestSelectedChannel)
 					adc_disable_channel( ADC, latestSelectedChannel );
 				latestSelectedChannel = ulChannel;
 			}

--- a/hardware/arduino/sam/cores/arduino/wiring_digital.c
+++ b/hardware/arduino/sam/cores/arduino/wiring_digital.c
@@ -29,6 +29,13 @@ extern void pinMode( uint32_t ulPin, uint32_t ulMode )
         return ;
     }
 
+#if defined __SAM3X8E__ || defined __SAM3X8H__
+  if(g_APinDescription[ulPin].ulPinType != NO_ADC && adc_get_channel_status(ADC, g_APinDescription[ulPin].ulADCChannelNumber))
+    {
+      adc_disable_channel( ADC, g_APinDescription[ulPin].ulADCChannelNumber);
+    }
+#endif
+
 	switch ( ulMode )
     {
         case INPUT:


### PR DESCRIPTION
to avoid the bug #2198 simply reconfigure the pin -> no additional overhead if pinMode configuration is performed at the beginning of the sketch, 4 to 25% overhead on all analogRead() due to the additional check