### PR TITLE
Expose CDC settings to sketch

### DIFF
--- a/hardware/arduino/avr/cores/arduino/CDC.cpp
+++ b/hardware/arduino/avr/cores/arduino/CDC.cpp
@@ -163,6 +163,11 @@ int Serial_::read(void)
 	return USB_Recv(CDC_RX);
 }
 
+int Serial_::availableForWrite(void)
+{
+	return USB_SendSpace(CDC_TX);
+}
+
 void Serial_::flush(void)
 {
 	USB_Flush(CDC_TX);

--- a/hardware/arduino/avr/cores/arduino/CDC.cpp
+++ b/hardware/arduino/avr/cores/arduino/CDC.cpp
@@ -18,6 +18,7 @@
 
 #include "USBAPI.h"
 #include <avr/wdt.h>
+#include <util/atomic.h>
 
 #if defined(USBCON)
 
@@ -203,6 +204,32 @@ Serial_::operator bool() {
 		result = true;
 	delay(10);
 	return result;
+}
+
+unsigned long Serial_::baud() {
+	ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+		return _usbLineInfo.dwDTERate;
+	}
+}
+
+uint8_t Serial_::stopbits() {
+	return _usbLineInfo.bCharFormat;
+}
+
+uint8_t Serial_::paritytype() {
+	return _usbLineInfo.bParityType;
+}
+
+uint8_t Serial_::numbits() {
+	return _usbLineInfo.bDataBits;
+}
+
+bool Serial_::dtr() {
+	return _usbLineInfo.lineState & 0x1;
+}
+
+bool Serial_::rts() {
+	return _usbLineInfo.lineState & 0x2;
 }
 
 Serial_ Serial;

--- a/hardware/arduino/avr/cores/arduino/HardwareSerial.cpp
+++ b/hardware/arduino/avr/cores/arduino/HardwareSerial.cpp
@@ -138,8 +138,7 @@ void HardwareSerial::begin(unsigned long baud, byte config)
 void HardwareSerial::end()
 {
   // wait for transmission of outgoing data
-  while (_tx_buffer_head != _tx_buffer_tail)
-    ;
+  flush();
 
   cbi(*_ucsrb, RXEN0);
   cbi(*_ucsrb, TXEN0);

--- a/hardware/arduino/avr/cores/arduino/USBAPI.h
+++ b/hardware/arduino/avr/cores/arduino/USBAPI.h
@@ -101,6 +101,29 @@ public:
 	volatile uint8_t _rx_buffer_head;
 	volatile uint8_t _rx_buffer_tail;
 	unsigned char _rx_buffer[SERIAL_BUFFER_SIZE];
+
+	// These return the settings specified by the USB host for the
+	// serial port. These aren't really used, but are offered here
+	// in case a sketch wants to act on these settings.
+	uint32_t baud();
+	uint8_t stopbits();
+	uint8_t paritytype();
+	uint8_t numbits();
+	bool dtr();
+	bool rts();
+	enum {
+		ONE_STOP_BIT = 0,
+		ONE_AND_HALF_STOP_BIT = 1,
+		TWO_STOP_BITS = 2,
+	};
+	enum {
+		NO_PARITY = 0,
+		ODD_PARITY = 1,
+		EVEN_PARITY = 2,
+		MARK_PARITY = 3,
+		SPACE_PARITY = 4,
+	};
+
 };
 extern Serial_ Serial;
 

--- a/hardware/arduino/avr/cores/arduino/USBAPI.h
+++ b/hardware/arduino/avr/cores/arduino/USBAPI.h
@@ -92,6 +92,7 @@ public:
 	virtual int available(void);
 	virtual int peek(void);
 	virtual int read(void);
+	int availableForWrite(void);
 	virtual void flush(void);
 	virtual size_t write(uint8_t);
 	virtual size_t write(const uint8_t*, size_t);
@@ -188,6 +189,7 @@ int USB_SendControl(uint8_t flags, const void* d, int len);
 int USB_RecvControl(void* d, int len);
 
 uint8_t	USB_Available(uint8_t ep);
+uint8_t USB_SendSpace(uint8_t ep);
 int USB_Send(uint8_t ep, const void* data, int len);	// blocking
 int USB_Recv(uint8_t ep, void* data, int len);		// non-blocking
 int USB_Recv(uint8_t ep);							// non-blocking

--- a/hardware/arduino/avr/cores/arduino/USBAPI.h
+++ b/hardware/arduino/avr/cores/arduino/USBAPI.h
@@ -102,6 +102,23 @@ public:
 	volatile uint8_t _rx_buffer_tail;
 	unsigned char _rx_buffer[SERIAL_BUFFER_SIZE];
 
+	// This method allows processing "SEND_BREAK" requests sent by
+	// the USB host. Those requests indicate that the host wants to
+	// send a BREAK signal and are accompanied by a single uint16_t
+	// value, specifying the duration of the break. The value 0
+	// means to end any current break, while the value 0xffff means
+	// to start an indefinite break.
+	// readBreak() will return the value of the most recent break
+	// request, but will return it at most once, returning -1 when
+	// readBreak() is called again (until another break request is
+	// received, which is again returned once).
+	// This also mean that if two break requests are received
+	// without readBreak() being called in between, the value of the
+	// first request is lost.
+	// Note that the value returned is a long, so it can return
+	// 0-0xffff as well as -1.
+	int32_t readBreak();
+
 	// These return the settings specified by the USB host for the
 	// serial port. These aren't really used, but are offered here
 	// in case a sketch wants to act on these settings.

--- a/hardware/arduino/avr/cores/arduino/USBCore.h
+++ b/hardware/arduino/avr/cores/arduino/USBCore.h
@@ -57,6 +57,7 @@
 #define CDC_SET_LINE_CODING			0x20
 #define CDC_GET_LINE_CODING			0x21
 #define CDC_SET_CONTROL_LINE_STATE	0x22
+#define CDC_SEND_BREAK				0x23
 
 #define MSC_RESET					0xFF
 #define MSC_GET_MAX_LUN				0xFE

--- a/hardware/arduino/sam/cores/arduino/USB/CDC.cpp
+++ b/hardware/arduino/sam/cores/arduino/USB/CDC.cpp
@@ -299,6 +299,30 @@ Serial_::operator bool()
 	return result;
 }
 
+unsigned long Serial_::baud() {
+	return _usbLineInfo.dwDTERate;
+}
+
+uint8_t Serial_::stopbits() {
+	return _usbLineInfo.bCharFormat;
+}
+
+uint8_t Serial_::paritytype() {
+	return _usbLineInfo.bParityType;
+}
+
+uint8_t Serial_::numbits() {
+	return _usbLineInfo.bDataBits;
+}
+
+bool Serial_::dtr() {
+	return _usbLineInfo.lineState & 0x1;
+}
+
+bool Serial_::rts() {
+	return _usbLineInfo.lineState & 0x2;
+}
+
 Serial_ SerialUSB;
 
 #endif

--- a/hardware/arduino/sam/cores/arduino/USB/USBAPI.h
+++ b/hardware/arduino/sam/cores/arduino/USB/USBAPI.h
@@ -61,6 +61,28 @@ public:
 	virtual size_t write(const uint8_t *buffer, size_t size);
 	using Print::write; // pull in write(str) from Print
 	operator bool();
+
+	// These return the settings specified by the USB host for the
+	// serial port. These aren't really used, but are offered here
+	// in case a sketch wants to act on these settings.
+	uint32_t baud();
+	uint8_t stopbits();
+	uint8_t paritytype();
+	uint8_t numbits();
+	bool dtr();
+	bool rts();
+	enum {
+		ONE_STOP_BIT = 0,
+		ONE_AND_HALF_STOP_BIT = 1,
+		TWO_STOP_BITS = 2,
+	};
+	enum {
+		NO_PARITY = 0,
+		ODD_PARITY = 1,
+		EVEN_PARITY = 2,
+		MARK_PARITY = 3,
+		SPACE_PARITY = 4,
+	};
 };
 extern Serial_ SerialUSB;
 


### PR DESCRIPTION
Having these settings available to the sketch, allows turning the Leonardo into a proper USB->serial converter (without having to hardcode the baudrate), to allow e.g. a computer to talk to an XBee module.