### PR TITLE
add Arduino Gemma Bootloader source files

### DIFF
--- a/hardware/arduino/avr/bootloaders/gemma/README.md
+++ b/hardware/arduino/avr/bootloaders/gemma/README.md
@@ -1,0 +1,14 @@
+Arduino Gemma Bootloader
+========================
+
+The Arduino Gemma Bootloader is based on the Adafruit Trinket/Gemma Bootloader. In the Arduino Gemma bootloader the USB VID&PID, the Manufacturer name and the Device name parameters are changed.
+
+The source code of the bootloader of the version used at the compile time can be found at the following link: https://github.com/adafruit/Adafruit-Trinket-Gemma-Bootloader/tree/3bc1bb561273535d4d493518a233a3a1fccf6b76
+
+The *'usbconfig.h'* and the *'usbconfig.patch'* files are provided if you want to recompile the bootloader.
+You only need to replace the original *'usbconfig.h'* file with this one or patch it with the provided patch file.
+
+**Please note: you cannot use the Arduino USB VID/PID for your own non-Gemma products or projects. Purchase a USB VID for yourself at**  http://www.usb.org/developers/vendor/ 
+
+
+

--- a/hardware/arduino/avr/bootloaders/gemma/usbconfig.h
+++ b/hardware/arduino/avr/bootloaders/gemma/usbconfig.h
@@ -1,0 +1,351 @@
+/* Name: usbconfig.h
+ * Project: V-USB, virtual USB port for Atmel's(r) AVR(r) microcontrollers
+ * Author: Christian Starkjohann
+ * Creation Date: 2005-04-01
+ * Tabsize: 4
+ * Copyright: (c) 2005 by OBJECTIVE DEVELOPMENT Software GmbH
+ * License: GNU GPL v2 or v3 (see License.txt)
+ */
+ 
+/* Modified by me@frank-zhao.com for project GemmaBoot
+ *  
+ * GemmaBoot is a bootloader that emulates a USBtinyISP (from Adafruit Industries)
+ *  
+ * Gemma will use GemmaBoot
+ *
+ * This code is heavily derived from USBaspLoader, but also from USBtiny, with USBtinyISP's settings
+ 
+  Copyright (c) 2013 Adafruit Industries
+  All rights reserved.
+
+  GemmaBoot is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 3 of
+  the License, or (at your option) any later version.
+
+  GemmaBoot is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with GemmaBoot. If not, see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef __usbconfig_h_included__
+#define __usbconfig_h_included__
+
+/* YOU SHOULD NOT NEED TO MODIFY THIS FILE! All configurations are supposed
+ * to go into bootloaderconfig.h!
+ */
+
+/* ---------------------------- Hardware Config ---------------------------- */
+
+/* All the port and pin assignments, as well as the clock speed and CRC
+   setting are now in bootloaderconfig.h: */
+
+#include "bootloaderconfig.h"
+
+/* --------------------------- Functional Range ---------------------------- */
+
+#define USB_CFG_HAVE_INTRIN_ENDPOINT    0
+/* Define this to 1 if you want to compile a version with two endpoints: The
+ * default control endpoint 0 and an interrupt-in endpoint (any other endpoint
+ * number).
+ */
+#define USB_CFG_HAVE_INTRIN_ENDPOINT3   0
+/* Define this to 1 if you want to compile a version with three endpoints: The
+ * default control endpoint 0, an interrupt-in endpoint 3 (or the number
+ * configured below) and a catch-all default interrupt-in endpoint as above.
+ * You must also define USB_CFG_HAVE_INTRIN_ENDPOINT to 1 for this feature.
+ */
+#define USB_CFG_EP3_NUMBER              3
+/* If the so-called endpoint 3 is used, it can now be configured to any other
+ * endpoint number (except 0) with this macro. Default if undefined is 3.
+ */
+/* #define USB_INITIAL_DATATOKEN           USBPID_DATA1 */
+/* The above macro defines the startup condition for data toggling on the
+ * interrupt/bulk endpoints 1 and 3. Defaults to USBPID_DATA1.
+ * Since the token is toggled BEFORE sending any data, the first packet is
+ * sent with the oposite value of this configuration!
+ */
+#define USB_CFG_IMPLEMENT_HALT          0
+/* Define this to 1 if you also want to implement the ENDPOINT_HALT feature
+ * for endpoint 1 (interrupt endpoint). Although you may not need this feature,
+ * it is required by the standard. We have made it a config option because it
+ * bloats the code considerably.
+ */
+#define USB_CFG_SUPPRESS_INTR_CODE      0
+/* Define this to 1 if you want to declare interrupt-in endpoints, but don't
+ * want to send any data over them. If this macro is defined to 1, functions
+ * usbSetInterrupt() and usbSetInterrupt3() are omitted. This is useful if
+ * you need the interrupt-in endpoints in order to comply to an interface
+ * (e.g. HID), but never want to send any data. This option saves a couple
+ * of bytes in flash memory and the transmit buffers in RAM.
+ */
+#define USB_CFG_INTR_POLL_INTERVAL      10
+/* If you compile a version with endpoint 1 (interrupt-in), this is the poll
+ * interval. The value is in milliseconds and must not be less than 10 ms for
+ * low speed devices.
+ */
+#ifndef USB_CFG_IS_SELF_POWERED // allow bootloaderconfig.h to override
+#define USB_CFG_IS_SELF_POWERED         0
+#endif
+/* Define this to 1 if the device has its own power supply. Set it to 0 if the
+ * device is powered from the USB bus.
+ */
+#ifndef USB_CFG_MAX_BUS_POWER   // allow bootloaderconfig.h to override
+#define USB_CFG_MAX_BUS_POWER           100
+#endif
+/* Set this variable to the maximum USB bus power consumption of your device.
+ * The value is in milliamperes. [It will be divided by two since USB
+ * communicates power requirements in units of 2 mA.]
+ */
+#define USB_CFG_IMPLEMENT_FN_WRITE      1
+/* Set this to 1 if you want usbFunctionWrite() to be called for control-out
+ * transfers. Set it to 0 if you don't need it and want to save a couple of
+ * bytes.
+ */
+#define USB_CFG_IMPLEMENT_FN_READ       1
+/* Set this to 1 if you need to send control replies which are generated
+ * "on the fly" when usbFunctionRead() is called. If you only want to send
+ * data from a static buffer, set it to 0 and return the data from
+ * usbFunctionSetup(). This saves a couple of bytes.
+ */
+#define USB_CFG_IMPLEMENT_FN_WRITEOUT   0
+/* Define this to 1 if you want to use interrupt-out (or bulk out) endpoints.
+ * You must implement the function usbFunctionWriteOut() which receives all
+ * interrupt/bulk data sent to any endpoint other than 0. The endpoint number
+ * can be found in 'usbRxToken'.
+ */
+#define USB_CFG_HAVE_FLOWCONTROL        0
+/* Define this to 1 if you want flowcontrol over USB data. See the definition
+ * of the macros usbDisableAllRequests() and usbEnableAllRequests() in
+ * usbdrv.h.
+ */
+#define USB_CFG_DRIVER_FLASH_PAGE       0
+/* If the device has more than 64 kBytes of flash, define this to the 64 k page
+ * where the driver's constants (descriptors) are located. Or in other words:
+ * Define this to 1 for boot loaders on the ATMega128.
+ */
+#define USB_CFG_LONG_TRANSFERS          0
+/* Define this to 1 if you want to send/receive blocks of more than 254 bytes
+ * in a single control-in or control-out transfer. Note that the capability
+ * for long transfers increases the driver size.
+ */
+#ifndef __ASSEMBLER__
+extern volatile char usbHasRxed;
+#endif
+#define USB_RX_USER_HOOK(data, len)     do { usbHasRxed = 1; } while (0);
+/* This macro is a hook if you want to do unconventional things. If it is
+ * defined, it's inserted at the beginning of received message processing.
+ * If you eat the received message and don't want default processing to
+ * proceed, do a return after doing your things. One possible application
+ * (besides debugging) is to flash a status LED on each packet.
+ */
+/* #define USB_RESET_HOOK(resetStarts)     if(!resetStarts){hadUsbReset();} */
+/* This macro is a hook if you need to know when an USB RESET occurs. It has
+ * one parameter which distinguishes between the start of RESET state and its
+ * end.
+ */
+/* #define USB_SET_ADDRESS_HOOK()              hadAddressAssigned(); */
+/* This macro (if defined) is executed when a USB SET_ADDRESS request was
+ * received.
+ */
+#define USB_COUNT_SOF                   0
+/* define this macro to 1 if you need the global variable "usbSofCount" which
+ * counts SOF packets. This feature requires that the hardware interrupt is
+ * connected to D- instead of D+.
+ */
+/* #ifdef __ASSEMBLER__
+ * macro myAssemblerMacro
+ *     in      YL, TCNT0
+ *     sts     timer0Snapshot, YL
+ *     endm
+ * #endif
+ * #define USB_SOF_HOOK                    myAssemblerMacro
+ * This macro (if defined) is executed in the assembler module when a
+ * Start Of Frame condition is detected. It is recommended to define it to
+ * the name of an assembler macro which is defined here as well so that more
+ * than one assembler instruction can be used. The macro may use the register
+ * YL and modify SREG. If it lasts longer than a couple of cycles, USB messages
+ * immediately after an SOF pulse may be lost and must be retried by the host.
+ * What can you do with this hook? Since the SOF signal occurs exactly every
+ * 1 ms (unless the host is in sleep mode), you can use it to tune OSCCAL in
+ * designs running on the internal RC oscillator.
+ * Please note that Start Of Frame detection works only if D- is wired to the
+ * interrupt, not D+. THIS IS DIFFERENT THAN MOST EXAMPLES!
+ */
+#define USB_CFG_CHECK_DATA_TOGGLING     0
+/* define this macro to 1 if you want to filter out duplicate data packets
+ * sent by the host. Duplicates occur only as a consequence of communication
+ * errors, when the host does not receive an ACK. Please note that you need to
+ * implement the filtering yourself in usbFunctionWriteOut() and
+ * usbFunctionWrite(). Use the global usbCurrentDataToken and a static variable
+ * for each control- and out-endpoint to check for duplicate packets.
+ */
+#define USB_CFG_HAVE_MEASURE_FRAME_LENGTH   1
+/* define this macro to 1 if you want the function usbMeasureFrameLength()
+ * compiled in. This function can be used to calibrate the AVR's RC oscillator.
+ */
+#define USB_USE_FAST_CRC                0
+/* The assembler module has two implementations for the CRC algorithm. One is
+ * faster, the other is smaller. This CRC routine is only used for transmitted
+ * messages where timing is not critical. The faster routine needs 31 cycles
+ * per byte while the smaller one needs 61 to 69 cycles. The faster routine
+ * may be worth the 32 bytes bigger code size if you transmit lots of data and
+ * run the AVR close to its limit.
+ */
+
+/* -------------------------- Device Description --------------------------- */
+
+#define USB_CFG_VENDOR_ID		0x41, 0x23 /* = 0x16c0 = 5824 = voti.nl */
+/* USB vendor ID for the device, low byte first. If you have registered your
+ * own Vendor ID, define it here. Otherwise you may use one of obdev's free
+ * shared VID/PID pairs. Be sure to read USB-IDs-for-free.txt for rules!
+ */
+#define USB_CFG_DEVICE_ID		0x9F, 0x0c /* = 0x05dc = 1500 */
+/* This is the ID of the product, low byte first. It is interpreted in the
+ * scope of the vendor ID. If you have registered your own VID with usb.org
+ * or if you have licensed a PID from somebody else, define it here. Otherwise
+ * you may use one of obdev's free shared VID/PID pairs. See the file
+ * USB-IDs-for-free.txt for details!
+ */
+#define USB_CFG_DEVICE_VERSION	0x00, 0x01
+/* Version number of the device: Minor number first, then major number.
+ */
+#define USB_CFG_VENDOR_NAME 'A','r','d','u','i','n','o','.','c','c'
+#define USB_CFG_VENDOR_NAME_LEN 10
+/* These two values define the vendor name returned by the USB device. The name
+ * must be given as a list of characters under single quotes. The characters
+ * are interpreted as Unicode (UTF-16) entities.
+ * If you don't want a vendor name string, undefine these macros.
+ * ALWAYS define a vendor name containing your Internet domain name if you use
+ * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
+ * details.
+ */
+#define USB_CFG_DEVICE_NAME 'G','e','m','m','a'
+#define USB_CFG_DEVICE_NAME_LEN 5
+/* Same as above for the device name. If you don't want a device name, undefine
+ * the macros. See the file USB-IDs-for-free.txt before you assign a name if
+ * you use a shared VID/PID.
+ */
+/*#define USB_CFG_SERIAL_NUMBER   'N', 'o', 'n', 'e' */
+/*#define USB_CFG_SERIAL_NUMBER_LEN   0 */
+/* Same as above for the serial number. If you don't want a serial number,
+ * undefine the macros.
+ * It may be useful to provide the serial number through other means than at
+ * compile time. See the section about descriptor properties below for how
+ * to fine tune control over USB descriptors such as the string descriptor
+ * for the serial number.
+ */
+#define USB_CFG_DEVICE_CLASS        0xFF    /* set to 0 if deferred to interface */
+#define USB_CFG_DEVICE_SUBCLASS     0
+/* See USB specification if you want to conform to an existing device class.
+ * Class 0xff is "vendor specific".
+ */
+#define USB_CFG_INTERFACE_CLASS     0   /* define class here if not at device level */
+#define USB_CFG_INTERFACE_SUBCLASS  0
+#define USB_CFG_INTERFACE_PROTOCOL  0
+/* See USB specification if you want to conform to an existing device class or
+ * protocol. The following classes must be set at interface level:
+ * HID class is 3, no subclass and protocol required (but may be useful!)
+ * CDC class is 2, use subclass 2 and protocol 1 for ACM
+ */
+/* #define USB_CFG_HID_REPORT_DESCRIPTOR_LENGTH    42 */
+/* Define this to the length of the HID report descriptor, if you implement
+ * an HID device. Otherwise don't define it or define it to 0.
+ * If you use this define, you must add a PROGMEM character array named
+ * "usbHidReportDescriptor" to your code which contains the report descriptor.
+ * Don't forget to keep the array and this define in sync!
+ */
+
+#define USB_PUBLIC static
+/* Use the define above if you #include usbdrv.c instead of linking against it.
+ * This technique saves a couple of bytes in flash memory.
+ */
+
+/* ------------------- Fine Control over USB Descriptors ------------------- */
+/* If you don't want to use the driver's default USB descriptors, you can
+ * provide our own. These can be provided as (1) fixed length static data in
+ * flash memory, (2) fixed length static data in RAM or (3) dynamically at
+ * runtime in the function usbFunctionDescriptor(). See usbdrv.h for more
+ * information about this function.
+ * Descriptor handling is configured through the descriptor's properties. If
+ * no properties are defined or if they are 0, the default descriptor is used.
+ * Possible properties are:
+ *   + USB_PROP_IS_DYNAMIC: The data for the descriptor should be fetched
+ *     at runtime via usbFunctionDescriptor(). If the usbMsgPtr mechanism is
+ *     used, the data is in FLASH by default. Add property USB_PROP_IS_RAM if
+ *     you want RAM pointers.
+ *   + USB_PROP_IS_RAM: The data returned by usbFunctionDescriptor() or found
+ *     in static memory is in RAM, not in flash memory.
+ *   + USB_PROP_LENGTH(len): If the data is in static memory (RAM or flash),
+ *     the driver must know the descriptor's length. The descriptor itself is
+ *     found at the address of a well known identifier (see below).
+ * List of static descriptor names (must be declared PROGMEM if in flash):
+ *   char usbDescriptorDevice[];
+ *   char usbDescriptorConfiguration[];
+ *   char usbDescriptorHidReport[];
+ *   char usbDescriptorString0[];
+ *   int usbDescriptorStringVendor[];
+ *   int usbDescriptorStringDevice[];
+ *   int usbDescriptorStringSerialNumber[];
+ * Other descriptors can't be provided statically, they must be provided
+ * dynamically at runtime.
+ *
+ * Descriptor properties are or-ed or added together, e.g.:
+ * #define USB_CFG_DESCR_PROPS_DEVICE   (USB_PROP_IS_RAM | USB_PROP_LENGTH(18))
+ *
+ * The following descriptors are defined:
+ *   USB_CFG_DESCR_PROPS_DEVICE
+ *   USB_CFG_DESCR_PROPS_CONFIGURATION
+ *   USB_CFG_DESCR_PROPS_STRINGS
+ *   USB_CFG_DESCR_PROPS_STRING_0
+ *   USB_CFG_DESCR_PROPS_STRING_VENDOR
+ *   USB_CFG_DESCR_PROPS_STRING_PRODUCT
+ *   USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER
+ *   USB_CFG_DESCR_PROPS_HID
+ *   USB_CFG_DESCR_PROPS_HID_REPORT
+ *   USB_CFG_DESCR_PROPS_UNKNOWN (for all descriptors not handled by the driver)
+ *
+ * Note about string descriptors: String descriptors are not just strings, they
+ * are Unicode strings prefixed with a 2 byte header. Example:
+ * int  serialNumberDescriptor[] = {
+ *     USB_STRING_DESCRIPTOR_HEADER(6),
+ *     'S', 'e', 'r', 'i', 'a', 'l'
+ * };
+ */
+
+#define USB_CFG_DESCR_PROPS_DEVICE                  0
+#define USB_CFG_DESCR_PROPS_CONFIGURATION           0
+#define USB_CFG_DESCR_PROPS_STRINGS                 0
+#define USB_CFG_DESCR_PROPS_STRING_0                0
+#define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
+#define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
+#define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_HID                     0
+#define USB_CFG_DESCR_PROPS_HID_REPORT              0
+#define USB_CFG_DESCR_PROPS_UNKNOWN                 0
+
+#define usbMsgPtr_t unsigned short  // scalar type yields shortest code
+
+/* ----------------------- Optional MCU Description ------------------------ */
+
+/* The following configurations have working defaults in usbdrv.h. You
+ * usually don't need to set them explicitly. Only if you want to run
+ * the driver on a device which is not yet supported or with a compiler
+ * which is not fully supported (such as IAR C) or if you use a differnt
+ * interrupt than INT0, you may have to define some of these.
+ */
+#define USB_INTR_CFG            PCMSK
+#define USB_INTR_CFG_SET        (1 << USB_CFG_DPLUS_BIT)
+#define USB_INTR_CFG_CLR        0
+#define USB_INTR_ENABLE         GIMSK
+#define USB_INTR_ENABLE_BIT     PCIE
+#define USB_INTR_PENDING        GIFR
+#define USB_INTR_PENDING_BIT    PCIF
+#define USB_INTR_VECTOR         PCINT0_vect
+
+#endif /* __usbconfig_h_included__ */

--- a/hardware/arduino/avr/bootloaders/gemma/usbconfig.patch
+++ b/hardware/arduino/avr/bootloaders/gemma/usbconfig.patch
@@ -1,0 +1,24 @@
+203c203
+< #define USB_CFG_VENDOR_ID		0x81, 0x17 /* = 0x16c0 = 5824 = voti.nl */
+---
+> #define USB_CFG_VENDOR_ID		0x41, 0x23 /* = 0x16c0 = 5824 = voti.nl */
+208c208
+< #define USB_CFG_DEVICE_ID		0x9F, 0x0C /* = 0x05dc = 1500 */
+---
+> #define USB_CFG_DEVICE_ID		0x9F, 0x0c /* = 0x05dc = 1500 */
+215c215
+< #define USB_CFG_DEVICE_VERSION	0x05, 0x01
+---
+> #define USB_CFG_DEVICE_VERSION	0x00, 0x01
+218,219c218,219
+< #define USB_CFG_VENDOR_NAME 'A','d','a','f','r','u','i','t'
+< #define USB_CFG_VENDOR_NAME_LEN 8
+---
+> #define USB_CFG_VENDOR_NAME 'A','r','d','u','i','n','o','.','c','c'
+> #define USB_CFG_VENDOR_NAME_LEN 10
+228,229c228,229
+< #define USB_CFG_DEVICE_NAME 'T','r','i','n','k','e','t'
+< #define USB_CFG_DEVICE_NAME_LEN 7
+---
+> #define USB_CFG_DEVICE_NAME 'G','e','m','m','a'
+> #define USB_CFG_DEVICE_NAME_LEN 5


### PR DESCRIPTION
The Arduino Gemma Bootloader is based on the Adafruit Trinket/Gemma bootloader. In the README.md file there are the links to the original source files and the patch files for compiling the Arduino Gemma bootloader are added.