### PR TITLE
Fix Uncategorized warning message

### DIFF
--- a/arduino-core/src/processing/app/packages/UserLibrary.java
+++ b/arduino-core/src/processing/app/packages/UserLibrary.java
@@ -131,9 +131,9 @@ public class UserLibrary extends ContributedLibrary {
     if (category == null)
       category = "Uncategorized";
     if (!CATEGORIES.contains(category)) {
-      category = "Uncategorized";
       System.out.println("WARNING: Category '" + category + "' in library " +
               properties.get("name") + " is not valid. Setting to 'Uncategorized'");
+      category = "Uncategorized";
     }
 
     String license = properties.get("license");


### PR DESCRIPTION
This fixes the Uncategorized warning, which currently always prints a message like this, regardless of the invalid category name.

      WARNING: Category 'Uncategorized' in library Snooze is not valid. Setting to 'Uncategorized'
