### PR TITLE
Stop using [ and ] as indentation menu accelerators

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -1420,7 +1420,8 @@ public class Editor extends JFrame implements RunnerListener {
     });
     menu.add(commentItem);
 
-    JMenuItem increaseIndentItem = newJMenuItem(_("Increase Indent"), ']');
+    JMenuItem increaseIndentItem = new JMenuItem(_("Increase Indent"));
+    increaseIndentItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_TAB, 0));
     increaseIndentItem.addActionListener(new ActionListener() {
         public void actionPerformed(ActionEvent e) {
           handleIndentOutdent(true);
@@ -1428,7 +1429,8 @@ public class Editor extends JFrame implements RunnerListener {
     });
     menu.add(increaseIndentItem);
 
-    JMenuItem decreseIndentItem = newJMenuItem(_("Decrease Indent"), '[');
+    JMenuItem decreseIndentItem = new JMenuItem(_("Decrease Indent"));
+    decreseIndentItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_TAB, InputEvent.SHIFT_MASK));
     decreseIndentItem.setName("menuDecreaseIndent");
     decreseIndentItem.addActionListener(new ActionListener() {
         public void actionPerformed(ActionEvent e) {

--- a/app/src/processing/app/syntax/SketchTextAreaDefaultInputMap.java
+++ b/app/src/processing/app/syntax/SketchTextAreaDefaultInputMap.java
@@ -39,6 +39,9 @@ public class SketchTextAreaDefaultInputMap extends RSyntaxTextAreaDefaultInputMa
       put(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, defaultModifier), DefaultEditorKit.endAction);
 
       remove(KeyStroke.getKeyStroke(KeyEvent.VK_J, defaultModifier));
+
+      put(KeyStroke.getKeyStroke(KeyEvent.VK_OPEN_BRACKET, defaultModifier), DefaultEditorKit.insertTabAction);
+      put(KeyStroke.getKeyStroke(KeyEvent.VK_CLOSE_BRACKET, defaultModifier), RSyntaxTextAreaEditorKit.rstaDecreaseIndentAction);
     }
 
     put(KeyStroke.getKeyStroke(KeyEvent.VK_DIVIDE, defaultModifier), RSyntaxTextAreaEditorKit.rstaToggleCommentAction);


### PR DESCRIPTION
Use TAB/SHIFT+TAB instead. Fixes #3224 and #220
This problem affects Processing as well. See https://github.com/processing/processing/issues/2199
Brackets may work on US keyboards, although no editor that I know uses them. TAB is a much more popular and widely accepted shortcut for indentation
