### PR TITLE
Fix for single line comments ending in \﻿

### DIFF
--- a/arduino-core/src/processing/app/preproc/PdePreprocessor.java
+++ b/arduino-core/src/processing/app/preproc/PdePreprocessor.java
@@ -394,10 +394,24 @@ public class PdePreprocessor {
           (p[index+1] == '/')) {
         p[index++] = ' ';
         p[index++] = ' ';
-        while ((index < p.length) &&
-               (p[index] != '\n')) {
-          p[index++] = ' ';
-        }
+		
+		char prev = ' ';
+		
+		while(index < p.length){
+		
+		  if(p[index] == '\n'){
+		  
+		    if( prev == '\\' ){
+			  p[index - 1] = prev;
+			  p[index - 2] = '/';
+			  p[index - 3] = '/';
+			}
+			break;
+		  }else{
+		    prev = p[index];
+		    p[index++] = ' ';
+		  }
+		}
 
         // check to see if this is the start of a new multiline comment.
         // if it is, then make sure it's actually terminated somewhere.


### PR DESCRIPTION
This is a fix for #956 

Comments are still stripped, however, single line comments with a multi line directive are replaced with spaces while preserving the comment and multi line slash.

```arduino

//A standard comment
unsigned char values[] = {
45, 12, 56, // A comment with a multi line pre-processor \
45, 13, 57,
45, 13, 58
};

/***
 * 
 * A fancy comment
 * 
 */

void setup() {/* An inline comment */}
void loop() {}
```

After pre-processing:

```arduino
#line 1 "comment_error.ino"

                    
#include "Arduino.h"
void setup();
void loop();
#line 3
unsigned char values[] = {
45, 12, 56,                                            //\
45, 13, 57,
45, 13, 58
};

    
   
                  
   
   

void setup() {                       }
void loop() {}

```