### PR TITLE
Fix for issue #292

### DIFF
--- a/hardware/arduino/avr/cores/arduino/Tone.cpp
+++ b/hardware/arduino/avr/cores/arduino/Tone.cpp
@@ -30,6 +30,7 @@ Version Modified By Date     Comments
 0006    D Mellis    09/12/29 Replaced objects with functions
 0007    M Sproul    10/08/29 Changed #ifdefs from cpu to register
 0008    S Kanemoto  12/06/22 Fixed for Leonardo by @maris_HY
+0009    J Reucker   15/04/10 Issue #292 Fixed problems with ATmega8 (thanks to Pete62)
 *************************************************/
 
 #include <avr/interrupt.h>
@@ -296,13 +297,13 @@ void tone(uint8_t _pin, unsigned int frequency, unsigned long duration)
 #if defined(TCCR0B)
       if (_timer == 0)
       {
-        TCCR0B = prescalarbits;
+        TCCR0B = (TCCR0B & 0b11111000) | prescalarbits;
       }
       else
 #endif
 #if defined(TCCR2B)
       {
-        TCCR2B = prescalarbits;
+        TCCR2B = (TCCR2B & 0b11111000) | prescalarbits;
       }
 #else
       {
@@ -456,19 +457,19 @@ void disableTimer(uint8_t _timer)
 
 #if defined(TIMSK3)
     case 3:
-      TIMSK3 = 0;
+      TIMSK3 &= ~(1 << OCIE3A);
       break;
 #endif
 
 #if defined(TIMSK4)
     case 4:
-      TIMSK4 = 0;
+      TIMSK4 &= ~(1 << OCIE4A);
       break;
 #endif
 
 #if defined(TIMSK5)
     case 5:
-      TIMSK5 = 0;
+      TIMSK5 &= ~(1 << OCIE5A);
       break;
 #endif
   }

--- a/hardware/arduino/avr/cores/arduino/Tone.cpp
+++ b/hardware/arduino/avr/cores/arduino/Tone.cpp
@@ -390,7 +390,7 @@ void tone(uint8_t _pin, unsigned int frequency, unsigned long duration)
         break;
 #endif
 
-#if defined(TIMSK3)
+#if defined(OCR3A) && defined(TIMSK3) && defined(OCIE3A)
       case 3:
         OCR3A = ocr;
         timer3_toggle_count = toggle_count;
@@ -398,7 +398,7 @@ void tone(uint8_t _pin, unsigned int frequency, unsigned long duration)
         break;
 #endif
 
-#if defined(TIMSK4)
+#if defined(OCR4A) && defined(TIMSK4) && defined(OCIE4A)
       case 4:
         OCR4A = ocr;
         timer4_toggle_count = toggle_count;
@@ -455,21 +455,21 @@ void disableTimer(uint8_t _timer)
       #endif
       break;
 
-#if defined(TIMSK3)
+#if defined(TIMSK3) && defined(OCIE3A)
     case 3:
-      TIMSK3 &= ~(1 << OCIE3A);
+      bitWrite(TIMSK3, OCIE3A, 0);
       break;
 #endif
 
-#if defined(TIMSK4)
+#if defined(TIMSK4) && defined(OCIE4A)
     case 4:
-      TIMSK4 &= ~(1 << OCIE4A);
+      bitWrite(TIMSK4, OCIE4A, 0);
       break;
 #endif
 
-#if defined(TIMSK5)
+#if defined(TIMSK5) && defined(OCIE5A)
     case 5:
-      TIMSK5 &= ~(1 << OCIE5A);
+      bitWrite(TIMSK5, OCIE5A, 0);
       break;
 #endif
   }


### PR DESCRIPTION
This bugfix makes the Tone library work with ATmega8-based boards. See #292.

Rebased the bugfix from the original [Google Code issue 292](https://code.google.com/p/arduino/issues/detail?id=292) to work with Arduino 1.6.x

Description of original fix provided by Pete62:
The later 8 bit AVR's use two registers (TCCRxA, TCCRxB) whereas the ATmega8 only uses a single register (TCCR2) to house the control bits for Timer 2.  Bits were inadvertently being cleared.