### PR TITLE
Hierarchical dependencies

### DIFF
--- a/app/src/processing/app/Sketch.java
+++ b/app/src/processing/app/Sketch.java
@@ -931,14 +931,14 @@ public class Sketch {
 
 
   public void importLibrary(UserLibrary lib) throws IOException {
-    importLibrary(lib.getSrcFolder());
+    importLibrary(lib.getSrcFolder(), lib.getDepSpec());
   }
 
   /**
    * Add import statements to the current tab for all of packages inside
    * the specified jar file.
    */
-  private void importLibrary(File jarPath) throws IOException {
+  private void importLibrary(File jarPath, String depSpec) throws IOException {
     // make sure the user didn't hide the sketch folder
     ensureExistence();
 
@@ -960,7 +960,11 @@ public class Sketch {
     for (String aList : list) {
       buffer.append("#include <");
       buffer.append(aList);
-      buffer.append(">\n");
+      buffer.append(">");
+      if (depSpec != null) {
+	buffer.append(" //!Lib '" + depSpec + "'");
+      }
+      buffer.append("\n");
     }
     buffer.append('\n');
     buffer.append(editor.getText());

--- a/app/src/processing/app/Sketch.java
+++ b/app/src/processing/app/Sketch.java
@@ -962,7 +962,7 @@ public class Sketch {
       buffer.append(aList);
       buffer.append(">");
       if (depSpec != null) {
-	buffer.append(" //!Lib '" + depSpec + "'");
+	buffer.append(" //!Lib \"" + depSpec + "\"");
       }
       buffer.append("\n");
     }

--- a/app/src/processing/app/syntax/SketchTextArea.java
+++ b/app/src/processing/app/syntax/SketchTextArea.java
@@ -40,6 +40,7 @@ import org.fife.ui.rtextarea.RTextAreaUI;
 import org.fife.ui.rtextarea.RUndoManager;
 import processing.app.*;
 import processing.app.packages.UserLibrary;
+import processing.app.packages.LibrarySelection;
 
 import javax.swing.*;
 import javax.swing.event.EventListenerList;
@@ -456,12 +457,13 @@ public class SketchTextArea extends RSyntaxTextArea {
     }
 
     private String getImportInfo(String line) {
-      UserLibrary lib = BaseNoGui.findFirstLibraryByCode(line);
+      LibrarySelection libSel = BaseNoGui.findLibraryByCode(line);
       String info = null;
-      if (lib != null) {
+      if (libSel != null) {
+        UserLibrary lib = libSel.get();
         info = getLibDescription(lib);
-        for (UserLibrary recLib : lib.getRequiredLibsRec()) {
-          info += "\n* " + getLibDescription(recLib);
+        for (LibrarySelection recLibSel : lib.getRequiredLibsRec()) {
+          info += "\n* " + getLibDescription(recLibSel.get());
         }
       }
       return info;

--- a/app/src/processing/app/syntax/SketchTextArea.java
+++ b/app/src/processing/app/syntax/SketchTextArea.java
@@ -461,7 +461,8 @@ public class SketchTextArea extends RSyntaxTextArea {
       java.util.List<String[]> incs = PdePreprocessor.findIncludes(line);
       LibrarySelection libSel = null;
       if (!incs.isEmpty()) {
-        libSel = BaseNoGui.findLibraryByImport(incs.get(0));
+        // Note: does not have a valid preferSet, so answer may be inaccurate
+        libSel = BaseNoGui.findLibraryByImport(incs.get(0), new HashSet<UserLibrary>());
       }
       String info = null;
       if (libSel != null) {

--- a/app/src/processing/app/syntax/SketchTextArea.java
+++ b/app/src/processing/app/syntax/SketchTextArea.java
@@ -462,7 +462,7 @@ public class SketchTextArea extends RSyntaxTextArea {
       LibrarySelection libSel = null;
       if (!incs.isEmpty()) {
         // Note: does not have a valid preferSet, so answer may be inaccurate
-        libSel = BaseNoGui.findLibraryByImport(incs.get(0), new HashSet<UserLibrary>());
+        libSel = BaseNoGui.findLibraryByImport(incs.get(0), new HashSet<>());
       }
       String info = null;
       if (libSel != null) {

--- a/app/src/processing/app/syntax/SketchTextArea.java
+++ b/app/src/processing/app/syntax/SketchTextArea.java
@@ -456,7 +456,7 @@ public class SketchTextArea extends RSyntaxTextArea {
     }
 
     private String getImportInfo(String line) {
-      UserLibrary lib = BaseNoGui.firstLibraryByCode(line);
+      UserLibrary lib = BaseNoGui.findFirstLibraryByCode(line);
       String info = null;
       if (lib != null) {
         info = getLibDescription(lib);

--- a/app/src/processing/app/syntax/SketchTextArea.java
+++ b/app/src/processing/app/syntax/SketchTextArea.java
@@ -39,6 +39,7 @@ import org.fife.ui.rtextarea.RTextArea;
 import org.fife.ui.rtextarea.RTextAreaUI;
 import org.fife.ui.rtextarea.RUndoManager;
 import processing.app.*;
+import processing.app.packages.UserLibrary;
 
 import javax.swing.*;
 import javax.swing.event.EventListenerList;
@@ -396,6 +397,7 @@ public class SketchTextArea extends RSyntaxTextArea {
         t = new TokenImpl(t);
       }
       Cursor c2;
+      String tipText = null;
       if (t != null && t.isHyperlink()) {
         if (hoveredOverLinkOffset == -1 ||
           hoveredOverLinkOffset != t.getOffset()) {
@@ -432,12 +434,34 @@ public class SketchTextArea extends RSyntaxTextArea {
         c2 = Cursor.getPredefinedCursor(Cursor.TEXT_CURSOR);
         hoveredOverLinkOffset = -1;
         //  linkGeneratorResult = null;
+
+        int pos = viewToModel(e.getPoint());
+        if (pos > -1) {
+          int lineNo = -1;
+          try {
+            lineNo = getLineOfOffset(pos);
+          } catch (BadLocationException ex) {}
+          String line = getTextLine(lineNo);
+          if (line != null) {
+            UserLibrary lib = BaseNoGui.firstLibraryByCode(line);
+            if (lib != null) {
+              String ver = lib.getVersion();
+              if (ver != null) {
+                ver = " " + ver;
+              } else {
+                ver = "";
+              }
+              tipText = lib.getName() + ver + ": " + lib.getSrcFolder().toString();
+            }
+          }
+        }
       }
       if (getCursor() != c2) {
         setCursor(c2);
         // TODO: Repaint just the affected line(s).
         repaint(); // Link either left or went into.
       }
+      setToolTipText(tipText);
     }
 
     private void stopScanningForLinks() {

--- a/app/src/processing/app/syntax/SketchTextArea.java
+++ b/app/src/processing/app/syntax/SketchTextArea.java
@@ -40,6 +40,7 @@ import org.fife.ui.rtextarea.RTextAreaUI;
 import org.fife.ui.rtextarea.RUndoManager;
 import processing.app.*;
 import processing.app.packages.UserLibrary;
+import cc.arduino.contributions.libraries.ContributedLibrary;
 
 import javax.swing.*;
 import javax.swing.event.EventListenerList;
@@ -443,16 +444,7 @@ public class SketchTextArea extends RSyntaxTextArea {
           } catch (BadLocationException ex) {}
           String line = getTextLine(lineNo);
           if (line != null) {
-            UserLibrary lib = BaseNoGui.firstLibraryByCode(line);
-            if (lib != null) {
-              String ver = lib.getVersion();
-              if (ver != null) {
-                ver = " " + ver;
-              } else {
-                ver = "";
-              }
-              tipText = lib.getName() + ver + ": " + lib.getSrcFolder().toString();
-            }
+            tipText = getImportInfo(line);
           }
         }
       }
@@ -462,6 +454,32 @@ public class SketchTextArea extends RSyntaxTextArea {
         repaint(); // Link either left or went into.
       }
       setToolTipText(tipText);
+    }
+
+    private String getImportInfo(String line) {
+      UserLibrary lib = BaseNoGui.firstLibraryByCode(line);
+      String info = null;
+      if (lib != null) {
+        info = getLibDescription(lib);
+        for (ContributedLibrary recLib : lib.getRequiredLibsRec()) {
+          info += "\n* " + getLibDescription(recLib);
+        }
+      }
+      return info;
+    }
+
+    private String getLibDescription(ContributedLibrary lib) {
+      String ver = lib.getVersion();
+      if (ver != null) {
+        ver = " " + ver;
+      } else {
+        ver = "";
+      }
+      String folder = "";
+      if (lib instanceof UserLibrary) {
+        folder = ": " + ((UserLibrary) lib).getSrcFolder().toString();
+      }
+      return lib.getName() + " (" + lib.getGlobalName() + ")" + ver + folder;
     }
 
     private void stopScanningForLinks() {

--- a/app/src/processing/app/syntax/SketchTextArea.java
+++ b/app/src/processing/app/syntax/SketchTextArea.java
@@ -40,7 +40,6 @@ import org.fife.ui.rtextarea.RTextAreaUI;
 import org.fife.ui.rtextarea.RUndoManager;
 import processing.app.*;
 import processing.app.packages.UserLibrary;
-import cc.arduino.contributions.libraries.ContributedLibrary;
 
 import javax.swing.*;
 import javax.swing.event.EventListenerList;
@@ -461,14 +460,14 @@ public class SketchTextArea extends RSyntaxTextArea {
       String info = null;
       if (lib != null) {
         info = getLibDescription(lib);
-        for (ContributedLibrary recLib : lib.getRequiredLibsRec()) {
+        for (UserLibrary recLib : lib.getRequiredLibsRec()) {
           info += "\n* " + getLibDescription(recLib);
         }
       }
       return info;
     }
 
-    private String getLibDescription(ContributedLibrary lib) {
+    private String getLibDescription(UserLibrary lib) {
       String ver = lib.getVersion();
       if (ver != null) {
         ver = " " + ver;
@@ -477,7 +476,7 @@ public class SketchTextArea extends RSyntaxTextArea {
       }
       String folder = "";
       if (lib instanceof UserLibrary) {
-        folder = ": " + ((UserLibrary) lib).getSrcFolder().toString();
+        folder = ": " + lib.getSrcFolder().toString();
       }
       return lib.getName() + " (" + lib.getGlobalName() + ")" + ver + folder;
     }

--- a/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibrary.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibrary.java
@@ -34,6 +34,7 @@ import processing.app.I18n;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.SortedSet;
 
 import static processing.app.I18n._;
 
@@ -68,6 +69,10 @@ public abstract class ContributedLibrary extends DownloadableContribution {
   public abstract List<ContributedLibrary> getRequiredLibs();
 
   public abstract List<ContributedLibrary> getRequiredLibsRec();
+
+  public abstract List<ContributedLibrary> getRequiredLibsRec(SortedSet<String> visited);
+
+  public abstract boolean changedSinceLastUpdateRec(int idx, SortedSet<String> visited);
 
   public static final Comparator<ContributedLibrary> CASE_INSENSITIVE_ORDER = (o1, o2) -> o1.getName().compareToIgnoreCase(o2.getName());
 

--- a/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibrary.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibrary.java
@@ -65,6 +65,10 @@ public abstract class ContributedLibrary extends DownloadableContribution {
 
   public abstract List<ContributedLibraryReference> getRequires();
 
+  public abstract List<ContributedLibrary> getRequiredLibs();
+
+  public abstract List<ContributedLibrary> getRequiredLibsRec();
+
   public static final Comparator<ContributedLibrary> CASE_INSENSITIVE_ORDER = (o1, o2) -> o1.getName().compareToIgnoreCase(o2.getName());
 
   /**

--- a/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibrary.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibrary.java
@@ -39,6 +39,8 @@ import static processing.app.I18n._;
 
 public abstract class ContributedLibrary extends DownloadableContribution {
 
+  public abstract String getGlobalName();
+
   public abstract String getName();
 
   public abstract String getMaintainer();
@@ -142,10 +144,10 @@ public abstract class ContributedLibrary extends DownloadableContribution {
     boolean versionEquals = thisVersion == otherVersion ||
       (thisVersion != null && otherVersion != null && thisVersion.equals(otherVersion));
 
-    String thisName = getName();
-    String otherName = ((ContributedLibrary) obj).getName();
+    String thisName = getGlobalName();
+    String otherName = ((ContributedLibrary) obj).getGlobalName();
 
-    boolean nameEquals = thisName == null || otherName == null || thisName.equals(otherName);
+    boolean nameEquals = thisName != null && otherName != null && thisName.equals(otherName);
 
     return versionEquals && nameEquals;
   }

--- a/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibrary.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibrary.java
@@ -66,14 +66,6 @@ public abstract class ContributedLibrary extends DownloadableContribution {
 
   public abstract List<ContributedLibraryReference> getRequires();
 
-  public abstract List<ContributedLibrary> getRequiredLibs();
-
-  public abstract List<ContributedLibrary> getRequiredLibsRec();
-
-  public abstract List<ContributedLibrary> getRequiredLibsRec(SortedSet<String> visited);
-
-  public abstract boolean changedSinceLastUpdateRec(int idx, SortedSet<String> visited);
-
   public static final Comparator<ContributedLibrary> CASE_INSENSITIVE_ORDER = (o1, o2) -> o1.getName().compareToIgnoreCase(o2.getName());
 
   /**

--- a/arduino-core/src/processing/app/BaseNoGui.java
+++ b/arduino-core/src/processing/app/BaseNoGui.java
@@ -19,6 +19,7 @@ import processing.app.helpers.filefilters.OnlyFilesWithExtension;
 import processing.app.legacy.PApplet;
 import processing.app.packages.LibraryList;
 import processing.app.packages.UserLibrary;
+import processing.app.preproc.PdePreprocessor;
 
 import java.io.*;
 import java.net.URISyntaxException;
@@ -960,6 +961,22 @@ public class BaseNoGui {
         } catch (IOException e) {
       }
     }
+  }
+
+  static public UserLibrary firstLibraryByImport(String importName) {
+    LibraryList list = importToLibraryTable.get(importName);
+    if (list == null || list.isEmpty()) {
+      return null;
+    }
+    return list.peekFirst();
+  }
+
+  static public UserLibrary firstLibraryByCode(String code) {
+    List<String> incs = PdePreprocessor.findIncludes(code);
+    if (incs.isEmpty()) {
+      return null;
+    }
+    return firstLibraryByImport(incs.get(0));
   }
 
   static public void initParameters(String args[]) throws IOException {

--- a/arduino-core/src/processing/app/BaseNoGui.java
+++ b/arduino-core/src/processing/app/BaseNoGui.java
@@ -963,7 +963,7 @@ public class BaseNoGui {
     }
   }
 
-  static public UserLibrary firstLibraryByImport(String importName) {
+  static public UserLibrary findFirstLibraryByImport(String importName) {
     LibraryList list = importToLibraryTable.get(importName);
     if (list == null || list.isEmpty()) {
       return null;
@@ -971,19 +971,19 @@ public class BaseNoGui {
     return list.peekFirst();
   }
 
-  static public UserLibrary firstLibraryByCode(String code) {
+  static public UserLibrary findFirstLibraryByCode(String code) {
     List<String> incs = PdePreprocessor.findIncludes(code);
     if (incs.isEmpty()) {
       return null;
     }
-    return firstLibraryByImport(incs.get(0));
+    return findFirstLibraryByImport(incs.get(0));
   }
 
-  static public List<UserLibrary> librariesByCode(String code) throws IOException {
+  static public List<UserLibrary> findLibrariesByCode(String code) throws IOException {
     List<UserLibrary> libs = new ArrayList<>();
     List<String> incs = PdePreprocessor.findIncludes(code);
     for (String inc : incs) {
-      UserLibrary lib = firstLibraryByImport(inc);
+      UserLibrary lib = findFirstLibraryByImport(inc);
       if (lib != null) {
         libs.add(lib);
       }
@@ -991,8 +991,8 @@ public class BaseNoGui {
     return libs;
   }
 
-  static public List<UserLibrary> librariesByCode(File file) throws IOException {
-    return librariesByCode(FileUtils.readFileToString(file));
+  static public List<UserLibrary> findLibrariesByCode(File file) throws IOException {
+    return findLibrariesByCode(FileUtils.readFileToString(file));
   }
 
   static public void initParameters(String args[]) throws IOException {

--- a/arduino-core/src/processing/app/BaseNoGui.java
+++ b/arduino-core/src/processing/app/BaseNoGui.java
@@ -979,6 +979,22 @@ public class BaseNoGui {
     return firstLibraryByImport(incs.get(0));
   }
 
+  static public List<UserLibrary> librariesByCode(String code) throws IOException {
+    List<UserLibrary> libs = new ArrayList<>();
+    List<String> incs = PdePreprocessor.findIncludes(code);
+    for (String inc : incs) {
+      UserLibrary lib = firstLibraryByImport(inc);
+      if (lib != null) {
+        libs.add(lib);
+      }
+    }
+    return libs;
+  }
+
+  static public List<UserLibrary> librariesByCode(File file) throws IOException {
+    return librariesByCode(FileUtils.readFileToString(file));
+  }
+
   static public void initParameters(String args[]) throws IOException {
     String preferencesFile = null;
 

--- a/arduino-core/src/processing/app/debug/Compiler.java
+++ b/arduino-core/src/processing/app/debug/Compiler.java
@@ -1404,10 +1404,12 @@ public class Compiler implements MessageConsumer {
           for (LibrarySelection libSelRec : lib.getRequiredLibsRec()) {
             if (!importedLibraries.contains(libSelRec.get())) {
               importedLibraries.add(libSelRec.get());
-              if (libSelRec.getList().size() > 1) {
-                importedDuplicateHeaders.add("UNKNOWN"); // FIXME
-                importedDuplicateLibraries.add(libSelRec);
-              }
+              // This is probably just confusing. People can examine the
+              // tooltips if they need this information.
+              //if (libSelRec.getList().size() > 1) {
+              //  importedDuplicateHeaders.add("UNKNOWN"); // FIXME
+              //  importedDuplicateLibraries.add(libSelRec);
+              //}
             }
           }
         }

--- a/arduino-core/src/processing/app/debug/Compiler.java
+++ b/arduino-core/src/processing/app/debug/Compiler.java
@@ -32,6 +32,7 @@ import cc.arduino.MyStreamPumper;
 import cc.arduino.packages.BoardPort;
 import cc.arduino.packages.Uploader;
 import cc.arduino.packages.UploaderFactory;
+import cc.arduino.contributions.libraries.ContributedLibrary;
 
 import cc.arduino.packages.uploaders.MergeSketchWithBooloader;
 import org.apache.commons.compress.utils.IOUtils;
@@ -606,6 +607,36 @@ public class Compiler implements MessageConsumer {
     p.put("extra.time.dst", Long.toString(daylight));
 
     return p;
+  }
+
+  static public List<File> findAllSources(File sourcePath, boolean recurse) {
+    List<File> allSources = new ArrayList<>();
+    allSources.addAll(findFilesInFolder(sourcePath, "S", recurse));
+    allSources.addAll(findFilesInFolder(sourcePath, "c", recurse));
+    allSources.addAll(findFilesInFolder(sourcePath, "cpp", recurse));
+    allSources.addAll(findFilesInFolder(sourcePath, "h", recurse));
+    allSources.addAll(findFilesInFolder(sourcePath, "hh", recurse));
+    allSources.addAll(findFilesInFolder(sourcePath, "hpp", recurse));
+    return allSources;
+  }
+
+  static public List<ContributedLibrary> findRequiredLibs(File sourcePath, boolean recurse) {
+    List<File> files = findAllSources(sourcePath, recurse);
+    List<ContributedLibrary> result = new ArrayList<>();
+    for (File file : files) {
+      List<UserLibrary> libs = null;
+      try { 
+        libs = BaseNoGui.librariesByCode(file);
+      } catch (IOException e) {
+        continue;
+      }
+      for (ContributedLibrary lib : libs) {
+        if (!result.contains(lib)) {
+          result.add(lib);
+        }
+      }
+    }
+    return result;
   }
 
   private List<File> compileFiles(File outputPath, File sourcePath,

--- a/arduino-core/src/processing/app/debug/Compiler.java
+++ b/arduino-core/src/processing/app/debug/Compiler.java
@@ -625,7 +625,7 @@ public class Compiler implements MessageConsumer {
     for (File file : files) {
       List<UserLibrary> libs = null;
       try { 
-        libs = BaseNoGui.librariesByCode(file);
+        libs = BaseNoGui.findLibrariesByCode(file);
       } catch (IOException e) {
         continue;
       }

--- a/arduino-core/src/processing/app/debug/Compiler.java
+++ b/arduino-core/src/processing/app/debug/Compiler.java
@@ -1389,7 +1389,7 @@ public class Compiler implements MessageConsumer {
     importedLibraries = new LibraryList();
     importedDuplicateHeaders = new ArrayList<>();
     importedDuplicateLibraries = new ArrayList<>();
-    Set<UserLibrary> preferSet = new HashSet<UserLibrary>();
+    Set<UserLibrary> preferSet = new HashSet<>();
     for (String[] item : preprocessor.getExtraImports()) {
       LibrarySelection libSel = BaseNoGui.findLibraryByImport(item, preferSet);
       if (libSel != null) {

--- a/arduino-core/src/processing/app/debug/Compiler.java
+++ b/arduino-core/src/processing/app/debug/Compiler.java
@@ -1395,6 +1395,12 @@ public class Compiler implements MessageConsumer {
             importedDuplicateHeaders.add(item);
             importedDuplicateLibraries.add(list);
           }
+          // Add recursive dependencies
+          for (UserLibrary libRec : lib.getRequiredLibsRec()) {
+            if (!importedLibraries.contains(libRec)) {
+              importedLibraries.add(libRec);
+            }
+          }
         }
       }
     }

--- a/arduino-core/src/processing/app/debug/Compiler.java
+++ b/arduino-core/src/processing/app/debug/Compiler.java
@@ -623,13 +623,13 @@ public class Compiler implements MessageConsumer {
     return allSources;
   }
 
-  static public List<LibrarySelection> findRequiredLibs(File sourcePath, boolean recurse) {
+  static public List<LibrarySelection> findRequiredLibs(File sourcePath, boolean recurse, Set<UserLibrary> preferSet) {
     List<File> files = findAllSources(sourcePath, recurse);
     List<LibrarySelection> result = new ArrayList<>();
     for (File file : files) {
       List<LibrarySelection> libSels = null;
       try { 
-        libSels = BaseNoGui.findLibrariesByCode(file);
+        libSels = BaseNoGui.findLibrariesByCode(file, preferSet);
       } catch (IOException e) {
         continue;
       }
@@ -1389,8 +1389,9 @@ public class Compiler implements MessageConsumer {
     importedLibraries = new LibraryList();
     importedDuplicateHeaders = new ArrayList<>();
     importedDuplicateLibraries = new ArrayList<>();
+    Set<UserLibrary> preferSet = new HashSet<UserLibrary>();
     for (String[] item : preprocessor.getExtraImports()) {
-      LibrarySelection libSel = BaseNoGui.findLibraryByImport(item);
+      LibrarySelection libSel = BaseNoGui.findLibraryByImport(item, preferSet);
       if (libSel != null) {
         UserLibrary lib = libSel.get();
         if (!importedLibraries.contains(lib)) {

--- a/arduino-core/src/processing/app/debug/Compiler.java
+++ b/arduino-core/src/processing/app/debug/Compiler.java
@@ -32,7 +32,6 @@ import cc.arduino.MyStreamPumper;
 import cc.arduino.packages.BoardPort;
 import cc.arduino.packages.Uploader;
 import cc.arduino.packages.UploaderFactory;
-import cc.arduino.contributions.libraries.ContributedLibrary;
 
 import cc.arduino.packages.uploaders.MergeSketchWithBooloader;
 import org.apache.commons.compress.utils.IOUtils;
@@ -620,9 +619,9 @@ public class Compiler implements MessageConsumer {
     return allSources;
   }
 
-  static public List<ContributedLibrary> findRequiredLibs(File sourcePath, boolean recurse) {
+  static public List<UserLibrary> findRequiredLibs(File sourcePath, boolean recurse) {
     List<File> files = findAllSources(sourcePath, recurse);
-    List<ContributedLibrary> result = new ArrayList<>();
+    List<UserLibrary> result = new ArrayList<>();
     for (File file : files) {
       List<UserLibrary> libs = null;
       try { 
@@ -630,7 +629,7 @@ public class Compiler implements MessageConsumer {
       } catch (IOException e) {
         continue;
       }
-      for (ContributedLibrary lib : libs) {
+      for (UserLibrary lib : libs) {
         if (!result.contains(lib)) {
           result.add(lib);
         }

--- a/arduino-core/src/processing/app/packages/LegacyUserLibrary.java
+++ b/arduino-core/src/processing/app/packages/LegacyUserLibrary.java
@@ -43,6 +43,7 @@ public class LegacyUserLibrary extends UserLibrary {
     res.setInstalled(true);
     res.layout = LibraryLayout.FLAT;
     res.name = libFolder.getName();
+    res.globalName = res.name;
     res.setTypes(Arrays.asList("Contributed"));
     res.setCategory("Uncategorized");
     return res;

--- a/arduino-core/src/processing/app/packages/LibrarySelection.java
+++ b/arduino-core/src/processing/app/packages/LibrarySelection.java
@@ -1,0 +1,26 @@
+package processing.app.packages;
+
+public class LibrarySelection {
+  private LibraryList list;
+  private int index;
+  public LibrarySelection(LibraryList list, int index) {
+    this.list = list;
+    this.index = index;
+  }
+  public UserLibrary get() {
+    return list.get(index);
+  }
+  public LibraryList getList() {
+    return list;
+  }
+  public int getIndex() {
+    return index;
+  }
+  public boolean equals(Object otherObj) {
+    if (!(otherObj instanceof LibrarySelection)) {
+      return false;
+    }
+    LibrarySelection other = (LibrarySelection) otherObj;
+    return this.get().equals(other.get());
+  }
+}

--- a/arduino-core/src/processing/app/packages/UserLibrary.java
+++ b/arduino-core/src/processing/app/packages/UserLibrary.java
@@ -221,10 +221,14 @@ public class UserLibrary extends ContributedLibrary {
   }
 
   public String getDepSpec() {
-    if (globalName != null && version != null) {
-      return globalName + ":" + version;
+    String depSpec = null;
+    if (globalName != null) {
+      depSpec = globalName;
+      if (version != null) {
+        depSpec += ":" + version;
+      }
     }
-    return null;
+    return depSpec;
   }
 
   @Override

--- a/arduino-core/src/processing/app/packages/UserLibrary.java
+++ b/arduino-core/src/processing/app/packages/UserLibrary.java
@@ -238,6 +238,11 @@ public class UserLibrary extends ContributedLibrary {
     return depSpec;
   }
 
+  @Override
+  public int hashCode() {
+    return getDepSpec().hashCode();
+  }
+
   public boolean matchesDepSpec(String spec) {
     String[] parts = spec.split(":", 2);
     return getGlobalName().equals(parts[0]);
@@ -266,7 +271,7 @@ public class UserLibrary extends ContributedLibrary {
     }
   }
 
-  private boolean versionsOrdered(String ver1, String ver2) {
+  static private boolean versionsOrdered(String ver1, String ver2) {
     String[] c1 = ver1.split("\\.");
     String[] c2 = ver2.split("\\.");
     int i;

--- a/arduino-core/src/processing/app/packages/UserLibrary.java
+++ b/arduino-core/src/processing/app/packages/UserLibrary.java
@@ -44,8 +44,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.TreeMap;
 import java.util.Map;
+import java.util.HashSet;
 import java.util.TreeSet;
 import java.util.SortedSet;
+import java.util.Set;
 
 public class UserLibrary extends ContributedLibrary {
 
@@ -418,7 +420,11 @@ public class UserLibrary extends ContributedLibrary {
 
   public List<LibrarySelection> getRequiredLibs() {
     if (requiredLibs == null || changedSinceLastUpdate(0)) {
-      requiredLibs = Compiler.findRequiredLibs(getSrcFolder(), useRecursion());
+      // Note: the "recursion" in useRecursion() refers to a strategy for
+      // finding files within an individual project
+      Set<UserLibrary> preferSet = new HashSet<>();
+      preferSet.add(this);
+      requiredLibs = Compiler.findRequiredLibs(getSrcFolder(), useRecursion(), preferSet);
       requiredLibs.remove(this);
     }
     return requiredLibs;

--- a/arduino-core/src/processing/app/packages/UserLibrary.java
+++ b/arduino-core/src/processing/app/packages/UserLibrary.java
@@ -238,10 +238,11 @@ public class UserLibrary extends ContributedLibrary {
 
   public boolean matchesDepSpec(String spec) {
     String[] parts = spec.split(":", 2);
-    if (!getGlobalName().equals(parts[0])) {
-      // Global name does not match - reject.
-      return false;
-    }
+    return getGlobalName().equals(parts[0]);
+  }
+
+  public boolean matchesDepSpecVersion(String spec) {
+    String[] parts = spec.split(":", 2);
     if (parts.length == 1) {
       // No version spec - accept any version.
       return true;

--- a/arduino-core/src/processing/app/packages/UserLibrary.java
+++ b/arduino-core/src/processing/app/packages/UserLibrary.java
@@ -330,8 +330,8 @@ public class UserLibrary extends ContributedLibrary {
 
   private Map<String,long[]> lastUpdateTimes = new TreeMap<String,long[]>();
 
-  private List<ContributedLibrary> requiredLibs = null;
-  private List<ContributedLibrary> requiredLibsRec = null;
+  private List<UserLibrary> requiredLibs = null;
+  private List<UserLibrary> requiredLibsRec = null;
 
   private boolean changedSinceLastUpdate(int idx) {
     List<File> files = Compiler.findAllSources(getSrcFolder(), useRecursion());
@@ -353,7 +353,6 @@ public class UserLibrary extends ContributedLibrary {
     return changed;
   }
 
-  @Override
   public boolean changedSinceLastUpdateRec(int idx, SortedSet<String> visited) {
     // Prevent infinite recursion.
     if (visited.contains(getDepSpec())) {
@@ -364,7 +363,7 @@ public class UserLibrary extends ContributedLibrary {
     if (changedSinceLastUpdate(idx)) {
       return true;
     }
-    for (ContributedLibrary lib : getRequiredLibs()) {
+    for (UserLibrary lib : getRequiredLibs()) {
       if (lib.changedSinceLastUpdateRec(idx, visited)) {
         return true;
       }
@@ -372,8 +371,7 @@ public class UserLibrary extends ContributedLibrary {
     return false;
   }
 
-  @Override
-  public List<ContributedLibrary> getRequiredLibs() {
+  public List<UserLibrary> getRequiredLibs() {
     if (requiredLibs == null || changedSinceLastUpdate(0)) {
       requiredLibs = Compiler.findRequiredLibs(getSrcFolder(), useRecursion());
       requiredLibs.remove(this);
@@ -381,13 +379,11 @@ public class UserLibrary extends ContributedLibrary {
     return requiredLibs;
   }
 
-  @Override
-  public List<ContributedLibrary> getRequiredLibsRec() {
+  public List<UserLibrary> getRequiredLibsRec() {
     return getRequiredLibsRec(new TreeSet<>());
   }
 
-  @Override
-  public List<ContributedLibrary> getRequiredLibsRec(SortedSet<String> visited) {
+  public List<UserLibrary> getRequiredLibsRec(SortedSet<String> visited) {
     // Prevent infinite recursion.
     if (visited.contains(getDepSpec())) {
       return new ArrayList<>();
@@ -396,10 +392,10 @@ public class UserLibrary extends ContributedLibrary {
 
     if (requiredLibsRec == null || changedSinceLastUpdateRec(1, new TreeSet<>(visited))) {
       requiredLibsRec = new ArrayList<>();
-      for (ContributedLibrary lib : getRequiredLibs()) {
+      for (UserLibrary lib : getRequiredLibs()) {
         if (!requiredLibsRec.contains(lib) && lib != this) {
           requiredLibsRec.add(lib);
-          for (ContributedLibrary libRec : lib.getRequiredLibsRec(visited)) {
+          for (UserLibrary libRec : lib.getRequiredLibsRec(visited)) {
             if (!requiredLibsRec.contains(libRec) && libRec != this) {
               requiredLibsRec.add(libRec);
             }

--- a/arduino-core/src/processing/app/packages/UserLibrary.java
+++ b/arduino-core/src/processing/app/packages/UserLibrary.java
@@ -213,7 +213,7 @@ public class UserLibrary extends ContributedLibrary {
       invalid = true;
       // Fallback.  Note: the global name is used to test for equality,
       // so it must have a value.
-      globalName = author.replace('/', '_') + "/" + name;
+      globalName = author.replace('|', '_') + "|" + name;
     }
     if (invalid) {
       System.err.println("WARNING: global_name not set in library " + name + ". Guessing '" + globalName + "'.\nPlease set this to a suitable Java-style package name, e.g. io.github.myaccount.myproject\nThe name should be set manually to avoid confusion when forking.");

--- a/arduino-core/src/processing/app/preproc/PdePreprocessor.java
+++ b/arduino-core/src/processing/app/preproc/PdePreprocessor.java
@@ -43,7 +43,7 @@ import java.util.regex.*;
  */
 public class PdePreprocessor {
   
-  private static final String IMPORT_REGEX = "^\\s*#include\\s*[<\"](\\S+)[\">]";
+  private static final String IMPORT_REGEX = "^\\s*#include\\s*[<\"](\\S+)[\">](?:[ \\t]*//!Lib[ \\t]+[\"']([^\"']*)[\"'])?";
   
   // stores number of built user-defined function prototypes
   public int prototypeCount = 0;
@@ -58,7 +58,7 @@ public class PdePreprocessor {
   // these ones have the .* at the end, since a class name might be at the end
   // instead of .* which would make trouble other classes using this can lop
   // off the . and anything after it to produce a package name consistently.
-  List<String> programImports;
+  List<String[]> programImports;
 
   // imports just from the code folder, treated differently
   // than the others, since the imports are auto-generated.
@@ -85,6 +85,12 @@ public class PdePreprocessor {
     // http://dev.processing.org/bugs/show_bug.cgi?id=5
     program += "\n";
 
+    //String importRegexp = "(?:^|\\s|;)(import\\s+)(\\S+)(\\s*;)";
+
+    // This must come before scrubbing the comments, so that we get the
+    // dependency specs (//!Lib comments)
+    programImports = findIncludes(program);
+
     // if the program ends with an unterminated multi-line comment,
     // an OutOfMemoryError or NullPointerException will happen.
     // again, not gonna bother tracking this down, but here's a hack.
@@ -95,10 +101,6 @@ public class PdePreprocessor {
     if (PreferencesData.getBoolean("preproc.substitute_unicode")) {
       program = substituteUnicode(program);
     }
-
-    //String importRegexp = "(?:^|\\s|;)(import\\s+)(\\S+)(\\s*;)";
-
-    programImports = findIncludes(program);
 
     codeFolderImports = new ArrayList<String>();
 //    if (codeFolderPackages != null) {
@@ -118,15 +120,16 @@ public class PdePreprocessor {
     return headerCount + prototypeCount;
   }
 
-  public static List<String> findIncludes(String code){
+  public static List<String[]> findIncludes(String code){
    
     String[][] pieces = PApplet.matchAll(code, IMPORT_REGEX);
 
-    ArrayList<String> programImports = new ArrayList<>();
+    ArrayList<String[]> programImports = new ArrayList<>();
     
     if (pieces != null)
       for (int i = 0; i < pieces.length; i++)
-        programImports.add(pieces[i][1]);  // the package name
+        programImports.add(new String[] { pieces[i][1], pieces[i][2] });
+        // the include file name, and the dependency spec (if any)
 
     return programImports;
   }
@@ -208,7 +211,7 @@ public class PdePreprocessor {
   protected void writeFooter(PrintStream out) throws java.lang.Exception {}
 
 
-  public List<String> getExtraImports() {
+  public List<String[]> getExtraImports() {
     return programImports;
   }
 

--- a/arduino-core/src/processing/app/preproc/PdePreprocessor.java
+++ b/arduino-core/src/processing/app/preproc/PdePreprocessor.java
@@ -97,13 +97,8 @@ public class PdePreprocessor {
     }
 
     //String importRegexp = "(?:^|\\s|;)(import\\s+)(\\S+)(\\s*;)";
-    programImports = new ArrayList<String>();
 
-    String[][] pieces = PApplet.matchAll(program, IMPORT_REGEX);
-
-    if (pieces != null)
-      for (int i = 0; i < pieces.length; i++)
-        programImports.add(pieces[i][1]);  // the package name
+    programImports = findIncludes(program);
 
     codeFolderImports = new ArrayList<String>();
 //    if (codeFolderPackages != null) {
@@ -127,7 +122,7 @@ public class PdePreprocessor {
    
     String[][] pieces = PApplet.matchAll(code, IMPORT_REGEX);
 
-    ArrayList programImports = new ArrayList<String>();
+    ArrayList<String> programImports = new ArrayList<>();
     
     if (pieces != null)
       for (int i = 0; i < pieces.length; i++)


### PR DESCRIPTION
This branch achieves 4 things:

1. Global library names
2. Dependency specs
3. Hierarchical dependency compilation
4. Hierarchical dependency tooltips

The general idea of this is to permit the development of mid-level libraries that encapsulate the details of the low-level libraries that they depend on, providing a simpler, more accessible, and perhaps more featureful interface to the same functionality, without bloating the low-level libraries; and to allow common parts of sketches to be factored out. Specifically, it should be possible to do these things without the user having to worry about additional headers to include because of recursive dependencies.

More details follow:

1. Libraries now have **global names**. The ordinary name of a library cannot be relied upon to be unique. Nor can documentation URLs (which are not, in any case, intended for identification purposes). This problem is especially exacerbated by forking. A hash, meanwhile, is too specific - you may want to work with different versions of the same library, possibly tweaked by the user immediately prior to compilation.

    The solution is to require each library to have a globally unique name, which should be based on a reverse domain name in the manner of Java or Android package names. For instance, if your project is stored at https://github.com/myaccount/myproject, the global name may be something like io.github.myaccount.myproject (note the use of GitHub's user-only namespace - this is probably best practice even if the user domain is not in use). If myproject contains several subprojects, then they may have global names like "io.github.myaccount.myproject.subproject".

    When the project is forked by otheraccount, the global name of "io.github.myaccount.myproject" should be changed to "io.github.otheraccount.myproject", etc. (unless it is to be considered the same library - e.g. when there is a change of maintainer).

    There is code to deal with legacy projects and projects predating the introduction of the global name, generally by trying to infer the repository/project URL and convert it to a suitable form, and, failing that, falling back on the simple name, combined with the author if present. For this proof-of-concept, the code only looks at the url, name, and author fields of the library.properties file, but other things to try include the repository information in the library.json file if present, repository metadata (.git, .svn...), etc. However, this should probably only ever be a stopgap solution before introducing a proper global name.

2. Dependencies are found by **dependency spec** (where present), rather than by header name alone. Next to each #include statement, there can be a comment consisting of //!Lib followed by a dependency spec. A dependency spec consists of a global name optionally followed by : and a version spec. A version spec may be a version number, or a partial version number followed by *, or a version number followed by +, or two version numbers separated by -. These are interpreted in the obvious way. A simple dependency spec is generated for each new #include line when the IDE is used to import a library.

    The global name part alone is used for deciding between alternative libraries, while the version is used to report an incorrect version. (At the moment, this reporting is only partially implemented.)

3. Dependencies are now **found hierarchically** (i.e. recursively). All source files within each imported library are examined for #include statements (which may also have dependency specs - see note 2), and additional libraries are added to the project accordingly. These additional imported libraries are also examined for further dependencies, and so on. Naturally, this is implemented such that it is able to deal with dependency loops. The information is also cached - although the cache is updated whenever a source file has changed.

4. In order to keep users in-the-loop about what libraries they are importing, when a #include statement is hovered over, a **tooltip** is displayed showing details of all libraries drawn in by that statement, starting with the one directly imported by the #include itself. Friendly name, global name, version and directory are shown for each library.

    The tooltips will always be correct about indirect dependencies (i.e. libraries imported by a library you import). However, they sometimes currently don't have enough context to know that a first-level dependency is affected by previous first-level dependencies (although this shouldn't be that difficult to fix). However, first-level dependency choices are still reported (correctly) with the compiler output, as before.

Further work needed:

- Find some way of providing a valid preferSet when creating the tooltips, so that they have the context needed to display the correct first-level imports

- Display a warning when two incompatible libraries are imported (before building, perhaps in tooltip)

- Extend the version warnings in tooltips to cover recursive dependencies as well.

- Improve methods for inferring global name.
	- Git/etc repository metadata
	- library.json

- Improve the caching of dependencies so that it does not recursively check file timestamps multiple times within a single run

- Discover why it isn't always removing incorrect recursive libs when it rescans

- Accept only <> for library includes?

- Display //!Lib spec as a special token in the editor?

- Improve formatting of tooltip?