### PR TITLE
Added EXTERNAL_NUM_INTERRUPTS for AVR xxU2 series

### DIFF
--- a/hardware/arduino/avr/cores/arduino/wiring_private.h
+++ b/hardware/arduino/avr/cores/arduino/wiring_private.h
@@ -52,7 +52,8 @@ uint32_t countPulseASM(volatile uint8_t *port, uint8_t bit, uint8_t stateMask, u
 #define EXTERNAL_INT_6 6
 #define EXTERNAL_INT_7 7
 
-#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega128RFA1__) || defined(__AVR_ATmega256RFR2__)
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega128RFA1__) || defined(__AVR_ATmega256RFR2__) || \
+    defined(__AVR_AT90USB82__) || defined(__AVR_AT90USB162__) || defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U2__) || defined(__AVR_ATmega8U2__)
 #define EXTERNAL_NUM_INTERRUPTS 8
 #elif defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega644__) || defined(__AVR_ATmega644A__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644PA__)
 #define EXTERNAL_NUM_INTERRUPTS 3


### PR DESCRIPTION
@NicoHood 
are you sure that the correct number is 8? it sounds weird since the 32U4 has 5.