### PR TITLE
Print not Aborting on Write() failure

### DIFF
--- a/hardware/arduino/avr/cores/arduino/Print.cpp
+++ b/hardware/arduino/avr/cores/arduino/Print.cpp
@@ -35,7 +35,7 @@ size_t Print::write(const uint8_t *buffer, size_t size)
 {
   size_t n = 0;
   while (size--) {
-    if(write(*buffer++) n++;
+    if(write(*buffer++)) n++;
     else break;
   }
   return n;

--- a/hardware/arduino/avr/cores/arduino/Print.cpp
+++ b/hardware/arduino/avr/cores/arduino/Print.cpp
@@ -17,6 +17,7 @@
  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  
  Modified 23 November 2006 by David A. Mellis
+ Modified 03 August 2015 by Chuck Todd
  */
 
 #include <stdlib.h>
@@ -34,7 +35,8 @@ size_t Print::write(const uint8_t *buffer, size_t size)
 {
   size_t n = 0;
   while (size--) {
-    n += write(*buffer++);
+    if(write(*buffer++) n++;
+    else break;
   }
   return n;
 }
@@ -46,7 +48,8 @@ size_t Print::print(const __FlashStringHelper *ifsh)
   while (1) {
     unsigned char c = pgm_read_byte(p++);
     if (c == 0) break;
-    n += write(c);
+    if(write(c)) n++;
+    else break;
   }
   return n;
 }


### PR DESCRIPTION
The current 1.6.5 Print library report the total count of characters send during operations.  The assumption is that this count is of contiguous characters.  If you printed a buffer of 45 characters and the print command returned 44 as the number of characters sent, the assumption is that the last character was not sent.  But, this is not a valid assumption.  The two low level functions through which all of the helper print funtions work (`size_t Print::write(const uint8_t *buffer, size_t size)` and `size_t Print::print(const __FlashStringHelper *ifsh)`) do not exit when a write failure is detected.  They just attempt to write the next character from the input buffer.  This renders any positional transmit information useless. 
  I propose to change the behavior of these two routines.  When a write error is encountered these function return with the count of sent characters.  If the calling procedure wants to retry sending then ~buffer[sentCount] is the next character needing to be send.

see arduino/Arduino issue #3614

Chuck Todd