### PR TITLE
WiFi: move init from constructor to method

### DIFF
--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -32,8 +32,6 @@ uint16_t 	WiFiClass::_server_port[MAX_SOCK_NUM] = { 0, 0, 0, 0 };
 
 WiFiClass::WiFiClass()
 {
-	// Driver initialization
-	init();
 }
 
 void WiFiClass::init()

--- a/libraries/WiFi/src/utility/spi_drv.cpp
+++ b/libraries/WiFi/src/utility/spi_drv.cpp
@@ -43,8 +43,8 @@ void SpiDrv::begin()
 	  pinMode(SLAVEREADY, INPUT);
 	  pinMode(WIFILED, OUTPUT);
 
-	  digitalWrite(SCK, LOW);
-	  digitalWrite(MOSI, LOW);
+	  // digitalWrite(SCK, LOW);
+	  // digitalWrite(MOSI, LOW);
 	  digitalWrite(SS, HIGH);
 	  digitalWrite(SLAVESELECT, HIGH);
 	  digitalWrite(WIFILED, LOW);

--- a/libraries/WiFi/src/utility/spi_drv.h
+++ b/libraries/WiFi/src/utility/spi_drv.h
@@ -30,11 +30,15 @@
 
 #define DUMMY_DATA  0xFF
 
-#define WAIT_FOR_SLAVE_SELECT()	 \
-	SpiDrv::waitForSlaveReady(); \
+#define WAIT_FOR_SLAVE_SELECT()	      \
+	if (!initialized) {           \
+		SpiDrv::begin();      \
+		initialized = true;   \
+	}                             \
+	SpiDrv::waitForSlaveReady();  \
 	SpiDrv::spiSlaveSelect();
 
-
+static bool initialized = false;
 
 class SpiDrv
 {


### PR DESCRIPTION
Zero SPI library is not responding correctly when invoked before main()

AVR compatibility ok
fixes arduino/ArduinoCore-samd#18