### PR TITLE
Set DTR and RTS in serial monitor

### DIFF
--- a/app/src/processing/app/SerialMonitor.java
+++ b/app/src/processing/app/SerialMonitor.java
@@ -96,6 +96,19 @@ public class SerialMonitor extends AbstractMonitor {
         addToUpdateBuffer(buff, n);
       }
     };
+	
+	int dtrState = PreferencesData.getInteger("serial.monitorDtr", -1);
+	if (dtrState == 0)
+		serial.setDTR(false);
+	if (dtrState == 1)
+		serial.setDTR(true);
+	
+	int rtsState = PreferencesData.getInteger("serial.monitorRts", -1);
+	if (rtsState == 0)
+		serial.setRTS(false);
+	if (rtsState == 1)
+		serial.setRTS(true);
+		
   }
 
   public void close() throws Exception {


### PR DESCRIPTION
Sets DTS and RTS pins in serial monitor.

Useful in projects where these lines control reset and chip-select pins.

Set serial.monitorDtr and serial.monitorRts in preferences.txt to configure the pins
