### PR TITLE
Added String handling to SD class

### DIFF
--- a/libraries/SD/src/SD.h
+++ b/libraries/SD/src/SD.h
@@ -71,18 +71,23 @@ public:
   // write, etc). Returns a File object for interacting with the file.
   // Note that currently only one file can be open at a time.
   File open(const char *filename, uint8_t mode = FILE_READ);
+  File open(const String &filename, uint8_t mode = FILE_READ) { return open( filename.c_str(), mode ); }
 
   // Methods to determine if the requested file path exists.
   boolean exists(char *filepath);
+  boolean exists(const String &filepath) { return exists(filepath.c_str()); }
 
   // Create the requested directory heirarchy--if intermediate directories
   // do not exist they will be created.
   boolean mkdir(char *filepath);
+  boolean mkdir(const String &filepath) { return mkdir(filepath.c_str()); }
   
   // Delete the file.
   boolean remove(char *filepath);
+  boolean remove(const String &filepath) { return remove(filepath.c_str()); }
   
   boolean rmdir(char *filepath);
+  boolean rmdir(const String &filepath) { return rmdir(filepath.c_str()); }
 
 private:
 


### PR DESCRIPTION
This resolves #413

As a consequence of supporting the String library, PROGMEM strings are now usable through the `F()` macro.

```arduino
SD.open( F("example.txt"), FILE_WRITE);

SD.exists( F("MyListData.csv") );
```