### PR TITLE
Added 74880 baud rate to the serial monitor.

### DIFF
--- a/app/src/processing/app/AbstractMonitor.java
+++ b/app/src/processing/app/AbstractMonitor.java
@@ -140,7 +140,7 @@ public abstract class AbstractMonitor extends JFrame implements ActionListener {
     }
     lineEndings.setMaximumSize(lineEndings.getMinimumSize());
 
-    String[] serialRateStrings = {"300", "1200", "2400", "4800", "9600", "19200", "38400", "57600", "115200", "230400", "250000"};
+    String[] serialRateStrings = {"300", "1200", "2400", "4800", "9600", "19200", "38400", "57600", "74880", "115200", "230400", "250000"};
 
     serialRates = new JComboBox();
     for (String rate : serialRateStrings) {


### PR DESCRIPTION
Now that the latest IDE incorporates a board/core manager, the
ESP8266 community is now using this software. The baud rate of 74880
is important for debugging as it is what the bootloader uses.﻿