### PR TITLE
Fix optiboot build for Arduino environment and AVR-GCC 4.8+.

### DIFF
--- a/hardware/arduino/avr/bootloaders/optiboot/Makefile
+++ b/hardware/arduino/avr/bootloaders/optiboot/Makefile
@@ -50,7 +50,7 @@ ifeq ($(ENV), arduino)
 # For Arduino, we assume that we're connected to the optiboot directory
 # included with the arduino distribution, which means that the full set
 # of avr-tools are "right up there" in standard places.
-TOOLROOT = ../../../tools
+TOOLROOT = ../../../../tools
 GCCROOT = $(TOOLROOT)/avr/bin/
 AVRDUDE_CONF = -C$(TOOLROOT)/avr/etc/avrdude.conf
 
@@ -108,7 +108,7 @@ STK500-1 = $(STK500) -e -d$(MCU_TARGET) -pf -vf -if$(PROGRAM)_$(TARGET).hex \
 STK500-2 = $(STK500) -d$(MCU_TARGET) -ms -q -lCF -LCF -cUSB -I200kHz -s -wt
 
 OBJ        = $(PROGRAM).o
-OPTIMIZE = -Os -fno-inline-small-functions -fno-split-wide-types -mshort-calls
+OPTIMIZE = -Os -fno-inline-small-functions -fno-split-wide-types -mrelax
 
 DEFS       = 
 LIBS       =

--- a/hardware/arduino/avr/bootloaders/optiboot/Makefile
+++ b/hardware/arduino/avr/bootloaders/optiboot/Makefile
@@ -376,7 +376,7 @@ pro8_isp: isp
 
 atmega328_pro8: TARGET = atmega328_pro_8MHz
 atmega328_pro8: MCU_TARGET = atmega328p
-atmega328_pro8: CFLAGS += '-DLED_START_FLASHES=3' '-DBAUD_RATE=115200'
+atmega328_pro8: CFLAGS += '-DLED_START_FLASHES=0' '-DBAUD_RATE=115200'
 atmega328_pro8: AVR_FREQ = 8000000L
 atmega328_pro8: LDSECTIONS = -Wl,--section-start=.text=0x7e00 -Wl,--section-start=.version=0x7ffe
 atmega328_pro8: $(PROGRAM)_atmega328_pro_8MHz.hex


### PR DESCRIPTION
Fixes the optiboot build to work with the Arduino bundled version of avr-gcc and paths.