### PR TITLE
Fix missing trailing parameters when opening URL's﻿ (WIN)

### DIFF
--- a/arduino-core/src/processing/app/windows/Platform.java
+++ b/arduino-core/src/processing/app/windows/Platform.java
@@ -134,7 +134,7 @@ public class Platform extends processing.app.Platform {
       // open dos prompt, give it 'start' command, which will
       // open the url properly. start by itself won't work since
       // it appears to need cmd
-      Runtime.getRuntime().exec("cmd /c start " + url);
+      Runtime.getRuntime().exec("cmd /c start \"\" \"" + url + "\"");
     } else {
       // just launching the .html file via the shell works
       // but make sure to chmod +x the .html files first


### PR DESCRIPTION
This is a PR for the issue #3392. On Windows platforms query string parameters separated using `&` are removed due to OS behavior. This PR wraps the URL in quotes allowing the URL to be passed unmodified to the browser.

Closes #3392