### PR TITLE
Corrected a bug in the SD card library. The SDClass class makes a refere...

### DIFF
--- a/libraries/SD/src/SD.cpp
+++ b/libraries/SD/src/SD.cpp
@@ -450,7 +450,7 @@ File SDClass::open(const char *filepath, uint8_t mode) {
 
   // there is a special case for the Root directory since its a static dir
   if (parentdir.isRoot()) {
-    if ( ! file.open(SD.root, filepath, mode)) {
+    if ( ! file.open(root, filepath, mode)) {
       // failed to open the file :(
       return File();
     }


### PR DESCRIPTION
...nce to "SD.card" instead of just "card". SD is a global instance of SDClass. This prevents any other instance of SDClass from functioning correctly. The fix also allows SDClass to be used with an SD card which is removed and replaced, whereas previously, using the global instance SD did not allow this due to the limitation of begin() which cannot be called more than once.