### PR TITLE
Cmd+Shift+Left/Right selects from cursor to start/end of line (OS X)

### DIFF
--- a/app/src/processing/app/syntax/SketchTextAreaDefaultInputMap.java
+++ b/app/src/processing/app/syntax/SketchTextAreaDefaultInputMap.java
@@ -39,8 +39,8 @@ public class SketchTextAreaDefaultInputMap extends RSyntaxTextAreaDefaultInputMa
       put(KeyStroke.getKeyStroke(KeyEvent.VK_UP, defaultModifier), DefaultEditorKit.beginAction);
       put(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, defaultModifier), DefaultEditorKit.endAction);
 
-      put(KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, defaultModifier | shift), DefaultEditorKit.selectLineAction);
-      put(KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, defaultModifier | shift), DefaultEditorKit.selectLineAction);
+      put(KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, defaultModifier | shift), DefaultEditorKit.selectionBeginLineAction);
+      put(KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, defaultModifier | shift), DefaultEditorKit.selectionEndLineAction);
 
       remove(KeyStroke.getKeyStroke(KeyEvent.VK_J, defaultModifier));
 


### PR DESCRIPTION
Instead of selecting the entire line. This brings it closer to the standard / expected behavior on OS X (and matches what I see in Processing 3.0a9). 

After applying this commit, the behavior is still slightly different than what you see in other OS X applications, but I think it's close enough. (The standard behavior is for the cursor to disappear once there's a selection, at which point Cmd+Shift+Left/Right/Up/Down always adds to the current selection, as opposed to moving the active end of the current selection, which can either add to or subtract from the selection. Weirdly, though, Shift+Left/Right/Up/Down Alt+Shift+Left/Right/Up/Down move the active end of the selection, rather than always adding to it.) If you wanted to get any closer to the standard behavior, you'd probably need to hide the cursor while text was selected, and I'm not sure if it's worth it.