### PR TITLE
Fixed bug with flushing

### DIFF
--- a/hardware/arduino/avr/cores/arduino/HardwareSerial.cpp
+++ b/hardware/arduino/avr/cores/arduino/HardwareSerial.cpp
@@ -220,6 +220,7 @@ size_t HardwareSerial::write(uint8_t c)
   if (_tx_buffer_head == _tx_buffer_tail && bit_is_set(*_ucsra, UDRE0)) {
     *_udr = c;
     sbi(*_ucsra, TXC0);
+     _written = true;
     return 1;
   }
   tx_buffer_index_t i = (_tx_buffer_head + 1) % SERIAL_TX_BUFFER_SIZE;


### PR DESCRIPTION
I tried to make a RS485 bridge and i use Serial.flush() to wait for the serial transmission is complete.
but it turned out that this never happened.
I used this sketch.
You need a oscilloscope, to measure pin 2 to verify it.
 
void setup()
{
  Serial.begin(38400);
  Serial1.begin(38400);
  pinMode(2, OUTPUT);
}

void loop()
{
  if(Serial.available())
  {    
      digitalWrite(2, HIGH);
      Serial1.write(Serial.read());
      Serial1.flush();
      digitalWrite(2, LOW);
  }
  
  if(Serial1.available())Serial.write(Serial1.read());
}
