### PR TITLE
MacOSX: attempting disabling OpenGL rendering pipeline

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -307,6 +307,7 @@
       <option value="-Dcom.apple.macos.use-file-dialog-packages=true"/>
       <option value="-Dcom.apple.smallTabs=true"/>
       <option value="-Dcom.apple.macos.useScreenMenuBar=true" />
+      <option value="-Dsun.java2d.opengl=false" />
 
       <!--
       <option value="-Dapple.awt.showGrowBox=false"/>


### PR DESCRIPTION
Some Macs have a dual GPU setup and the IDE (as well as other programs btw) is turning on the most powerful one, resulting in a shorter battery life