### PR TITLE
Handle duplicates of legacy libs correctly. (#3412)

### DIFF
--- a/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibrary.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibrary.java
@@ -142,7 +142,10 @@ public abstract class ContributedLibrary extends DownloadableContribution {
     String thisVersion = getParsedVersion();
     String otherVersion = ((ContributedLibrary) obj).getParsedVersion();
 
-    boolean versionEquals = thisVersion != null && otherVersion != null && thisVersion.equals(otherVersion);
+    // Important: for legacy libs, versions are null.  Two legacy libs must
+    // always pass this test.
+    boolean versionEquals = thisVersion == otherVersion ||
+      (thisVersion != null && otherVersion != null && thisVersion.equals(otherVersion));
 
     String thisName = getName();
     String otherName = ((ContributedLibrary) obj).getName();


### PR DESCRIPTION
Fixes issue [#3412](https://github.com/arduino/Arduino/issues/3412) (Legacy libraries linked multiple times, causing duplicate symbol errors).