### PR TITLE
Check TWWC (Write Collision Flag) bit after setting TWDR

### DIFF
--- a/hardware/arduino/avr/libraries/Wire/utility/twi.c
+++ b/hardware/arduino/avr/libraries/Wire/utility/twi.c
@@ -167,7 +167,9 @@ uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sen
     // up. Also, don't enable the START interrupt. There may be one pending from the 
     // repeated start that we sent outselves, and that would really confuse things.
     twi_inRepStart = false;			// remember, we're dealing with an ASYNC ISR
-    TWDR = twi_slarw;
+    do {
+      TWDR = twi_slarw;
+    } while(TWCR & _BV(TWWC));
     TWCR = _BV(TWINT) | _BV(TWEA) | _BV(TWEN) | _BV(TWIE);	// enable INTs, but not START
   }
   else
@@ -247,7 +249,9 @@ uint8_t twi_writeTo(uint8_t address, uint8_t* data, uint8_t length, uint8_t wait
     // up. Also, don't enable the START interrupt. There may be one pending from the 
     // repeated start that we sent outselves, and that would really confuse things.
     twi_inRepStart = false;			// remember, we're dealing with an ASYNC ISR
-    TWDR = twi_slarw;				
+    do {
+      TWDR = twi_slarw;				
+    } while(TWCR & _BV(TWWC));
     TWCR = _BV(TWINT) | _BV(TWEA) | _BV(TWEN) | _BV(TWIE);	// enable INTs, but not START
   }
   else


### PR DESCRIPTION
As suggested by @earlyprogrammer in #2173, to ensure TWDR value is set if there is a write collision. See #2173 for more details.