### PR TITLE
Added Ethernet.maintain() to examples

### DIFF
--- a/libraries/Ethernet/examples/DhcpAddressPrinter/DhcpAddressPrinter.ino
+++ b/libraries/Ethernet/examples/DhcpAddressPrinter/DhcpAddressPrinter.ino
@@ -1,18 +1,20 @@
 /*
   DHCP-based IP printer
 
- This sketch uses the DHCP extensions to the Ethernet library
- to get an IP address via DHCP and print the address obtained.
- using an Arduino Wiznet Ethernet shield.
+  This sketch uses the DHCP extensions to the Ethernet library
+  to get an IP address via DHCP and print the address obtained.
+  using an Arduino Wiznet Ethernet shield.
 
- Circuit:
- * Ethernet shield attached to pins 10, 11, 12, 13
+  Circuit:
+   Ethernet shield attached to pins 10, 11, 12, 13
 
- created 12 April 2011
- modified 9 Apr 2012
- by Tom Igoe
+  created 12 April 2011
+  modified 9 Apr 2012
+  by Tom Igoe
+  modified 02 Sept 2015
+  by Arturo Guadalupi
 
- */
+*/
 
 #include <SPI.h>
 #include <Ethernet.h>
@@ -44,17 +46,54 @@ void setup() {
       ;
   }
   // print your local IP address:
+  printIPAddress();
+}
+
+void loop() {
+
+  switch (Ethernet.maintain())
+  {
+    case 1:
+      //renewed fail
+      Serial.println("Error: renewed fail");
+      break;
+
+    case 2:
+      //renewed success
+      Serial.println("Renewed success");
+
+      //print your local IP address:
+      printIPAddress();
+      break;
+
+    case 3:
+      //rebind fail
+      Serial.println("Error: rebind fail");
+      break;
+
+    case 4:
+      //rebind success
+      Serial.println("Rebind success");
+
+      //print your local IP address:
+      printIPAddress();
+      break;
+
+    default:
+      //nothing happened
+      break;
+
+  }
+}
+
+void printIPAddress()
+{
   Serial.print("My IP address: ");
   for (byte thisByte = 0; thisByte < 4; thisByte++) {
     // print the value of each byte of the IP address:
     Serial.print(Ethernet.localIP()[thisByte], DEC);
     Serial.print(".");
   }
+
   Serial.println();
 }
-
-void loop() {
-
-}
-
-

--- a/libraries/Ethernet/examples/DhcpChatServer/DhcpChatServer.ino
+++ b/libraries/Ethernet/examples/DhcpChatServer/DhcpChatServer.ino
@@ -14,6 +14,8 @@
  created 21 May 2011
  modified 9 Apr 2012
  by Tom Igoe
+ modified 02 Sept 2015
+ by Arturo Guadalupi
  Based on ChatServer example by David A. Mellis
 
  */
@@ -83,6 +85,7 @@ void loop() {
     server.write(thisChar);
     // echo the bytes to the server as well:
     Serial.print(thisChar);
+    Ethernet.maintain();
   }
 }
 

--- a/libraries/Ethernet/examples/UdpNtpClient/UdpNtpClient.ino
+++ b/libraries/Ethernet/examples/UdpNtpClient/UdpNtpClient.ino
@@ -11,6 +11,8 @@
  by Michael Margolis
  modified 9 Apr 2012
  by Tom Igoe
+ modified 02 Sept 2015
+ by Arturo Guadalupi
 
  This code is in the public domain.
 
@@ -103,6 +105,7 @@ void loop() {
   }
   // wait ten seconds before asking for the time again
   delay(10000);
+  Ethernet.maintain();
 }
 
 // send an NTP request to the time server at the given address

--- a/libraries/Ethernet/examples/WebServer/WebServer.ino
+++ b/libraries/Ethernet/examples/WebServer/WebServer.ino
@@ -12,6 +12,8 @@
  by David A. Mellis
  modified 9 Apr 2012
  by Tom Igoe
+ modified 02 Sept 2015
+ by Arturo Guadalupi
 
  */
 
@@ -95,6 +97,7 @@ void loop() {
     // close the connection:
     client.stop();
     Serial.println("client disconnected");
+    Ethernet.maintain();
   }
 }
 


### PR DESCRIPTION
According to #3634 I added the Ethernet.maintain to examples:
Webserver
UdpNtpClient
DhcpChatServer
DhcpAddressPrinter