### PR TITLE
improve already downloaded contribution file check

### DIFF
--- a/arduino-core/src/cc/arduino/contributions/packages/DownloadableContributionsDownloader.java
+++ b/arduino-core/src/cc/arduino/contributions/packages/DownloadableContributionsDownloader.java
@@ -57,9 +57,13 @@ public class DownloadableContributionsDownloader {
     // Ensure the existence of staging folder
     stagingFolder.mkdirs();
 
-    if (!alreadyDownloadedFileViable(outputFile, contribution)) {
-      download(url, outputFile, progress, statusText);
+    if (fileAlreadyDownloaded(outputFile, contribution)) {
+      contribution.setDownloaded(true);
+      contribution.setDownloadedFile(outputFile);
+      return outputFile;
     }
+
+    download(url, outputFile, progress, statusText);
 
     // Test checksum
     progress.setStatus(_("Verifying archive integrity..."));
@@ -82,10 +86,14 @@ public class DownloadableContributionsDownloader {
     return FileHash.hash(outputFile, algo).equals(checksum);
   }
 
-  private boolean alreadyDownloadedFileViable
+  private boolean fileAlreadyDownloaded
       (File outputFile,
        DownloadableContribution contribution) throws Exception {
     if (!outputFile.isFile()) {
+      return false;
+    }
+
+    if (outputFile.length() != contribution.getSize()) {
       return false;
     }
 


### PR DESCRIPTION
When downloading a file, it's possible that a corrupted archive could be
bigger, smaller, or the same size as a non-corrupted archive, so it is
not good to rely on the archive file size. Instead, the checksum can be
used to verify if the already downloaded file is viable for reuse.