### PR TITLE
Correct Ethernet.begin()

### DIFF
--- a/libraries/Ethernet/examples/AdvancedChatServer/AdvancedChatServer.ino
+++ b/libraries/Ethernet/examples/AdvancedChatServer/AdvancedChatServer.ino
@@ -41,7 +41,7 @@ EthernetClient clients[4];
 
 void setup() {
   // initialize the ethernet device
-  Ethernet.begin(mac, ip, gateway, subnet);
+  Ethernet.begin(mac, ip, gateway, gateway, subnet);
   // start listening for clients
   server.begin();
   // Open serial communications and wait for port to open:

--- a/libraries/Ethernet/examples/ChatServer/ChatServer.ino
+++ b/libraries/Ethernet/examples/ChatServer/ChatServer.ino
@@ -37,7 +37,7 @@ boolean alreadyConnected = false; // whether or not the client was connected pre
 
 void setup() {
   // initialize the ethernet device
-  Ethernet.begin(mac, ip, gateway, subnet);
+  Ethernet.begin(mac, ip, gateway, gateway, subnet);
   // start listening for clients
   server.begin();
   // Open serial communications and wait for port to open:


### PR DESCRIPTION
The correct inizialization of Ethernet.begin() is:
- Ethernet.begin(mac);
- Ethernet.begin(mac, ip);
- Ethernet.begin(mac, ip, dns);
- Ethernet.begin(mac, ip, dns, gateway);
- Ethernet.begin(mac, ip, dns, gateway, subnet);

Ethernet.begin(mac, ip, gateway, subnet); is a common mistake.
--> https://www.arduino.cc/en/Reference/EthernetBegin

Will need to change the examples in the Reference.