### PR TITLE
Fix build on windows (rename/move).

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -187,14 +187,14 @@
       <param name="final_folder" value="${target.path}/libraries/Firmata-2.4.3" />
       <param name="dest_folder" value="${target.path}/libraries" />
     </antcall>
-    <rename src="${target.path}/libraries/Firmata-2.4.3" dest="${target.path}/libraries/Firmata"/>
+	<move file="${target.path}/libraries/Firmata-2.4.3" tofile="${target.path}/libraries/Firmata" />
     <antcall target="unzip">
       <param name="archive_file" value="Temboo-1.1.2.zip" />
       <param name="archive_url" value="https://github.com/temboo/Temboo/archive/1.1.2.zip" />
       <param name="final_folder" value="${target.path}/libraries/Temboo-1.1.2" />
       <param name="dest_folder" value="${target.path}/libraries" />
     </antcall>
-    <rename src="${target.path}/libraries/Temboo-1.1.2" dest="${target.path}/libraries/Temboo"/>
+	<move file="${target.path}/libraries/Temboo-1.1.2" tofile="${target.path}/libraries/Temboo" />
   </target>
 
   <!-- copy hardware folder -->

--- a/build/build.xml
+++ b/build/build.xml
@@ -187,14 +187,14 @@
       <param name="final_folder" value="${target.path}/libraries/Firmata-2.4.3" />
       <param name="dest_folder" value="${target.path}/libraries" />
     </antcall>
-	<move file="${target.path}/libraries/Firmata-2.4.3" tofile="${target.path}/libraries/Firmata" />
+    <move file="${target.path}/libraries/Firmata-2.4.3" tofile="${target.path}/libraries/Firmata" />
     <antcall target="unzip">
       <param name="archive_file" value="Temboo-1.1.2.zip" />
       <param name="archive_url" value="https://github.com/temboo/Temboo/archive/1.1.2.zip" />
       <param name="final_folder" value="${target.path}/libraries/Temboo-1.1.2" />
       <param name="dest_folder" value="${target.path}/libraries" />
     </antcall>
-	<move file="${target.path}/libraries/Temboo-1.1.2" tofile="${target.path}/libraries/Temboo" />
+    <move file="${target.path}/libraries/Temboo-1.1.2" tofile="${target.path}/libraries/Temboo" />
   </target>
 
   <!-- copy hardware folder -->


### PR DESCRIPTION
It appears ant is no longer supporting `rename` in windows.
This patch replaces these commands with `move`.

This fixes #3322