### PR TITLE
Added missing function call to serialEvent example

### DIFF
--- a/build/shared/examples/04.Communication/SerialEvent/SerialEvent.ino
+++ b/build/shared/examples/04.Communication/SerialEvent/SerialEvent.ino
@@ -28,6 +28,7 @@ void setup() {
 }
 
 void loop() {
+  serialEvent(); //call the function
   // print the string when a newline arrives:
   if (stringComplete) {
     Serial.println(inputString);


### PR DESCRIPTION
In the example is stated that the function is run between one loop and the next, but actually the call to the function was missing.
The comment also state that the response can be delayed using a delay in the loop,so I think that the way it should be is so by only
adding a call to the function serialEvent as first operation in the loop. I so added this call.