### PR TITLE
Check if INT2 is actually defined before issuing warning in detachInterrupt

### DIFF
--- a/hardware/arduino/avr/cores/arduino/WInterrupts.c
+++ b/hardware/arduino/avr/cores/arduino/WInterrupts.c
@@ -231,7 +231,7 @@ void detachInterrupt(uint8_t interruptNum) {
       GICR &= ~(1 << INT2); // atmega32
     #elif defined(GIMSK) && defined(INT2)
       GIMSK &= ~(1 << INT2);
-    #else
+    #elif defined(INT2)
       #warning detachInterrupt may need some more work for this cpu (case 2)
     #endif
       break;       


### PR DESCRIPTION
This was caused after: https://github.com/arduino/Arduino/pull/3221