### PR TITLE
Bug (solved): D24 bit value is wrong in digital pin masks.

### DIFF
--- a/hardware/arduino/avr/variants/leonardo/pins_arduino.h
+++ b/hardware/arduino/avr/variants/leonardo/pins_arduino.h
@@ -173,8 +173,10 @@ extern const uint8_t PROGMEM analog_pin_to_channel_PGM[];
 // MOSI		D16		PB2					MOSI,PCINT2
 // SS		D17		PB0					RXLED,SS/PCINT0
 //
-// TXLED			PD5
-// RXLED		    PB0
+// Connected LEDs on board for TX and RX
+// TXLED	D24		PD5					XCK1
+// RXLED	D17		PB0
+//
 // HWB				PE2					HWB
 
 // these arrays map port names (e.g. port B) to the
@@ -276,7 +278,7 @@ const uint8_t PROGMEM digital_pin_to_bit_mask_PGM[] = {
 	_BV(1), // D22 - A4 - PF1
 	_BV(0), // D23 - A5 - PF0
 	
-	_BV(4), // D24 / D4 - A6 - PD4
+	_BV(5), // D24 - PD5
 	_BV(7), // D25 / D6 - A7 - PD7
 	_BV(4), // D26 / D8 - A8 - PB4
 	_BV(5), // D27 / D9 - A9 - PB5


### PR DESCRIPTION
In Leonardo hardware pin assignment, the correspondence between bit mask and pin PD5 is missing, while PD4 is repeated as D24, so __D24 should be PD5__. 

Atmega32U4 PD5 pin is _XCK1/~CTS_ and it is connected to TX led on Leonardo board. After this patch, D24 is assigned to PD5 and these lines can blink TX led:

```
void setup() {
  pinMode(24, OUTPUT);
}

void loop() {
 digitalWrite(24, HIGH);   // turn the LED on (HIGH is the voltage level)
 delay(500);              // wait for a second
 digitalWrite(24, LOW);    // turn the LED off by making the voltage LOW
 delay(500); 
}
```

This bug was found by @xdesig (member of the Escornabot project :) This is his hardware unit test: https://www.youtube.com/watch?v=nClBTrmG7Sk
