### PR TITLE
Adding accidentally removed serial baud rates back in

### DIFF
--- a/app/src/processing/app/AbstractMonitor.java
+++ b/app/src/processing/app/AbstractMonitor.java
@@ -40,6 +40,8 @@ public abstract class AbstractMonitor extends JFrame implements ActionListener {
   private Timer updateTimer;
 
   private BoardPort boardPort;
+  
+  protected String[] serialRateStrings = {"300", "1200", "2400", "4800", "9600", "19200", "38400", "57600", "74880", "115200", "230400", "250000"};
 
   public AbstractMonitor(BoardPort boardPort) {
     super(boardPort.getLabel());

--- a/app/src/processing/app/AbstractTextMonitor.java
+++ b/app/src/processing/app/AbstractTextMonitor.java
@@ -109,11 +109,6 @@ public abstract class AbstractTextMonitor extends AbstractMonitor {
     }
     lineEndings.setMaximumSize(lineEndings.getMinimumSize());
 
-    String[] serialRateStrings = {
-            "300", "1200", "2400", "4800", "9600",
-            "19200", "38400", "57600", "115200", "230400", "250000"
-    };
-
     serialRates = new JComboBox();
     for (String rate : serialRateStrings) {
       serialRates.addItem(rate + " " + _("baud"));

--- a/app/src/processing/app/SerialPlotter.java
+++ b/app/src/processing/app/SerialPlotter.java
@@ -163,11 +163,6 @@ public class SerialPlotter extends AbstractMonitor {
     JPanel pane = new JPanel();
     pane.setLayout(new BoxLayout(pane, BoxLayout.X_AXIS));
     pane.setBorder(new EmptyBorder(4, 4, 4, 4));
-         
-    String[] serialRateStrings = {
-      "300","1200","2400","4800","9600","14400",
-      "19200","28800","38400","57600","115200"
-    };
     
     serialRates = new JComboBox();
     for (int i = 0; i < serialRateStrings.length; i++)


### PR DESCRIPTION
I just noticed I accidentally removed some baud rate settings recently added in #3389 when rebasing the plotting code for #2177. As those serial rate strings then existed in two places I took the liberty to consolidate them (same baud rates as in #3389) in AbstractMonitor.java. 