### PR TITLE
Fix for FileUtils.recursiveDelete() when dealing with symbolic links

### DIFF
--- a/arduino-core/src/processing/app/helpers/FileUtils.java
+++ b/arduino-core/src/processing/app/helpers/FileUtils.java
@@ -274,10 +274,6 @@ public class FileUtils {
       return true;
     }
 
-    if (!file.exists()) {
-      return false;
-    }
-
     return file.delete();
   }
 

--- a/arduino-core/src/processing/app/helpers/FileUtils.java
+++ b/arduino-core/src/processing/app/helpers/FileUtils.java
@@ -85,7 +85,7 @@ public class FileUtils {
         recursiveDelete(current);
       }
     }
-    deleteIfExists(file);
+    file.delete();
   }
 
   public static File createTempFolder() throws IOException {


### PR DESCRIPTION
More detailed info in the commit message:

```
The documentation for File.delete() says that the method return true
if the the file is successfully deleted, otherwise false is returned.
An exception is thrown only when the file is not accessible (for
permission problem).

Removing the extra check solves another problem, for example in a
folder with the following situation:

    linkToFileA -> FileA
    FileA

if we remove FileA, we remain with a broken link that can't be removed
using FileUtils.deleteIfExists() because calling File.exists() on a
broken link returns *false*. This commit solve this problem.
```

note that the bug not always happens, it depends on the order the files are deleted.
