### PR TITLE
Modified randomSeed, now uses unsigned long.﻿

### DIFF
--- a/hardware/arduino/avr/cores/arduino/Arduino.h
+++ b/hardware/arduino/avr/cores/arduino/Arduino.h
@@ -239,7 +239,7 @@ void noTone(uint8_t _pin);
 // WMath prototypes
 long random(long);
 long random(long, long);
-void randomSeed(unsigned int);
+void randomSeed(unsigned long);
 long map(long, long, long, long, long);
 
 #endif

--- a/hardware/arduino/avr/cores/arduino/WMath.cpp
+++ b/hardware/arduino/avr/cores/arduino/WMath.cpp
@@ -27,7 +27,7 @@ extern "C" {
   #include "stdlib.h"
 }
 
-void randomSeed(unsigned int seed)
+void randomSeed(unsigned long seed)
 {
   if (seed != 0) {
     srandom(seed);


### PR DESCRIPTION
This is a fix for issue #575

`randomSeed()` now accepts unsigned long, the same type as the underlying AVR system call `srandom()`.

This now matches the SAM core which already uses `uint32_t`.