### PR TITLE
New feature: validate function for String class.

### DIFF
--- a/hardware/arduino/avr/cores/arduino/WString.cpp
+++ b/hardware/arduino/avr/cores/arduino/WString.cpp
@@ -152,6 +152,13 @@ unsigned char String::reserve(unsigned int size)
 	return 0;
 }
 
+unsigned int String::validate( bool remainder )
+{
+	if( !remainder ) len = 0;
+	while( len < capacity && buffer[ len ] ) ++len;
+	return len;	
+}
+
 unsigned char String::changeBuffer(unsigned int maxStrLen)
 {
 	char *newbuffer = (char *)realloc(buffer, maxStrLen + 1);

--- a/hardware/arduino/avr/cores/arduino/WString.h
+++ b/hardware/arduino/avr/cores/arduino/WString.h
@@ -78,6 +78,15 @@ public:
 	// is left unchanged).  reserve(0), if successful, will validate an
 	// invalid string (i.e., "if (s)" will be true afterwards)
 	unsigned char reserve(unsigned int size);
+	
+	// If reserved data is modified externally using c_str()/&str[x] 
+	// this function will allow the contents to be validated and ready
+	// for use with the String functionality.
+
+	// If remainder is true, only the reserved buffer is validated (capacity - len bytes)
+	// If remainder is false, the entire buffer is re-validated.
+	unsigned int validate( bool remainder = false );
+	
 	inline unsigned int length(void) const {return len;}
 
 	// creates a copy of the assigned value.  if the value is null or

--- a/hardware/arduino/sam/cores/arduino/WString.cpp
+++ b/hardware/arduino/sam/cores/arduino/WString.cpp
@@ -154,6 +154,13 @@ unsigned char String::reserve(unsigned int size)
 	return 0;
 }
 
+unsigned int String::validate( bool remainder )
+{
+	if( !remainder ) len = 0;
+	while( len < capacity && buffer[ len ] ) ++len;
+	return len;	
+}
+
 unsigned char String::changeBuffer(unsigned int maxStrLen)
 {
 	char *newbuffer = (char *)realloc(buffer, maxStrLen + 1);

--- a/hardware/arduino/sam/cores/arduino/WString.h
+++ b/hardware/arduino/sam/cores/arduino/WString.h
@@ -78,6 +78,15 @@ public:
 	// is left unchanged).  reserve(0), if successful, will validate an
 	// invalid string (i.e., "if (s)" will be true afterwards)
 	unsigned char reserve(unsigned int size);
+	
+	// If reserved data is modified externally using c_str()/&str[x] 
+	// this function will allow the contents to be validated and ready
+	// for use with the String functionality.
+
+	// If remainder is true, only the reserved buffer is validated (capacity - len bytes)
+	// If remainder is false, the entire buffer is re-validated.
+	unsigned int validate( bool remainder = false );
+	
 	inline unsigned int length(void) const {return len;}
 
 	// creates a copy of the assigned value.  if the value is null or


### PR DESCRIPTION
As people can access the internal buffer using various provided methods: `str.c_str()`, `&str[0]` It gives reason to believe that someone will modify the string externally, or provide these pointers to functions that do. It makes sense as a user can reserve memory using `str.reserve()`, or simply overwrite existing data already in the pointer.

Once this happens the String can reflect incorrect values despite having valid data inside it.

Take for example, someone buffering a string to receive data provided by some source external to the library.

```Arduino
  String result;
  result.reserve( 32 ); //Buffer enough space for the String data.

  I2C_EEPROM.get( address, result.c_str(), 32 );  //'get' the data directly into the String buffer.

  Serial.print( result ); //Prints an empty string.
```
This problem is solved with this PR:
```Arduino
  String result;
  result.reserve( 32 ); //Buffer enough space for the String data.

  I2C_EEPROM.get( address, result.c_str(), 32 );  //'get' the data directly into the String buffer.

  result.validate(); // Allow the String to detect the changed data.

  Serial.print( result ); //The internal 'len' is now correct, and data is printed.
```

The function simply searches for the null character. There is one parameter called `remainder` which if set to:
- `true`: the function only searches the unused buffer (capacity - len).
- `false`: the entire buffer is re-validated.

The default is to validate the entire buffer.

This seems important as the Print library uses the string's internal data to determine length, not the actual null character. If someone was to simply cut a string in half (`str[5] = '\0';) then functions using the null will perform differently to what is seen in debugging (may hinder debugging as Serial.print() is affected).