### PR TITLE
Option for SOFTWARESERIAL_UNUSED to allow TX or RX only configs

### DIFF
--- a/hardware/arduino/avr/libraries/SoftwareSerial/README.adoc
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/README.adoc
@@ -1,0 +1,27 @@
+= SoftwareSerial Library for Arduino (formerly NewSoftSerial) =
+
+The SoftwareSerial library has been developed to allow serial communication (TX and/or RX) on other digital pins of the Arduino and other Atmel chips, using software to replicate the functionality (hence the name "SoftwareSerial"). It is possible to have multiple software serial ports with speeds up to 115200 bps. A parameter enables inverted signaling for devices which require that protocol.
+
+For more information about this library please visit us at
+http://www.arduino.cc/en/Reference/SoftwareSerial
+
+== Written by ==
+
+Mikal Hart; with improvements from: ladyada, Paul Stoffregen, Garrett Mace, Brett Hagman and Scott Brynen.
+
+== License ==
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+

--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -275,19 +275,11 @@ void SoftwareSerial::setTX(uint8_t tx)
   // is fine. With inverse logic, either order is fine.
   _transmitPin = tx;
   if (tx != SOFTWARESERIAL_UNUSED) {
-<<<<<<< HEAD
-	digitalWrite(tx, _inverse_logic ? LOW : HIGH);
-	pinMode(tx, OUTPUT);
-	_transmitBitMask = digitalPinToBitMask(tx);
-	uint8_t port = digitalPinToPort(tx);
-	_transmitPortRegister = portOutputRegister(port);
-=======
     digitalWrite(tx, _inverse_logic ? LOW : HIGH);
     pinMode(tx, OUTPUT);
     _transmitBitMask = digitalPinToBitMask(tx);
     uint8_t port = digitalPinToPort(tx);
    _transmitPortRegister = portOutputRegister(port);
->>>>>>> 269cde97b5f635643dd32c00abad5e4ece6c6139
   }
 }
 
@@ -295,21 +287,12 @@ void SoftwareSerial::setRX(uint8_t rx)
 {
   _receivePin = rx;
   if (rx != SOFTWARESERIAL_UNUSED) {
-<<<<<<< HEAD
-	pinMode(rx, INPUT);
-	if (!_inverse_logic)
-	  digitalWrite(rx, HIGH);  // pullup for normal logic!
-	_receiveBitMask = digitalPinToBitMask(rx);
-	uint8_t port = digitalPinToPort(rx);
-	_receivePortRegister = portInputRegister(port);
-=======
     pinMode(rx, INPUT);
     if (!_inverse_logic)
       digitalWrite(rx, HIGH);  // pullup for normal logic!
     _receiveBitMask = digitalPinToBitMask(rx);
     uint8_t port = digitalPinToPort(rx);
     _receivePortRegister = portInputRegister(port);
->>>>>>> 269cde97b5f635643dd32c00abad5e4ece6c6139
   }
 }
 

--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.h
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.h
@@ -10,6 +10,7 @@ Multi-instance software serial library for Arduino/Wiring
 -- Pin change interrupt macros by Paul Stoffregen (http://www.pjrc.com)
 -- 20MHz processor support by Garrett Mace (http://www.macetech.com)
 -- ATmega1280/2560 support by Brett Hagman (http://www.roguerobotics.com/)
+-- Transmit or Receive Only by Scott Brynen (http://github.com/sbrynen)
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -39,7 +40,9 @@ http://arduiniana.org.
 * Definitions
 ******************************************************************************/
 
-#define _SS_MAX_RX_BUFF 64 // RX buffer size
+#define _SS_MAX_RX_BUFF 64        // RX buffer size
+#define SOFTWARESERIAL_UNUSED -1  // flag for unused TX or RX pins
+
 #ifndef GCC_VERSION
 #define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #endif
@@ -51,6 +54,7 @@ private:
   uint8_t _receivePin;
   uint8_t _receiveBitMask;
   volatile uint8_t *_receivePortRegister;
+  uint8_t _transmitPin;
   uint8_t _transmitBitMask;
   volatile uint8_t *_transmitPortRegister;
   volatile uint8_t *_pcint_maskreg;
@@ -92,7 +96,7 @@ public:
   void begin(long speed);
   bool listen();
   void end();
-  bool isListening() { return this == active_object; }
+  bool isListening() { return (_receivePin != SOFTWARESERIAL_UNUSED) && (this == active_object); }
   bool stopListening();
   bool overflow() { bool ret = _buffer_overflow; if (ret) _buffer_overflow = false; return ret; }
   int peek();


### PR DESCRIPTION
This patch allows you to pass a pin# of "SOFTWARESERIAL_UNUSED" for a transmit or receive pin, to avoid having to use two pins in situations where you only want receive or transmit.
