### PR TITLE
Update Tone.cpp to fix #2923

### DIFF
--- a/hardware/arduino/avr/cores/arduino/Tone.cpp
+++ b/hardware/arduino/avr/cores/arduino/Tone.cpp
@@ -30,6 +30,7 @@ Version Modified By Date     Comments
 0006    D Mellis    09/12/29 Replaced objects with functions
 0007    M Sproul    10/08/29 Changed #ifdefs from cpu to register
 0008    S Kanemoto  12/06/22 Fixed for Leonardo by @maris_HY
+0009    jipp        15/04/13 added additional define check #2923
 *************************************************/
 
 #include <avr/interrupt.h>
@@ -151,7 +152,7 @@ static int8_t toneBegin(uint8_t _pin)
     // whereas 16 bit timers are set to either ck/1 or ck/64 prescalar
     switch (_timer)
     {
-      #if defined(TCCR0A) && defined(TCCR0B)
+      #if defined(TCCR0A) && defined(TCCR0B) && defined(WGM01)
       case 0:
         // 8 bit timer
         TCCR0A = 0;


### PR DESCRIPTION
Tone.cpp stops compile when TCCR0A/TCCR0B defined and WGM01 not defined #2923