### PR TITLE
Improvements and fixes for Stream library.

### DIFF
--- a/hardware/arduino/avr/cores/arduino/Stream.cpp
+++ b/hardware/arduino/avr/cores/arduino/Stream.cpp
@@ -54,14 +54,17 @@ int Stream::timedPeek()
 
 // returns peek of the next digit in the stream or -1 if timeout
 // discards non-numeric characters
-int Stream::peekNextDigit()
+int Stream::peekNextDigit( bool detectDecimal )
 {
   int c;
   while (1) {
     c = timedPeek();
-    if (c < 0) return c;  // timeout
-    if (c == '-') return c;
-    if (c >= '0' && c <= '9') return c;
+
+    if( c < 0 ||
+        c == '-' ||
+        c >= '0' && c <= '9' ||
+        detectDecimal && c == '.') return c;
+
     read();  // discard non-numeric
   }
 }
@@ -124,7 +127,7 @@ long Stream::parseInt(char skipChar)
   long value = 0;
   int c;
 
-  c = peekNextDigit();
+  c = peekNextDigit(false);
   // ignore non numeric leading characters
   if(c < 0)
     return 0; // zero returned if timeout
@@ -162,7 +165,7 @@ float Stream::parseFloat(char skipChar){
   char c;
   float fraction = 1.0;
 
-  c = peekNextDigit();
+  c = peekNextDigit(true);
     // ignore non numeric leading characters
   if(c < 0)
     return 0; // zero returned if timeout

--- a/hardware/arduino/avr/cores/arduino/Stream.cpp
+++ b/hardware/arduino/avr/cores/arduino/Stream.cpp
@@ -26,7 +26,6 @@
 #include "Stream.h"
 
 #define PARSE_TIMEOUT 1000  // default number of milli-seconds to wait
-#define NO_SKIP_CHAR  1  // a magic char not found in a valid ASCII numeric field
 
 // private method to read stream with timeout
 int Stream::timedRead()
@@ -121,17 +120,11 @@ bool Stream::findUntil(char *target, size_t targetLen, char *terminator, size_t 
   }
 }
 
-
 // returns the first valid (long) integer value from the current position.
-// initial characters that are not digits (or the minus sign) are skipped
-// function is terminated by the first character that is not a digit.
-long Stream::parseInt(LookaheadMode lookahead)
-{
-  return parseInt(lookahead, NO_SKIP_CHAR); // terminate on first non-digit character (or timeout)
-}
-
-// as above but 'ignore' is ignored
-// this allows format characters (typically commas) in values to be ignored
+// lookahead determines how parseInt looks ahead in the stream.
+// See LookaheadMode enumeration at the top of the file.
+// Lookahead is terminated by the first character that is not a valid part of an integer.
+// Once parsing commences, 'ignore' will be skipped in the stream.
 long Stream::parseInt(LookaheadMode lookahead, char ignore)
 {
   bool isNegative = false;
@@ -160,16 +153,9 @@ long Stream::parseInt(LookaheadMode lookahead, char ignore)
   return value;
 }
 
-
 // as parseInt but returns a floating point value
-float Stream::parseFloat(LookaheadMode lookahead)
+float Stream::parseFloat(LookaheadMode lookahead, char ignore)
 {
-  return parseFloat(lookahead, NO_SKIP_CHAR);
-}
-
-// as above but the given ignore is ignored
-// this allows format characters (typically commas) in values to be ignored
-float Stream::parseFloat(LookaheadMode lookahead, char ignore){
   bool isNegative = false;
   bool isFraction = false;
   long value = 0;

--- a/hardware/arduino/avr/cores/arduino/Stream.cpp
+++ b/hardware/arduino/avr/cores/arduino/Stream.cpp
@@ -185,7 +185,7 @@ float Stream::parseFloat(char skipChar){
     read();  // consume the character we got with peek
     c = timedPeek();
   }
-  while( (c >= '0' && c <= '9')  || c == '.' || c == skipChar );
+  while( (c >= '0' && c <= '9')  || c == '.' && !isFraction || c == skipChar );
 
   if(isNegative)
     value = -value;

--- a/hardware/arduino/avr/cores/arduino/Stream.h
+++ b/hardware/arduino/avr/cores/arduino/Stream.h
@@ -44,6 +44,8 @@ enum LookaheadMode{
     SKIP_WHITESPACE // Only tabs, spaces, line feeds & carriage returns are skipped.
 };
 
+#define NO_IGNORE_CHAR  '\x01' // a char not found in a valid ASCII numeric field
+
 class Stream : public Print
 {
   protected:
@@ -81,12 +83,15 @@ class Stream : public Print
   bool findUntil(char *target, size_t targetLen, char *terminate, size_t termLen);   // as above but search ends if the terminate string is found
   bool findUntil(uint8_t *target, size_t targetLen, char *terminate, size_t termLen) {return findUntil((char *)target, targetLen, terminate, termLen); }
 
+  long parseInt(LookaheadMode lookahead = SKIP_ALL, char ignore = NO_IGNORE_CHAR);
+  // returns the first valid (long) integer value from the current position.
+  // lookahead determines how parseInt looks ahead in the stream.
+  // See LookaheadMode enumeration at the top of the file.
+  // Lookahead is terminated by the first character that is not a valid part of an integer.
+  // Once parsing commences, 'ignore' will be skipped in the stream.
 
-  long parseInt(LookaheadMode lookahead = SKIP_ALL); // returns the first valid (long) integer value from the current position.
-  // initial characters that are not digits (or the minus sign) are skipped
-  // integer is terminated by the first character that is not a digit.
-
-  float parseFloat(LookaheadMode lookahead = SKIP_ALL);               // float version of parseInt
+  float parseFloat(LookaheadMode lookahead = SKIP_ALL, char ignore = NO_IGNORE_CHAR);
+  // float version of parseInt
 
   size_t readBytes( char *buffer, size_t length); // read chars from stream into buffer
   size_t readBytes( uint8_t *buffer, size_t length) { return readBytes((char *)buffer, length); }
@@ -104,12 +109,10 @@ class Stream : public Print
 
   protected:
   long parseInt(char ignore) { return parseInt(SKIP_ALL, ignore); }
-  long parseInt(LookaheadMode lookahead, char ignore); // as above but the given ignore is ignored
-  // as above but 'ignore' is ignored
-  // this allows format characters (typically commas) in values to be ignored
-  
-  float parseFloat(char ignore) { return parseFloat(SKIP_ALL, ignore); }  
-  float parseFloat(LookaheadMode lookahead, char ignore);  // as above but the given ignore is ignored
+  float parseFloat(char ignore) { return parseFloat(SKIP_ALL, ignore); }
+  // These overload exists for compatibility with any class that has derived
+  // Stream and used parseFloat/Int with a custom ignore character. To keep
+  // the public API simple, these overload remains protected.
 
   struct MultiTarget {
     const char *str;  // string you're searching for
@@ -122,5 +125,5 @@ class Stream : public Print
   int findMulti(struct MultiTarget *targets, int tCount);
 };
 
-
+#undef NO_IGNORE_CHAR
 #endif

--- a/hardware/arduino/avr/cores/arduino/Stream.h
+++ b/hardware/arduino/avr/cores/arduino/Stream.h
@@ -28,12 +28,21 @@
 // compatability macros for testing
 /*
 #define   getInt()            parseInt()
-#define   getInt(skipChar)    parseInt(skipchar)
+#define   getInt(ignore)    parseInt(ignore)
 #define   getFloat()          parseFloat()
-#define   getFloat(skipChar)  parseFloat(skipChar)
+#define   getFloat(ignore)  parseFloat(ignore)
 #define   getString( pre_string, post_string, buffer, length)
 readBytesBetween( pre_string, terminator, buffer, length)
 */
+
+// This enumeration provides the lookahead options for parseInt(), parseFloat()
+// The rules set out here are used until either the first valid character is found
+// or a time out occurs due to lack of input.
+enum LookaheadMode{
+    SKIP_ALL,       // All invalid characters are ignored.
+    SKIP_NONE,      // Nothing is skipped, and the stream is not touched unless the first waiting character is valid.
+    SKIP_WHITESPACE // Only tabs, spaces, line feeds & carriage returns are skipped.
+};
 
 class Stream : public Print
 {
@@ -42,7 +51,7 @@ class Stream : public Print
     unsigned long _startMillis;  // used for timeout measurement
     int timedRead();    // private method to read stream with timeout
     int timedPeek();    // private method to peek stream with timeout
-    int peekNextDigit( bool detectDecimal ); // returns the next numeric digit in the stream or -1 if timeout
+    int peekNextDigit(LookaheadMode lookahead, bool detectDecimal); // returns the next numeric digit in the stream or -1 if timeout
 
   public:
     virtual int available() = 0;
@@ -73,11 +82,11 @@ class Stream : public Print
   bool findUntil(uint8_t *target, size_t targetLen, char *terminate, size_t termLen) {return findUntil((char *)target, targetLen, terminate, termLen); }
 
 
-  long parseInt(); // returns the first valid (long) integer value from the current position.
+  long parseInt(LookaheadMode lookahead = SKIP_ALL); // returns the first valid (long) integer value from the current position.
   // initial characters that are not digits (or the minus sign) are skipped
   // integer is terminated by the first character that is not a digit.
 
-  float parseFloat();               // float version of parseInt
+  float parseFloat(LookaheadMode lookahead = SKIP_ALL);               // float version of parseInt
 
   size_t readBytes( char *buffer, size_t length); // read chars from stream into buffer
   size_t readBytes( uint8_t *buffer, size_t length) { return readBytes((char *)buffer, length); }
@@ -94,11 +103,13 @@ class Stream : public Print
   String readStringUntil(char terminator);
 
   protected:
-  long parseInt(char skipChar); // as above but the given skipChar is ignored
-  // as above but the given skipChar is ignored
+  long parseInt(char ignore) { return parseInt(SKIP_ALL, ignore); }
+  long parseInt(LookaheadMode lookahead, char ignore); // as above but the given ignore is ignored
+  // as above but 'ignore' is ignored
   // this allows format characters (typically commas) in values to be ignored
-
-  float parseFloat(char skipChar);  // as above but the given skipChar is ignored
+  
+  float parseFloat(char ignore) { return parseFloat(SKIP_ALL, ignore); }  
+  float parseFloat(LookaheadMode lookahead, char ignore);  // as above but the given ignore is ignored
 
   struct MultiTarget {
     const char *str;  // string you're searching for

--- a/hardware/arduino/avr/cores/arduino/Stream.h
+++ b/hardware/arduino/avr/cores/arduino/Stream.h
@@ -42,7 +42,7 @@ class Stream : public Print
     unsigned long _startMillis;  // used for timeout measurement
     int timedRead();    // private method to read stream with timeout
     int timedPeek();    // private method to peek stream with timeout
-    int peekNextDigit(); // returns the next numeric digit in the stream or -1 if timeout
+    int peekNextDigit( bool detectDecimal ); // returns the next numeric digit in the stream or -1 if timeout
 
   public:
     virtual int available() = 0;

--- a/hardware/arduino/sam/cores/arduino/Stream.cpp
+++ b/hardware/arduino/sam/cores/arduino/Stream.cpp
@@ -54,14 +54,17 @@ int Stream::timedPeek()
 
 // returns peek of the next digit in the stream or -1 if timeout
 // discards non-numeric characters
-int Stream::peekNextDigit()
+int Stream::peekNextDigit( bool detectDecimal )
 {
   int c;
   while (1) {
     c = timedPeek();
-    if (c < 0) return c;  // timeout
-    if (c == '-') return c;
-    if (c >= '0' && c <= '9') return c;
+
+    if( c < 0 ||
+        c == '-' ||
+        c >= '0' && c <= '9' ||
+        detectDecimal && c == '.') return c;
+
     read();  // discard non-numeric
   }
 }
@@ -124,7 +127,7 @@ long Stream::parseInt(char skipChar)
   long value = 0;
   int c;
 
-  c = peekNextDigit();
+  c = peekNextDigit(false);
   // ignore non numeric leading characters
   if(c < 0)
     return 0; // zero returned if timeout
@@ -162,7 +165,7 @@ float Stream::parseFloat(char skipChar){
   char c;
   float fraction = 1.0;
 
-  c = peekNextDigit();
+  c = peekNextDigit(true);
     // ignore non numeric leading characters
   if(c < 0)
     return 0; // zero returned if timeout

--- a/hardware/arduino/sam/cores/arduino/Stream.cpp
+++ b/hardware/arduino/sam/cores/arduino/Stream.cpp
@@ -26,7 +26,6 @@
 #include "Stream.h"
 
 #define PARSE_TIMEOUT 1000  // default number of milli-seconds to wait
-#define NO_SKIP_CHAR  1  // a magic char not found in a valid ASCII numeric field
 
 // private method to read stream with timeout
 int Stream::timedRead()
@@ -121,17 +120,11 @@ bool Stream::findUntil(char *target, size_t targetLen, char *terminator, size_t 
   }
 }
 
-
 // returns the first valid (long) integer value from the current position.
-// initial characters that are not digits (or the minus sign) are skipped
-// function is terminated by the first character that is not a digit.
-long Stream::parseInt(LookaheadMode lookahead)
-{
-  return parseInt(lookahead, NO_SKIP_CHAR); // terminate on first non-digit character (or timeout)
-}
-
-// as above but 'ignore' is ignored
-// this allows format characters (typically commas) in values to be ignored
+// lookahead determines how parseInt looks ahead in the stream.
+// See LookaheadMode enumeration at the top of the file.
+// Lookahead is terminated by the first character that is not a valid part of an integer.
+// Once parsing commences, 'ignore' will be skipped in the stream.
 long Stream::parseInt(LookaheadMode lookahead, char ignore)
 {
   bool isNegative = false;
@@ -160,16 +153,9 @@ long Stream::parseInt(LookaheadMode lookahead, char ignore)
   return value;
 }
 
-
 // as parseInt but returns a floating point value
-float Stream::parseFloat(LookaheadMode lookahead)
+float Stream::parseFloat(LookaheadMode lookahead, char ignore)
 {
-  return parseFloat(lookahead, NO_SKIP_CHAR);
-}
-
-// as above but the given ignore is ignored
-// this allows format characters (typically commas) in values to be ignored
-float Stream::parseFloat(LookaheadMode lookahead, char ignore){
   bool isNegative = false;
   bool isFraction = false;
   long value = 0;

--- a/hardware/arduino/sam/cores/arduino/Stream.cpp
+++ b/hardware/arduino/sam/cores/arduino/Stream.cpp
@@ -185,7 +185,7 @@ float Stream::parseFloat(char skipChar){
     read();  // consume the character we got with peek
     c = timedPeek();
   }
-  while( (c >= '0' && c <= '9')  || c == '.' || c == skipChar );
+  while( (c >= '0' && c <= '9')  || c == '.' && !isFraction || c == skipChar );
 
   if(isNegative)
     value = -value;

--- a/hardware/arduino/sam/cores/arduino/Stream.cpp
+++ b/hardware/arduino/sam/cores/arduino/Stream.cpp
@@ -54,7 +54,7 @@ int Stream::timedPeek()
 
 // returns peek of the next digit in the stream or -1 if timeout
 // discards non-numeric characters
-int Stream::peekNextDigit( bool detectDecimal )
+int Stream::peekNextDigit(LookaheadMode lookahead, bool detectDecimal )
 {
   int c;
   while (1) {
@@ -65,6 +65,17 @@ int Stream::peekNextDigit( bool detectDecimal )
         c >= '0' && c <= '9' ||
         detectDecimal && c == '.') return c;
 
+    switch( lookahead ){
+        case SKIP_NONE: return -1; // Fail code.
+        case SKIP_WHITESPACE:
+            switch( c ){
+                case ' ':
+                case '\t':
+                case '\r':
+                case '\n': break;
+                default: return -1; // Fail code.
+            }
+    }
     read();  // discard non-numeric
   }
 }
@@ -114,27 +125,27 @@ bool Stream::findUntil(char *target, size_t targetLen, char *terminator, size_t 
 // returns the first valid (long) integer value from the current position.
 // initial characters that are not digits (or the minus sign) are skipped
 // function is terminated by the first character that is not a digit.
-long Stream::parseInt()
+long Stream::parseInt(LookaheadMode lookahead)
 {
-  return parseInt(NO_SKIP_CHAR); // terminate on first non-digit character (or timeout)
+  return parseInt(lookahead, NO_SKIP_CHAR); // terminate on first non-digit character (or timeout)
 }
 
-// as above but a given skipChar is ignored
+// as above but 'ignore' is ignored
 // this allows format characters (typically commas) in values to be ignored
-long Stream::parseInt(char skipChar)
+long Stream::parseInt(LookaheadMode lookahead, char ignore)
 {
   bool isNegative = false;
   long value = 0;
   int c;
 
-  c = peekNextDigit(false);
+  c = peekNextDigit(lookahead, false);
   // ignore non numeric leading characters
   if(c < 0)
     return 0; // zero returned if timeout
 
   do{
-    if(c == skipChar)
-      ; // ignore this charactor
+    if(c == ignore)
+      ; // ignore this character
     else if(c == '-')
       isNegative = true;
     else if(c >= '0' && c <= '9')        // is c a digit?
@@ -142,7 +153,7 @@ long Stream::parseInt(char skipChar)
     read();  // consume the character we got with peek
     c = timedPeek();
   }
-  while( (c >= '0' && c <= '9') || c == skipChar );
+  while( (c >= '0' && c <= '9') || c == ignore );
 
   if(isNegative)
     value = -value;
@@ -151,27 +162,27 @@ long Stream::parseInt(char skipChar)
 
 
 // as parseInt but returns a floating point value
-float Stream::parseFloat()
+float Stream::parseFloat(LookaheadMode lookahead)
 {
-  return parseFloat(NO_SKIP_CHAR);
+  return parseFloat(lookahead, NO_SKIP_CHAR);
 }
 
-// as above but the given skipChar is ignored
+// as above but the given ignore is ignored
 // this allows format characters (typically commas) in values to be ignored
-float Stream::parseFloat(char skipChar){
+float Stream::parseFloat(LookaheadMode lookahead, char ignore){
   bool isNegative = false;
   bool isFraction = false;
   long value = 0;
   char c;
   float fraction = 1.0;
 
-  c = peekNextDigit(true);
+  c = peekNextDigit(lookahead, true);
     // ignore non numeric leading characters
   if(c < 0)
     return 0; // zero returned if timeout
 
   do{
-    if(c == skipChar)
+    if(c == ignore)
       ; // ignore
     else if(c == '-')
       isNegative = true;
@@ -185,7 +196,7 @@ float Stream::parseFloat(char skipChar){
     read();  // consume the character we got with peek
     c = timedPeek();
   }
-  while( (c >= '0' && c <= '9')  || c == '.' && !isFraction || c == skipChar );
+  while( (c >= '0' && c <= '9')  || c == '.' && !isFraction || c == ignore );
 
   if(isNegative)
     value = -value;

--- a/hardware/arduino/sam/cores/arduino/Stream.h
+++ b/hardware/arduino/sam/cores/arduino/Stream.h
@@ -42,7 +42,7 @@ class Stream : public Print
     unsigned long _startMillis;  // used for timeout measurement
     int timedRead();    // private method to read stream with timeout
     int timedPeek();    // private method to peek stream with timeout
-    int peekNextDigit(); // returns the next numeric digit in the stream or -1 if timeout
+    int peekNextDigit( bool detectDecimal ); // returns the next numeric digit in the stream or -1 if timeout
 
   public:
     virtual int available() = 0;

--- a/hardware/arduino/sam/cores/arduino/Stream.h
+++ b/hardware/arduino/sam/cores/arduino/Stream.h
@@ -28,12 +28,21 @@
 // compatability macros for testing
 /*
 #define   getInt()            parseInt()
-#define   getInt(skipChar)    parseInt(skipchar)
+#define   getInt(ignore)    parseInt(ignore)
 #define   getFloat()          parseFloat()
-#define   getFloat(skipChar)  parseFloat(skipChar)
+#define   getFloat(ignore)  parseFloat(ignore)
 #define   getString( pre_string, post_string, buffer, length)
 readBytesBetween( pre_string, terminator, buffer, length)
 */
+
+// This enumeration provides the lookahead options for parseInt(), parseFloat()
+// The rules set out here are used until either the first valid character is found
+// or a time out occurs due to lack of input.
+enum LookaheadMode{
+    SKIP_ALL,       // All invalid characters are ignored.
+    SKIP_NONE,      // Nothing is skipped, and the stream is not touched unless the first waiting character is valid.
+    SKIP_WHITESPACE // Only tabs, spaces, line feeds & carriage returns are skipped.
+};
 
 class Stream : public Print
 {
@@ -42,7 +51,7 @@ class Stream : public Print
     unsigned long _startMillis;  // used for timeout measurement
     int timedRead();    // private method to read stream with timeout
     int timedPeek();    // private method to peek stream with timeout
-    int peekNextDigit( bool detectDecimal ); // returns the next numeric digit in the stream or -1 if timeout
+    int peekNextDigit(LookaheadMode lookahead, bool detectDecimal); // returns the next numeric digit in the stream or -1 if timeout
 
   public:
     virtual int available() = 0;
@@ -71,11 +80,11 @@ class Stream : public Print
   bool findUntil(uint8_t *target, size_t targetLen, char *terminate, size_t termLen) {return findUntil((char *)target, targetLen, terminate, termLen); }
 
 
-  long parseInt(); // returns the first valid (long) integer value from the current position.
+  long parseInt(LookaheadMode lookahead = SKIP_ALL); // returns the first valid (long) integer value from the current position.
   // initial characters that are not digits (or the minus sign) are skipped
   // integer is terminated by the first character that is not a digit.
 
-  float parseFloat();               // float version of parseInt
+  float parseFloat(LookaheadMode lookahead = SKIP_ALL);               // float version of parseInt
 
   size_t readBytes( char *buffer, size_t length); // read chars from stream into buffer
   size_t readBytes( uint8_t *buffer, size_t length) { return readBytes((char *)buffer, length); }
@@ -92,11 +101,13 @@ class Stream : public Print
   String readStringUntil(char terminator);
 
   protected:
-  long parseInt(char skipChar); // as above but the given skipChar is ignored
-  // as above but the given skipChar is ignored
+  long parseInt(char ignore) { return parseInt(SKIP_ALL, ignore); }
+  long parseInt(LookaheadMode lookahead, char ignore); // as above but the given ignore is ignored
+  // as above but 'ignore' is ignored
   // this allows format characters (typically commas) in values to be ignored
-
-  float parseFloat(char skipChar);  // as above but the given skipChar is ignored
+  
+  float parseFloat(char ignore) { return parseFloat(SKIP_ALL, ignore); }  
+  float parseFloat(LookaheadMode lookahead, char ignore);  // as above but the given ignore is ignored
 
   struct MultiTarget {
     const char *str;  // string you're searching for

--- a/hardware/arduino/sam/cores/arduino/Stream.h
+++ b/hardware/arduino/sam/cores/arduino/Stream.h
@@ -73,6 +73,8 @@ class Stream : public Print
   bool find(uint8_t *target, size_t length) { return find ((char *)target, length); }
   // returns true if target string is found, false if timed out
 
+  bool find(char target) { return find (&target, 1); }
+  
   bool findUntil(char *target, char *terminator);   // as find but search ends if the terminator string is found
   bool findUntil(uint8_t *target, char *terminator) { return findUntil((char *)target, terminator); }
 

--- a/hardware/arduino/sam/cores/arduino/Stream.h
+++ b/hardware/arduino/sam/cores/arduino/Stream.h
@@ -44,6 +44,8 @@ enum LookaheadMode{
     SKIP_WHITESPACE // Only tabs, spaces, line feeds & carriage returns are skipped.
 };
 
+#define NO_IGNORE_CHAR  '\x01' // a char not found in a valid ASCII numeric field
+
 class Stream : public Print
 {
   protected:
@@ -74,19 +76,22 @@ class Stream : public Print
   // returns true if target string is found, false if timed out
 
   bool find(char target) { return find (&target, 1); }
-  
+
   bool findUntil(char *target, char *terminator);   // as find but search ends if the terminator string is found
   bool findUntil(uint8_t *target, char *terminator) { return findUntil((char *)target, terminator); }
 
   bool findUntil(char *target, size_t targetLen, char *terminate, size_t termLen);   // as above but search ends if the terminate string is found
   bool findUntil(uint8_t *target, size_t targetLen, char *terminate, size_t termLen) {return findUntil((char *)target, targetLen, terminate, termLen); }
 
+  long parseInt(LookaheadMode lookahead = SKIP_ALL, char ignore = NO_IGNORE_CHAR);
+  // returns the first valid (long) integer value from the current position.
+  // lookahead determines how parseInt looks ahead in the stream.
+  // See LookaheadMode enumeration at the top of the file.
+  // Lookahead is terminated by the first character that is not a valid part of an integer.
+  // Once parsing commences, 'ignore' will be skipped in the stream.
 
-  long parseInt(LookaheadMode lookahead = SKIP_ALL); // returns the first valid (long) integer value from the current position.
-  // initial characters that are not digits (or the minus sign) are skipped
-  // integer is terminated by the first character that is not a digit.
-
-  float parseFloat(LookaheadMode lookahead = SKIP_ALL);               // float version of parseInt
+  float parseFloat(LookaheadMode lookahead = SKIP_ALL, char ignore = NO_IGNORE_CHAR);
+  // float version of parseInt
 
   size_t readBytes( char *buffer, size_t length); // read chars from stream into buffer
   size_t readBytes( uint8_t *buffer, size_t length) { return readBytes((char *)buffer, length); }
@@ -104,12 +109,10 @@ class Stream : public Print
 
   protected:
   long parseInt(char ignore) { return parseInt(SKIP_ALL, ignore); }
-  long parseInt(LookaheadMode lookahead, char ignore); // as above but the given ignore is ignored
-  // as above but 'ignore' is ignored
-  // this allows format characters (typically commas) in values to be ignored
-  
-  float parseFloat(char ignore) { return parseFloat(SKIP_ALL, ignore); }  
-  float parseFloat(LookaheadMode lookahead, char ignore);  // as above but the given ignore is ignored
+  float parseFloat(char ignore) { return parseFloat(SKIP_ALL, ignore); }
+  // These overload exists for compatibility with any class that has derived
+  // Stream and used parseFloat/Int with a custom ignore character. To keep
+  // the public API simple, these overload remains protected.
 
   struct MultiTarget {
     const char *str;  // string you're searching for
@@ -122,4 +125,5 @@ class Stream : public Print
   int findMulti(struct MultiTarget *targets, int tCount);
 };
 
+#undef NO_IGNORE_CHAR
 #endif


### PR DESCRIPTION
This set of commits improves the parsing capabilities of `Stream::parseFloat()` and `Stream::parseInt()`.

### parseFloat

The function will now accept decimals starting with an `.` character not just `0.`

An error has been fixed where where **_1.23.45_** is parsed as **_1.2345_** rather than **_1.23_** and subsequent calls reading **_0.45_﻿** _(after the fix mentioned above)_.

### both parseInt/Float
The lookahead feature can be controlled using either `SKIP_NONE`, `SKIP_ALL`, or `SKIP_WHITESPACE`

The hidden member `skipChar` has been exposed. This allows parsing of formatted decimals, not just shorthand like _**.12**_ but complex formatting like: _**-1,234.567**_  _(parseFloat)_, **_1,234_** _(parseInt)_. Rather than removing the hidden unused features, they could be quite beneficial.

As the interface changes are implemented using optional parameters, the code is backwards compatible without change.

### SAM

The `Stream::find(char);` method has been added to the SAM core making it equivalent to the AVR implementation.

This resolves:
#1962 
#2007 
#630