### PR TITLE
Windows: new Arduino15 location and automatic migration

### DIFF
--- a/arduino-core/src/processing/app/BaseNoGui.java
+++ b/arduino-core/src/processing/app/BaseNoGui.java
@@ -962,7 +962,7 @@ public class BaseNoGui {
     }
   }
 
-  static public void initParameters(String args[]) {
+  static public void initParameters(String args[]) throws IOException {
     String preferencesFile = null;
 
     // Do a first pass over the commandline arguments, the rest of them

--- a/arduino-core/src/processing/app/Platform.java
+++ b/arduino-core/src/processing/app/Platform.java
@@ -245,4 +245,8 @@ public class Platform {
     Process process = Runtime.getRuntime().exec(new String[]{"chmod", Integer.toOctalString(mode), file.getAbsolutePath()}, null, null);
     process.waitFor();
   }
+
+  public void fixSettingsLocation() throws IOException {
+    //noop
+  }
 }

--- a/arduino-core/src/processing/app/PreferencesData.java
+++ b/arduino-core/src/processing/app/PreferencesData.java
@@ -31,7 +31,10 @@ public class PreferencesData {
   static boolean doSave = true;
 
 
-  static public void init(File file) {
+  static public void init(File file) throws IOException {
+    if (file == null) {
+      BaseNoGui.getPlatform().fixSettingsLocation();
+    }
     if (file != null) {
       preferencesFile = file;
     } else {

--- a/arduino-core/src/processing/app/windows/Platform.java
+++ b/arduino-core/src/processing/app/windows/Platform.java
@@ -35,6 +35,9 @@ import processing.app.legacy.PConstants;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -54,7 +57,7 @@ public class Platform extends processing.app.Platform {
   }
 
   private void recoverSettingsFolderPath() throws IOException {
-    String path = Advapi32Util.registryGetStringValue(WinReg.HKEY_CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders", "AppData");
+    String path = Advapi32Util.registryGetStringValue(WinReg.HKEY_CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders", "Local AppData");
     this.settingsFolder = new File(path, "Arduino15");
   }
 
@@ -219,5 +222,24 @@ public class Platform extends processing.app.Platform {
   }
 
   public void chmod(File file, int mode) throws IOException, InterruptedException {
+  }
+
+  @Override
+  public void fixSettingsLocation() throws IOException {
+    String path = Advapi32Util.registryGetStringValue(WinReg.HKEY_CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders", "AppData");
+    Path previousSettingsFolder = Paths.get(path, "Arduino15");
+    if (!Files.exists(previousSettingsFolder)) {
+      return;
+    }
+
+    if (!Files.exists(previousSettingsFolder.resolve(Paths.get("preferences.txt")))) {
+      return;
+    }
+
+    if (settingsFolder.exists()) {
+      return;
+    }
+
+    Files.move(previousSettingsFolder, settingsFolder.toPath());
   }
 }


### PR DESCRIPTION
This PR aims at solving the long debate that took place on the developers mailing list about the location of cores/tools installed through Boards Manager. On windows it **was** `Roaming\Arduino15`, which breaks Microsoft rules and causes troubles to who actually like own profile to roam between different computers

New location is `%LOCALAPPDATA%\Arduino15`

When no custom preferences file location is specified (via CLI) and if the IDE finds something in `%APPDATA%\Arduino15` and no `%LOCALAPPDATA%\Arduino15` is present, IDE prefs files will be moved. Nothing will happen otherwise.

Fixes #2902

/cc @rogerclarkmelbourne