### PR TITLE
Bridge: fix transfers which ignored host response

### DIFF
--- a/libraries/Bridge/library.properties
+++ b/libraries/Bridge/library.properties
@@ -1,5 +1,5 @@
 name=Bridge
-version=1.0.0
+version=1.0.1
 author=Arduino
 maintainer=Arduino <info@arduino.cc>
 sentence=Enables the communication between the Linux processor and the AVR. For Arduino Yún and TRE only.

--- a/libraries/Bridge/src/Bridge.cpp
+++ b/libraries/Bridge/src/Bridge.cpp
@@ -87,10 +87,11 @@ void BridgeClass::begin() {
 void BridgeClass::put(const char *key, const char *value) {
   // TODO: do it in a more efficient way
   String cmd = "D";
+  uint8_t res[1];
   cmd += key;
   cmd += "\xFE";
   cmd += value;
-  transfer((uint8_t*)cmd.c_str(), cmd.length());
+  transfer((uint8_t*)cmd.c_str(), cmd.length(), res, 1);
 }
 
 unsigned int BridgeClass::get(const char *key, uint8_t *value, unsigned int maxlen) {

--- a/libraries/Bridge/src/FileIO.cpp
+++ b/libraries/Bridge/src/FileIO.cpp
@@ -175,7 +175,8 @@ void File::close() {
   if (mode == 255)
     return;
   uint8_t cmd[] = {'f', handle};
-  bridge.transfer(cmd, 2);
+  uint8_t ret[1];
+  bridge.transfer(cmd, 2, ret, 1);
   mode = 255;
 }
 


### PR DESCRIPTION
Bridge.put() was broken by #2781 because it used transfer() 2-parameters overloaded version, which imply that rxlen == 0.
But the Linux Bridge responded, so the check (i >= rxlen) was true and the function timed out after retrying 50 times.

Every bridge command (python side) has been checked and now SHOULD strictly follow this rule and never ignore silently the received data