### PR TITLE
Release TWI bus right after stop or repeated start condition

### DIFF
--- a/hardware/arduino/avr/libraries/Wire/utility/twi.c
+++ b/hardware/arduino/avr/libraries/Wire/utility/twi.c
@@ -476,6 +476,8 @@ ISR(TWI_vect)
       }
       break;
     case TW_SR_STOP: // stop or repeated start condition received
+      // ack future responses and leave slave receiver state
+      twi_releaseBus();
       // put a null char after data if there's room
       if(twi_rxBufferIndex < TWI_BUFFER_LENGTH){
         twi_rxBuffer[twi_rxBufferIndex] = '\0';
@@ -484,8 +486,6 @@ ISR(TWI_vect)
       twi_onSlaveReceive(twi_rxBuffer, twi_rxBufferIndex);
       // since we submit rx buffer to "wire" library, we can reset it
       twi_rxBufferIndex = 0;
-      // ack future responses and leave slave receiver state
-      twi_releaseBus();
       break;
     case TW_SR_DATA_NACK:       // data received, returned nack
     case TW_SR_GCALL_DATA_NACK: // data received generally, returned nack


### PR DESCRIPTION
This resolves timing issues seen in #1477.

Merging #66 made timing errors from #1477 more frequent, as TWI bus was no longer released earlier (via ``twi_stop``). This change releases the TWI bus right after a stop or repeated start condition is received.

Example sketches from https://github.com/arduino/Arduino/issues/1477#issuecomment-135459738 can be used to reproduce, and verify the fix with 2 Arduino Uno boards. The delay in the master can also be removed.