### PR TITLE
Cut off board/port name when greater than 50

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -801,7 +801,7 @@ public class Editor extends JFrame implements RunnerListener {
             if (sel == null) {
               if (!name.equals(basename)) menu.setText(basename);
             } else {
-              if (sel.length() > 17) sel = sel.substring(0, 16) + "...";
+              if (sel.length() > 50) sel = sel.substring(0, 50) + "...";
               String newname = basename + ": \"" + sel + "\"";
               if (!name.equals(newname)) menu.setText(newname);
             }


### PR DESCRIPTION
Fixes #3104

Please try the IDE resulting from this PR and express your (dis)agreement for
1) the current behaviour, which truncates board/port names in order to avoid looooong names
2) the proposed behaviour, which doesn't truncate at all, even if that may lead to very long names
/cc @damellis 