### PR TITLE
Windows build: look for JDK release file in parent dir.

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -905,7 +905,9 @@
       <fileset dir="windows/work" includes="**/*.html, **/*.dll, **/*.exe" />
     </chmod>
 
-    <loadproperties srcfile="${WINDOWS_BUNDLED_JVM}/release" prefix="windows"/>
+    <!-- For JVM within JDK, release file is in parent directory -->
+    <property file="${WINDOWS_BUNDLED_JVM}/release" prefix="windows"/>
+    <property file="${WINDOWS_BUNDLED_JVM}/../release" prefix="windows"/>
 
     <fail message="It looks like ${WINDOWS_BUNDLED_JVM} does not contain a Windows JVM">
       <condition>


### PR DESCRIPTION
Fixes [#3413](https://github.com/arduino/Arduino/issues/3413) (Windows build fails, because it looks for JDK release file in the wrong place)