### PR TITLE
Fixed behaviour in the falling phase PJ03 StarterKit

### DIFF
--- a/build/shared/examples/10.StarterKit/p03_LoveOMeter/p03_LoveOMeter.ino
+++ b/build/shared/examples/10.StarterKit/p03_LoveOMeter/p03_LoveOMeter.ino
@@ -60,7 +60,7 @@ void loop() {
 
   // if the current temperature is lower than the baseline
   // turn off all LEDs
-  if (temperature < baselineTemp) {
+  if (temperature < baselineTemp + 2) {
     digitalWrite(2, LOW);
     digitalWrite(3, LOW);
     digitalWrite(4, LOW);


### PR DESCRIPTION
According to #2585 there was a "glitch" in the falling phase because of a missing +2 in the first condition