### PR TITLE
Update CDC.cpp - Remove delay in operator bool()

### DIFF
--- a/hardware/arduino/sam/cores/arduino/USB/CDC.cpp
+++ b/hardware/arduino/sam/cores/arduino/USB/CDC.cpp
@@ -28,6 +28,8 @@
 
 #define CDC_LINESTATE_READY		(CDC_LINESTATE_RTS | CDC_LINESTATE_DTR)
 
+uint32_t lineStateChangeTime = 0;
+
 struct ring_buffer
 {
 	uint8_t buffer[CDC_SERIAL_BUFFER_SIZE];
@@ -128,6 +130,7 @@ bool WEAK CDC_Setup(Setup& setup)
 		if (CDC_SET_CONTROL_LINE_STATE == r)
 		{
 			_usbLineInfo.lineState = setup.wValueL;
+			lineStateChangeTime = millis();
 			// auto-reset into the bootloader is triggered when the port, already
 			// open at 1200 bps, is closed.
 			if (1200 == _usbLineInfo.dwDTERate)
@@ -290,12 +293,11 @@ Serial_::operator bool()
 
 	bool result = false;
 
-	if (_usbLineInfo.lineState > 0)
+	if (_usbLineInfo.lineState > 0 && ((millis() - lineStateChangeTime) >= 10))
 	{
 		result = true;
 	}
 
-	delay(10);
 	return result;
 }
 


### PR DESCRIPTION
Remove 10ms blocking wait from bool() operator in CDC code. Instead, set a timestamp and wait 10ms before returning true.