### PR TITLE
Defaults output pins to LOW on Due

### DIFF
--- a/hardware/arduino/sam/cores/arduino/wiring_digital.c
+++ b/hardware/arduino/sam/cores/arduino/wiring_digital.c
@@ -54,7 +54,7 @@ extern void pinMode( uint32_t ulPin, uint32_t ulMode )
         case OUTPUT:
             PIO_Configure(
             	g_APinDescription[ulPin].pPort,
-            	PIO_OUTPUT_1,
+            	PIO_OUTPUT_0,
             	g_APinDescription[ulPin].ulPin,
             	g_APinDescription[ulPin].ulPinConfiguration ) ;
 


### PR DESCRIPTION
When a pin is designated as an output on the Arduino Due, the pin is set
to a HIGH logic level. Changing the default pin state to LOW makes the
behaviour correspond with AVR. See #3310 