### PR TITLE
Add code out charset selection

### DIFF
--- a/app/src/processing/app/Preferences.java
+++ b/app/src/processing/app/Preferences.java
@@ -64,6 +64,9 @@ import static processing.app.I18n._;
  */
 public class Preferences {
 
+  String charsets[] = { "UTF-8", "ASCII", "windows-1250", "windows-1251", "windows-1252", "windows-1253", "windows-1254", "windows-1255", "windows-1256", "windows-1257", "CP 866(MS-DOS)", "ISO-8859-5", "KOI8-R", "KOI8-U", "ISO-8859-1", "ISO-8859-2", "ISO-8859-4", "ISO-8859-7", "GB2312", "EUC-KR", "Shift_JIS" };
+  String charsetsISO[] = { "UTF8", "ASCII", "Cp1250", "Cp1251", "Cp1252", "Cp1253", "Cp1254", "Cp1255", "Cp1256", "Cp1257", "Cp866", "ISO8859_5", "KOI8_R", "KOI8_U", "ISO8859_1", "ISO8859_2", "ISO8859_4", "ISO8859_7", "EUC_CN", "EUC_KR", "SJIS" };
+
   class Language {
     Language(String _name, String _originalName, String _isoCode) {
       name = _name;
@@ -212,6 +215,7 @@ public class Preferences {
   JCheckBox updateExtensionBox;
   JCheckBox autoAssociateBox;
   JComboBox comboLanguage;
+  JComboBox comboCharset;
   JCheckBox saveVerifyUploadBox;
   JTextField proxyHTTPServer;
   JTextField proxyHTTPPort;
@@ -322,6 +326,26 @@ public class Preferences {
     box.setBounds(left, top, d.width, d.height);
     right = Math.max(right, left + d.width);
     top += d.height + GUI_BETWEEN;
+
+    // Code out charset [    ]
+    
+    box = Box.createHorizontalBox();
+    label = new JLabel(_("Code out Charset: "));
+    box.add(label);
+    comboCharset = new JComboBox(charsets);
+    String charset = PreferencesData.get("preproc.charset");
+    if (charset == "") {
+      charset = "UTF8";
+    }
+    comboCharset.setSelectedIndex(Arrays.asList(charsetsISO).indexOf(charset));
+    box.add(comboCharset);
+    pane.add(box);
+    d = box.getPreferredSize();
+    box.setForeground(Color.gray);
+    box.setBounds(left, top, d.width, d.height);
+    right = Math.max(right, left + d.width);
+    top += d.height + GUI_BETWEEN;
+
 
     // Editor font size [    ]
 
@@ -730,6 +754,9 @@ public class Preferences {
     // adds the selected language to the preferences file
     Language newLanguage = (Language) comboLanguage.getSelectedItem();
     PreferencesData.set("editor.languages.current", newLanguage.isoCode);
+    
+    int posc = Arrays.asList(charsets).indexOf(comboCharset.getSelectedItem().toString());
+    PreferencesData.set("preproc.charset", (String)Arrays.asList(this.charsetsISO).get(posc));
 
     Preferences.set("proxy.http.server", proxyHTTPServer.getText());
     try {

--- a/app/src/processing/app/Preferences.java
+++ b/app/src/processing/app/Preferences.java
@@ -27,6 +27,7 @@ import processing.app.helpers.PreferencesHelper;
 import processing.app.helpers.PreferencesMap;
 import processing.app.legacy.PApplet;
 
+import java.util.Arrays;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.*;

--- a/app/src/processing/app/Preferences.java
+++ b/app/src/processing/app/Preferences.java
@@ -757,7 +757,7 @@ public class Preferences {
     PreferencesData.set("editor.languages.current", newLanguage.isoCode);
     
     int posc = Arrays.asList(charsets).indexOf(comboCharset.getSelectedItem().toString());
-    PreferencesData.set("preproc.charset", (String)Arrays.asList(this.charsetsISO).get(posc));
+    PreferencesData.set("preproc.charset", (String)Arrays.asList(charsetsISO).get(posc));
 
     Preferences.set("proxy.http.server", proxyHTTPServer.getText());
     try {

--- a/arduino-core/src/processing/app/preproc/PdePreprocessor.java
+++ b/arduino-core/src/processing/app/preproc/PdePreprocessor.java
@@ -89,7 +89,14 @@ public class PdePreprocessor {
     program = scrubComments(program);
     // If there are errors, an exception is thrown and this fxn exits.
 
-    if (PreferencesData.getBoolean("preproc.substitute_unicode")) {
+    String charset = PreferencesData.get("preproc.charset");
+    if (charset == "") {
+      charset = "UTF8";
+    }
+    if (charset != "UTF8") {
+      program = reencodeProgram(program, charset);
+    }
+    if ((PreferencesData.getBoolean("preproc.substitute_unicode")) && (charset == "UTF8")) {
       program = substituteUnicode(program);
     }
 
@@ -120,7 +127,16 @@ public class PdePreprocessor {
 
     return headerCount + prototypeCount;
   }
-
+  
+  static String reencodeProgram(String program, String charset)
+  {
+    try
+    {
+      program = new String(program.getBytes(charset));
+    }
+    catch (UnsupportedEncodingException e) {}
+    return program;
+  }
 
   static String substituteUnicode(String program) {
     // check for non-ascii chars (these will be/must be in unicode format)

--- a/build/shared/lib/preferences.txt
+++ b/build/shared/lib/preferences.txt
@@ -209,6 +209,9 @@ export.delete_target_folder = true
 # may be useful when attempting to debug the preprocessor
 preproc.save_build_files=false
 
+# code out chraset
+preproc.charset=UTF8
+
 # allows various preprocessor features to be toggled 
 # in case they are causing problems
 


### PR DESCRIPTION
Add selection charset of compiled code in preprocessor. It may be useful for simplify using native languages in one byte charset. For u8glib and more other libraries, for minimal size of compiled code. 