### PR TITLE
Fixes to YunClient in connected() and stop()

### DIFF
--- a/libraries/Bridge/src/YunClient.cpp
+++ b/libraries/Bridge/src/YunClient.cpp
@@ -114,6 +114,10 @@ void YunClient::flush() {
 uint8_t YunClient::connected() {
   if (!opened)
     return false;
+  // Client is "connected" if it has unread bytes
+  if (available())
+    return true;
+
   uint8_t cmd[] = {'L', handle};
   uint8_t res[1];
   bridge.transfer(cmd, 2, res, 1);

--- a/libraries/Bridge/src/YunClient.cpp
+++ b/libraries/Bridge/src/YunClient.cpp
@@ -41,6 +41,8 @@ void YunClient::stop() {
     bridge.transfer(cmd, 2);
   }
   opened = false;
+  buffered = 0;
+  readPos = 0;
 }
 
 void YunClient::doBuffer() {


### PR DESCRIPTION
This pull request fixes YunClient to better conform to other Clients like EthernetClient and WiFiClient:

1) `connected()` now returns true if there are unread bytes, like other Clients and the docs say.
2) `stop()` now resets `buffered` and `readPos` so reusing a client with unread bytes does not cause those old bytes to be read.