### PR TITLE
programmer.txt definitions must have priority over platforms.txt tools definitions

### DIFF
--- a/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
+++ b/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
@@ -253,8 +253,8 @@ public class SerialUploader extends Uploader {
     if (programmerPrefs == null)
       throw new RunnerException(
           _("Please select a programmer from Tools->Programmer menu"));
+    prefs.putAll(targetPlatform.getTool(programmerPrefs.getOrExcept("program.tool")));
     prefs.putAll(programmerPrefs);
-    prefs.putAll(targetPlatform.getTool(prefs.getOrExcept("program.tool")));
 
     prefs.put("build.path", buildPath);
     prefs.put("build.project_name", className);


### PR DESCRIPTION
This allows properties defined in programmers.txt to override the generic configurations in platform.txt where needed, for example in the following configuration:

programmers.txt:

```
myprog.name=My New Programmer
[...]
myprog.program.tool=avrdude
myprog.config.path={runtime.platform.path}/myprog_avrdude.conf
[...]
```

platform.txt:

```
[...]
tools.avrdude.path={runtime.tools.avrdude.path}
tools.avrdude.cmd.path={path}/bin/avrdude
tools.avrdude.config.path={path}/etc/avrdude.conf
[...]
tools.avrdude.upload.pattern="{cmd.path}" "-C{config.path}" {upload.verbose} -p{build.mcu} -c{upload.protocol} -P{serial.port} -b{upload.speed} -D "-Uflash:w:{build.path}/{build.project_name}.hex:i"
```

the generic tools.avrdude.config.path value `{path}/etc/avrdude.conf` is replaced by the more specific myprog.config.path used in "myprog" programmer `{runtime.plaform.path}/myprog_avrdude.conf`

