### PR TITLE
Fix for #2969 (I2C reserved addresses)

### DIFF
--- a/hardware/arduino/avr/libraries/Wire/examples/master_reader/master_reader.ino
+++ b/hardware/arduino/avr/libraries/Wire/examples/master_reader/master_reader.ino
@@ -20,7 +20,7 @@ void setup()
 
 void loop()
 {
-  Wire.requestFrom(2, 6);    // request 6 bytes from slave device #2
+  Wire.requestFrom(8, 6);    // request 6 bytes from slave device #8
 
   while (Wire.available())   // slave may send less than requested
   {

--- a/hardware/arduino/avr/libraries/Wire/examples/master_writer/master_writer.ino
+++ b/hardware/arduino/avr/libraries/Wire/examples/master_writer/master_writer.ino
@@ -21,7 +21,7 @@ byte x = 0;
 
 void loop()
 {
-  Wire.beginTransmission(4); // transmit to device #4
+  Wire.beginTransmission(8); // transmit to device #8
   Wire.write("x is ");        // sends five bytes
   Wire.write(x);              // sends one byte
   Wire.endTransmission();    // stop transmitting

--- a/hardware/arduino/avr/libraries/Wire/examples/slave_receiver/slave_receiver.ino
+++ b/hardware/arduino/avr/libraries/Wire/examples/slave_receiver/slave_receiver.ino
@@ -14,7 +14,7 @@
 
 void setup()
 {
-  Wire.begin(4);                // join i2c bus with address #4
+  Wire.begin(8);                // join i2c bus with address #8
   Wire.onReceive(receiveEvent); // register event
   Serial.begin(9600);           // start serial for output
 }

--- a/hardware/arduino/avr/libraries/Wire/examples/slave_sender/slave_sender.ino
+++ b/hardware/arduino/avr/libraries/Wire/examples/slave_sender/slave_sender.ino
@@ -14,7 +14,7 @@
 
 void setup()
 {
-  Wire.begin(2);                // join i2c bus with address #2
+  Wire.begin(8);                // join i2c bus with address #8
   Wire.onRequest(requestEvent); // register event
 }
 


### PR DESCRIPTION
This fixes the Wire examples that uses I2C reserved address (from 0 to 7) substituting them with 8 that is the first one available and that can be used.

I also modified the wire reference
http://www.arduino.cc/en/reference/wire
according to this fact.