### PR TITLE
Fixed typo in Scheduler header guard.

### DIFF
--- a/libraries/Scheduler/src/Scheduler.h
+++ b/libraries/Scheduler/src/Scheduler.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef _SCHEDULDER_H_
-#define _SCHEDULDER_H_
+#ifndef _SCHEDULER_H_
+#define _SCHEDULER_H_
 
 #include <Arduino.h>
 


### PR DESCRIPTION
The header guard in the Scheduler.h file was previously misspelled.  This PR corrects the spelling.