### PR TITLE
Optional .a linkage for libraries

### DIFF
--- a/arduino-core/src/processing/app/debug/Compiler.java
+++ b/arduino-core/src/processing/app/debug/Compiler.java
@@ -1070,8 +1070,76 @@ public class Compiler implements MessageConsumer {
     if (lib.useRecursion()) {
       // libBuildFolder == {build.path}/LibName
       // libFolder      == {lib.path}/src
-      recursiveCompileFilesInFolder(libBuildFolder, libFolder, includeFolders);
-      
+
+      // Compile the library with .a linkage if a flag was set in library.properties
+      if(lib.alinkage()){
+
+          File afile = new File(libBuildFolder, lib.getName() + ".a");
+
+          createFolder(libBuildFolder);
+          List<File> libraryObjectFiles = compileFiles(libBuildFolder, libFolder, true, includeFolders);
+
+          // See if the .a file is already uptodate
+          if (afile.exists()) {
+            boolean changed = false;
+            for (File file : libraryObjectFiles) {
+              if (file.lastModified() > afile.lastModified()) {
+                changed = true;
+                break;
+              }
+            }
+
+            // If none of the object files is newer than the .a file, don't
+            // bother rebuilding the .a file. There is a small corner case
+            // here: If a source file was removed, but no other source file
+            // was modified, this will not rebuild core.a even when it
+            // should. It's hard to fix and not a realistic case, so it
+            // shouldn't be a problem.
+            if (!changed) {
+              if (verbose)
+                System.out.println(I18n.format(tr("Using previously compiled file: {0}"), afile.getPath()));
+
+                // this is no longer an object file, but will be added anyways.
+                objectFiles.add(afile);
+              return;
+            }
+          }
+
+          // Delete the .a file, to prevent any previous code from lingering
+          afile.delete();
+
+          try {
+            for (File file : libraryObjectFiles) {
+              PreferencesMap dict = new PreferencesMap(prefs);
+              dict.put("ide_version", "" + BaseNoGui.REVISION);
+              dict.put("archive_file", afile.getName());
+              dict.put("object_file", file.getAbsolutePath());
+              dict.put("build.path", libBuildFolder.getAbsolutePath());
+
+              String[] cmdArray;
+              String cmd = prefs.getOrExcept("recipe.ar.pattern");
+              try {
+                cmdArray = StringReplacer.formatAndSplit(cmd, dict, true);
+              } catch (Exception e) {
+                throw new RunnerException(e);
+              }
+              execAsynchronously(cmdArray);
+            }
+
+          } catch (RunnerException e) {
+            afile.delete();
+            throw e;
+          }
+
+          // this is no longer an object file, but will be added anyways.
+          objectFiles.add(afile);
+      }
+
+      // no alinkage, old, default .o file linkage
+      else{
+        recursiveCompileFilesInFolder(libBuildFolder, libFolder, includeFolders);
+      }
+
     } else {
       // libFolder          == {lib.path}/
       // utilityFolder      == {lib.path}/utility

--- a/arduino-core/src/processing/app/packages/UserLibrary.java
+++ b/arduino-core/src/processing/app/packages/UserLibrary.java
@@ -58,6 +58,7 @@ public class UserLibrary extends ContributedLibrary {
   private List<String> types;
   private List<String> declaredTypes;
   private boolean onGoingDevelopment;
+  private boolean alinkage;
 
   private static final List<String> MANDATORY_PROPERTIES = Arrays
     .asList("name", "version", "author", "maintainer",
@@ -154,6 +155,12 @@ public class UserLibrary extends ContributedLibrary {
       typesList.add(type.trim());
     }
 
+    String alinkageString = properties.get("alinkage");
+    boolean alinkage = false;
+    if(alinkageString != null && alinkageString.equals("true")) {
+      alinkage = true;
+    }
+
     UserLibrary res = new UserLibrary();
     res.setInstalledFolder(libFolder);
     res.setInstalled(true);
@@ -170,6 +177,7 @@ public class UserLibrary extends ContributedLibrary {
     res.layout = layout;
     res.declaredTypes = typesList;
     res.onGoingDevelopment = Files.exists(Paths.get(libFolder.getAbsolutePath(), Constants.LIBRARY_DEVELOPMENT_FLAG_FILE));
+    res.alinkage = alinkage;
     return res;
   }
 
@@ -272,6 +280,10 @@ public class UserLibrary extends ContributedLibrary {
 
   public boolean onGoingDevelopment() {
     return onGoingDevelopment;
+  }
+
+  public boolean alinkage() {
+    return alinkage;
   }
 
   protected enum LibraryLayout {


### PR DESCRIPTION
Fixes:
https://github.com/arduino/Arduino/issues/2800
https://github.com/arduino/Arduino/issues/3649
And adds the possibility to create more enhanced libraries with smaller flash size. **This feature is optional and won't break any existing library.**

All you need to do is add a `alinkage=true` to your library.properties file. By default alinkage is off, to not break older libraries with ISRs. A linkage is only possible for newer libraries with a /src folder.

Most of the code was adapted from here, so it should work fine, I did not reinvent the wheel here.
https://github.com/arduino/Arduino/blob/master/arduino-core/src/processing/app/debug/Compiler.java#L1130-L1182

The code now moved in its own function (2nd commit) to reduce code duplication.

I am still not sure if we need `recursiveCompileFilesInFolder()` or if we can use `compileFiles()` with `true` as paramter. If desired I can add a new `recursiveCompileFilesInFolder()` which returns a List of Files instead of void, if that helps in any case. What was the thought behind this? For this PR it is not critical since .a linkage is optional and won't break anything, and the core compiling stays the same.