### PR TITLE
Serial monitor: added check when setting serial port parameters

### DIFF
--- a/arduino-core/src/processing/app/Serial.java
+++ b/arduino-core/src/processing/app/Serial.java
@@ -112,7 +112,11 @@ public class Serial implements SerialPortEventListener {
     try {
       port = new SerialPort(iname);
       port.openPort();
-      port.setParams(irate, idatabits, stopbits, parity, true, true);
+      boolean res = port.setParams(irate, idatabits, stopbits, parity, true, true);
+      if (!res) {
+        System.err.println(format(_("Error while setting serial port parameters: {0} {1} {2} {3}"),
+                                  irate, iparity, idatabits, istopbits));
+      }
       port.addEventListener(this);
     } catch (SerialPortException e) {
       if (e.getPortName().startsWith("/dev") && SerialPortException.TYPE_PERMISSION_DENIED.equals(e.getExceptionType())) {


### PR DESCRIPTION
This allows to detect for invalid baud rate settings in particular on Linux where the kernel do not allows non-standard baud rates on some devices.

See #3389 #3351