### PR TITLE
Added support for .hh and .hpp libraries

### DIFF
--- a/arduino-core/src/processing/app/BaseNoGui.java
+++ b/arduino-core/src/processing/app/BaseNoGui.java
@@ -417,7 +417,7 @@ public class BaseNoGui {
    * within the header files at the top-level).
    */
   static public String[] headerListFromIncludePath(File path) throws IOException {
-    String[] list = path.list(new OnlyFilesWithExtension(".h"));
+    String[] list = path.list(new OnlyFilesWithExtension(".h", ".hh", ".hpp"));
     if (list == null) {
       throw new IOException();
     }


### PR DESCRIPTION
This allows libraries to be imported correctly when they use .hh or .hpp extensions.

Resolves #2372