### PR TITLE
Create timer0 overflow interrupt service routine for all ATtinies 

### DIFF
--- a/hardware/arduino/avr/cores/arduino/wiring.c
+++ b/hardware/arduino/avr/cores/arduino/wiring.c
@@ -41,7 +41,7 @@ volatile unsigned long timer0_overflow_count = 0;
 volatile unsigned long timer0_millis = 0;
 static unsigned char timer0_fract = 0;
 
-#if defined(__AVR_ATtiny24__) || defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__)
+#if defined(TIM0_OVF_vect)
 ISR(TIM0_OVF_vect)
 #else
 ISR(TIMER0_OVF_vect)


### PR DESCRIPTION
The current version only creates a timer0 ISR for ATtiny24, 44 and 84. This causes the delay function not to work for ATtiny13 and other ATtiny processors.