### PR TITLE
MacOSX: CMD+SHIFT-LEFT/RIGHT selects the entire line. Fixes #3238

### DIFF
--- a/app/src/processing/app/syntax/SketchTextAreaDefaultInputMap.java
+++ b/app/src/processing/app/syntax/SketchTextAreaDefaultInputMap.java
@@ -46,6 +46,9 @@ public class SketchTextAreaDefaultInputMap extends RSyntaxTextAreaDefaultInputMa
 
       put(KeyStroke.getKeyStroke(KeyEvent.VK_OPEN_BRACKET, defaultModifier), DefaultEditorKit.insertTabAction);
       put(KeyStroke.getKeyStroke(KeyEvent.VK_CLOSE_BRACKET, defaultModifier), RSyntaxTextAreaEditorKit.rstaDecreaseIndentAction);
+
+      put(KeyStroke.getKeyStroke(KeyEvent.VK_UP, defaultModifier | shift), DefaultEditorKit.selectionBeginAction);
+      put(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, defaultModifier | shift), DefaultEditorKit.selectionEndAction);
     }
 
     put(KeyStroke.getKeyStroke(KeyEvent.VK_DIVIDE, defaultModifier), RSyntaxTextAreaEditorKit.rstaToggleCommentAction);

--- a/app/src/processing/app/syntax/SketchTextAreaDefaultInputMap.java
+++ b/app/src/processing/app/syntax/SketchTextAreaDefaultInputMap.java
@@ -16,6 +16,7 @@ public class SketchTextAreaDefaultInputMap extends RSyntaxTextAreaDefaultInputMa
   public SketchTextAreaDefaultInputMap() {
     int defaultModifier = getDefaultModifier();
     int alt = InputEvent.ALT_MASK;
+    int shift = InputEvent.SHIFT_MASK;
     boolean isOSX = RTextArea.isOSX();
     int moveByWordMod = isOSX ? alt : defaultModifier;
 
@@ -37,6 +38,9 @@ public class SketchTextAreaDefaultInputMap extends RSyntaxTextAreaDefaultInputMa
 
       put(KeyStroke.getKeyStroke(KeyEvent.VK_UP, defaultModifier), DefaultEditorKit.beginAction);
       put(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, defaultModifier), DefaultEditorKit.endAction);
+
+      put(KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, defaultModifier | shift), DefaultEditorKit.selectLineAction);
+      put(KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, defaultModifier | shift), DefaultEditorKit.selectLineAction);
 
       remove(KeyStroke.getKeyStroke(KeyEvent.VK_J, defaultModifier));
 


### PR DESCRIPTION
/cc @Lauszus 