### PR TITLE
Add isFlushed() method to HardwareSerial class for AVR and UARTClass for SAM

### DIFF
--- a/build/shared/lib/keywords.txt
+++ b/build/shared/lib/keywords.txt
@@ -152,6 +152,7 @@ println	KEYWORD2	Serial_Println
 available	KEYWORD2	Serial_Available
 availableForWrite	KEYWORD2
 flush	KEYWORD2	Serial_Flush
+isFlushed	KEYWORD2
 setTimeout	KEYWORD2
 find	KEYWORD2
 findUntil	KEYWORD2

--- a/hardware/arduino/avr/cores/arduino/HardwareSerial.cpp
+++ b/hardware/arduino/avr/cores/arduino/HardwareSerial.cpp
@@ -210,6 +210,12 @@ void HardwareSerial::flush()
   // the hardware finished tranmission (TXC is set).
 }
 
+bool HardwareSerial::isFlushed(void)
+{
+  if (!_written) return true;
+  return (_tx_buffer_head == _tx_buffer_tail) && bit_is_clear(*_ucsrb, UDRIE0) && bit_is_set(*_ucsra, TXC0);
+}
+
 size_t HardwareSerial::write(uint8_t c)
 {
   _written = true;

--- a/hardware/arduino/avr/cores/arduino/HardwareSerial.h
+++ b/hardware/arduino/avr/cores/arduino/HardwareSerial.h
@@ -126,6 +126,7 @@ class HardwareSerial : public Stream
     virtual int read(void);
     int availableForWrite(void);
     virtual void flush(void);
+    virtual bool isFlushed(void);
     virtual size_t write(uint8_t);
     inline size_t write(unsigned long n) { return write((uint8_t)n); }
     inline size_t write(long n) { return write((uint8_t)n); }

--- a/hardware/arduino/sam/cores/arduino/UARTClass.cpp
+++ b/hardware/arduino/sam/cores/arduino/UARTClass.cpp
@@ -142,6 +142,11 @@ void UARTClass::flush( void )
    ;
 }
 
+bool UARTClass::isFlushed( void )
+{
+  return ((_pUart->UART_SR & UART_SR_TXRDY) == UART_SR_TXRDY) && (_tx_buffer->_iTail == _tx_buffer->_iHead);
+}
+
 size_t UARTClass::write( const uint8_t uc_data )
 {
   // Is the hardware currently busy?

--- a/hardware/arduino/sam/cores/arduino/UARTClass.h
+++ b/hardware/arduino/sam/cores/arduino/UARTClass.h
@@ -52,6 +52,7 @@ class UARTClass : public HardwareSerial
     int peek(void);
     int read(void);
     void flush(void);
+    bool isFlushed(void);
     size_t write(const uint8_t c);
     using Print::write; // pull in write(str) and write(buf, size) from Print
 


### PR DESCRIPTION
Needed a non-blocking way to check if the transmit buffer was flushed/clear. This is a re-request because I stink at Git, original request was #3589. Sorry!
