### PR TITLE
Call on onBoardOrPortChange after selectBoard when board argument passed into command line

### DIFF
--- a/arduino-core/src/processing/app/helpers/CommandlineParser.java
+++ b/arduino-core/src/processing/app/helpers/CommandlineParser.java
@@ -249,6 +249,7 @@ public class CommandlineParser {
     }
 
     BaseNoGui.selectBoard(targetBoard);
+    BaseNoGui.onBoardOrPortChange();
 
     if (split.length > 3) {
       String[] options = split[3].split(",");


### PR DESCRIPTION
Implements same behaviour as the GUI when a board is changed via the menu.

I was having issues with the build failing because the library path for previous architecture was used for bundled libraries like Wire.