### PR TITLE
making UART/USART handler weak to allow custom external handlers

### DIFF
--- a/hardware/arduino/sam/variants/arduino_due_x/variant.cpp
+++ b/hardware/arduino/sam/variants/arduino_due_x/variant.cpp
@@ -306,6 +306,7 @@ void serialEvent() __attribute__((weak));
 void serialEvent() { }
 
 // IT handlers
+void UART_Handler(void)  __attribute__((weak));
 void UART_Handler(void)
 {
   Serial.IrqHandler();
@@ -333,16 +334,19 @@ void serialEvent3() __attribute__((weak));
 void serialEvent3() { }
 
 // IT handlers
+void USART0_Handler(void)  __attribute__((weak));
 void USART0_Handler(void)
 {
   Serial1.IrqHandler();
 }
 
+void USART1_Handler(void)  __attribute__((weak));
 void USART1_Handler(void)
 {
   Serial2.IrqHandler();
 }
 
+void USART3_Handler(void)  __attribute__((weak));
 void USART3_Handler(void)
 {
   Serial3.IrqHandler();


### PR DESCRIPTION
I've opened a thread about this here: https://groups.google.com/a/arduino.cc/forum/#!topic/developers/FIjuI4z06tY
