### PR TITLE
SD: remove any reference to pinMode(10, OUTPUT) in the examples

### DIFF
--- a/libraries/SD/examples/CardInfo/CardInfo.ino
+++ b/libraries/SD/examples/CardInfo/CardInfo.ino
@@ -44,12 +44,6 @@ void setup()
 
 
   Serial.print("\nInitializing SD card...");
-  // On the Ethernet Shield, CS is pin 4. It's set as an output by default.
-  // Note that even if it's not used as the CS pin, the hardware SS pin
-  // (10 on most Arduino boards, 53 on the Mega) must be left as an output
-  // or the SD library functions will not work.
-  pinMode(10, OUTPUT);     // change this to 53 on a mega
-
 
   // we'll use the initialization code from the utility libraries
   // since we're just testing if the card is working!

--- a/libraries/SD/examples/Datalogger/Datalogger.ino
+++ b/libraries/SD/examples/Datalogger/Datalogger.ino
@@ -23,10 +23,6 @@
 #include <SPI.h>
 #include <SD.h>
 
-// On the Ethernet Shield, CS is pin 4. Note that even if it's not
-// used as the CS pin, the hardware CS pin (10 on most Arduino boards,
-// 53 on the Mega) must be left as an output or the SD library
-// functions will not work.
 const int chipSelect = 4;
 
 void setup()
@@ -39,9 +35,6 @@ void setup()
 
 
   Serial.print("Initializing SD card...");
-  // make sure that the default chip select pin is set to
-  // output, even if you don't use it:
-  pinMode(10, OUTPUT);
 
   // see if the card is present and can be initialized:
   if (!SD.begin(chipSelect)) {

--- a/libraries/SD/examples/DumpFile/DumpFile.ino
+++ b/libraries/SD/examples/DumpFile/DumpFile.ino
@@ -23,10 +23,6 @@
 #include <SPI.h>
 #include <SD.h>
 
-// On the Ethernet Shield, CS is pin 4. Note that even if it's not
-// used as the CS pin, the hardware CS pin (10 on most Arduino boards,
-// 53 on the Mega) must be left as an output or the SD library
-// functions will not work.
 const int chipSelect = 4;
 
 void setup()
@@ -39,9 +35,6 @@ void setup()
 
 
   Serial.print("Initializing SD card...");
-  // make sure that the default chip select pin is set to
-  // output, even if you don't use it:
-  pinMode(10, OUTPUT);
 
   // see if the card is present and can be initialized:
   if (!SD.begin(chipSelect)) {

--- a/libraries/SD/examples/Files/Files.ino
+++ b/libraries/SD/examples/Files/Files.ino
@@ -32,11 +32,6 @@ void setup()
 
 
   Serial.print("Initializing SD card...");
-  // On the Ethernet Shield, CS is pin 4. It's set as an output by default.
-  // Note that even if it's not used as the CS pin, the hardware SS pin
-  // (10 on most Arduino boards, 53 on the Mega) must be left as an output
-  // or the SD library functions will not work.
-  pinMode(10, OUTPUT);
 
   if (!SD.begin(4)) {
     Serial.println("initialization failed!");

--- a/libraries/SD/examples/ReadWrite/ReadWrite.ino
+++ b/libraries/SD/examples/ReadWrite/ReadWrite.ino
@@ -33,11 +33,6 @@ void setup()
 
 
   Serial.print("Initializing SD card...");
-  // On the Ethernet Shield, CS is pin 4. It's set as an output by default.
-  // Note that even if it's not used as the CS pin, the hardware SS pin
-  // (10 on most Arduino boards, 53 on the Mega) must be left as an output
-  // or the SD library functions will not work.
-  pinMode(10, OUTPUT);
 
   if (!SD.begin(4)) {
     Serial.println("initialization failed!");

--- a/libraries/SD/examples/listfiles/listfiles.ino
+++ b/libraries/SD/examples/listfiles/listfiles.ino
@@ -35,11 +35,6 @@ void setup()
   }
 
   Serial.print("Initializing SD card...");
-  // On the Ethernet Shield, CS is pin 4. It's set as an output by default.
-  // Note that even if it's not used as the CS pin, the hardware SS pin
-  // (10 on most Arduino boards, 53 on the Mega) must be left as an output
-  // or the SD library functions will not work.
-  pinMode(10, OUTPUT);
 
   if (!SD.begin(4)) {
     Serial.println("initialization failed!");

--- a/libraries/SD/library.properties
+++ b/libraries/SD/library.properties
@@ -1,5 +1,5 @@
 name=SD
-version=1.0.1
+version=1.0.2
 author=Arduino, SparkFun
 maintainer=Arduino <info@arduino.cc>
 sentence=Enables reading and writing on SD cards. For all Arduino boards.


### PR DESCRIPTION
correct SS pin setup is already handled by SPI subsystem.
this should prevent future issues like #2868

current implementation assures that:
* pin10 is OUTPUT HIGH if SPI.begin() is called and the pin was unconfigured
* pin10 state is not modified if pinMode(10, OUTPUT) is called before SPI.begin()
* pin10 is INPUT HI-Z if nor pinMode(10, OUTPUT) nor SPI.begin() are called