### PR TITLE
Println optimize

### DIFF
--- a/hardware/arduino/avr/cores/arduino/Print.cpp
+++ b/hardware/arduino/avr/cores/arduino/Print.cpp
@@ -122,9 +122,7 @@ size_t Print::print(const Printable& x)
 
 size_t Print::println(void)
 {
-  size_t n = print('\r');
-  n += print('\n');
-  return n;
+  return write("\r\n");
 }
 
 size_t Print::println(const String &s)

--- a/hardware/arduino/sam/cores/arduino/Print.cpp
+++ b/hardware/arduino/sam/cores/arduino/Print.cpp
@@ -115,9 +115,7 @@ size_t Print::print(const Printable& x)
 
 size_t Print::println(void)
 {
-  size_t n = print('\r');
-  n += print('\n');
-  return n;
+  return write("\r\n");
 }
 
 size_t Print::println(const String &s)


### PR DESCRIPTION
This PR resolves issue #884

The sketch below dropped 30 bytes. The increase to ram is only 2 bytes (AVR). The changes aren't as big on the SAM core, but still show a slight improvement in code size.

```arduino
/***

  Standard:
    Sketch uses 5,634 bytes (18%) of program storage space. Maximum is 32,256 bytes.
    Global variables use 228 bytes (11%) of dynamic memory, leaving 1,820 bytes for local variables. Maximum is 2,048 bytes.
     
  Proposed:
    Sketch uses 5,604 bytes (17%) of program storage space. Maximum is 32,256 bytes.
    Global variables use 230 bytes (11%) of dynamic memory, leaving 1,818 bytes for local variables. Maximum is 2,048 bytes.
  
***/

void setup(){
  Serial.begin( 9600 );
  Serial.println( F("Printing a flash string!") );
  Serial.println( 12.34567f, 4 );
  Serial.println( "A plain string" );
  Serial.println( 'a' );
  Serial.println( String( "A String" ) );
  Serial.println( 123456, BIN );
  Serial.println( 123456, OCT );
  Serial.println( 123456, DEC );
  Serial.println( 123456, HEX );
}

void loop(){}
```