### PR TITLE
Build: Remove spawn from exec command (Windows)

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -880,7 +880,7 @@
 
   <target name="windows-run" depends="build"
 	  description="Run windows version">
-    <exec executable="windows/work/arduino.exe" dir="windows/work" spawn="true" failonerror="true"/>
+    <exec executable="windows/work/arduino.exe" dir="windows/work" failonerror="true"/>
   </target>
 
   <target name="windows-dist" depends="build" description="Create .zip files of windows version">


### PR DESCRIPTION
It appears in `ant` that `spawn` on windows is not needed/usable with `exec`.

This error now is visible due to the commit here: https://github.com/arduino/Arduino/commit/37e2a1994a18131d048fbfe808cfd0bdeed6dbe1, before hand it was ignored.

Currently a windows build generates this (using `ant run`): 

> windows-run:
spawn does not allow attributes related to input, output, error, result
spawn also does not allow timeout
finally, spawn is not compatible with a nested I/O
> 
BUILD FAILED
F:\Arduino\build\build.xml:71: The following error occurred while executing this line:
F:\Arduino\build\build.xml:869: You have used an attribute or nested element which is not compatible with spawn

If I remove the `spawn` attribute everything compiles and runs fine.
If I remove the `failonerror` attribute, it also works fine.

It appears that spawn is only useful for background processes.