### PR TITLE
Include sketchbook folder and LibrarySettings.h

### DIFF
--- a/arduino-core/src/processing/app/debug/Compiler.java
+++ b/arduino-core/src/processing/app/debug/Compiler.java
@@ -396,6 +396,20 @@ public class Compiler implements MessageConsumer {
     progressListener.progress(20);
     List<File> includeFolders = new ArrayList<File>();
     includeFolders.add(prefs.getFile("build.core.path"));
+    includeFolders.add(sketchBuildFolder);
+    
+    // Create empty LibrarySettings.h file if it does not exist yet to avoid compile errors
+    File librarySettingsFile = new File(sketchBuildFolder, "LibrarySettings.h");
+    if (librarySettingsFile.exists() == false)
+    {
+        try{
+            librarySettingsFile.createNewFile();
+        }
+        catch (IOException e) {
+            throw new RunnerException("Unable to create file " + librarySettingsFile);
+        }
+    }
+    
     if (prefs.getFile("build.variant.path") != null)
       includeFolders.add(prefs.getFile("build.variant.path"));
     for (UserLibrary lib : importedLibraries) {


### PR DESCRIPTION
Test to improve https://github.com/arduino/Arduino/pull/3717

Some notes to this PR:
- It (basically) does the same (idea) as the linked PR above
- You do not need to save the file before it is used for compiling
- A Global "LibrarySetting.h" filename is used for custom Library settings
- If it does not exists in the sketch folder it will be created emty
- You can still overwrite this empty file in the IDE again
- If you create and delete the file this wont be noticed
- The try catch may be improved, I am not a java pro.

This way you can place custom settings in this file. You can also add something like
`#define LIBCONFIG_EXISTS` to use custom settings or `#ifndef SETTING`. The reason why a specific filename is used is, that it will compile fine even if the file was not created by the user.

You can also create custom settings like `MylibSetting.h` and include it from the library. This makes the file required to exist. If not it will throw a compile error. If the file also exists in the library, the library file will be preferred (so you should use the Librarysettings.h instead for this usecase).
### Independent Issue found:

The deletion seems to be a general IDE issue. If you create a file and compile the sketch the file is copied to the build folder. If you delete the file again it wont be noticed and the sketchfolder still has this file. (The core has the same error, [which is ignored](https://github.com/arduino/Arduino/blob/master/arduino-core/src/processing/app/debug/Compiler.java#L1146-L1151)).

I tried to delete the file after each compile. That worked fine till the point when LibrarySettings.h causes a compile error. The file wont be deleted then (in the build folder). If you delete it (in the IDE) its still in the build folder.

So this is a general, separate bug. Should I open a ticket for this?
### May anyone build this to test it?
