### PR TITLE
Add iSerial field to Native USB devices

### DIFF
--- a/hardware/arduino/avr/cores/arduino/PluggableUSB.cpp
+++ b/hardware/arduino/avr/cores/arduino/PluggableUSB.cpp
@@ -50,6 +50,15 @@ int PluggableUSB_::getDescriptor(USBSetup& setup)
 	return 0;
 }
 
+void PluggableUSB_::getShortName(char *iSerialNum)
+{
+	PluggableUSBModule* node;
+	for (node = rootNode; node; node = node->next) {
+		iSerialNum += node->getShortName(iSerialNum);
+	}
+	*iSerialNum = 0;
+}
+
 bool PluggableUSB_::setup(USBSetup& setup)
 {
 	PluggableUSBModule* node;

--- a/hardware/arduino/avr/cores/arduino/PluggableUSB.h
+++ b/hardware/arduino/avr/cores/arduino/PluggableUSB.h
@@ -35,6 +35,7 @@ protected:
   virtual bool setup(USBSetup& setup) = 0;
   virtual int getInterface(uint8_t* interfaceCount) = 0;
   virtual int getDescriptor(USBSetup& setup) = 0;
+  virtual uint8_t getShortName(char *name) { name[0] = 'A'+pluggedInterface; return 1; }
 
   uint8_t pluggedInterface;
   uint8_t pluggedEndpoint;
@@ -55,6 +56,7 @@ public:
   int getInterface(uint8_t* interfaceCount);
   int getDescriptor(USBSetup& setup);
   bool setup(USBSetup& setup);
+  void getShortName(char *iSerialNum);
 
 private:
   uint8_t lastIf;

--- a/hardware/arduino/avr/cores/arduino/USBDesc.h
+++ b/hardware/arduino/avr/cores/arduino/USBDesc.h
@@ -24,6 +24,8 @@
 #define USB_ENDPOINTS 5 // AtMegaxxU2
 #endif
 
+#define ISERIAL_MAX_LEN     20
+
 #define CDC_INTERFACE_COUNT	2
 #define CDC_ENPOINT_COUNT	3
 
@@ -39,6 +41,6 @@
 #define CDC_RX CDC_ENDPOINT_OUT
 #define CDC_TX CDC_ENDPOINT_IN
 
-#define IMANUFACTURER	1
-#define IPRODUCT		2
-
+#define IMANUFACTURER   1
+#define IPRODUCT        2
+#define ISERIAL         3

--- a/hardware/arduino/avr/libraries/HID/HID.cpp
+++ b/hardware/arduino/avr/libraries/HID/HID.cpp
@@ -57,6 +57,16 @@ int HID_::getDescriptor(USBSetup& setup)
 	return total;
 }
 
+uint8_t HID_::getShortName(char *name)
+{
+	name[0] = 'H';
+	name[1] = 'I';
+	name[2] = 'D';
+	name[3] = 'A' + (descriptorSize & 0x0F);
+	name[4] = 'A' + ((descriptorSize >> 4) & 0x0F);
+	return 5;
+}
+
 void HID_::AppendDescriptor(HIDSubDescriptor *node)
 {
 	if (!rootNode) {

--- a/hardware/arduino/avr/libraries/HID/HID.h
+++ b/hardware/arduino/avr/libraries/HID/HID.h
@@ -96,6 +96,7 @@ protected:
   int getInterface(uint8_t* interfaceCount);
   int getDescriptor(USBSetup& setup);
   bool setup(USBSetup& setup);
+  uint8_t getShortName(char* name);
 
 private:
   uint8_t epType[1];


### PR DESCRIPTION
Windows PCs always believe that an USB device with a particular triplet of VID/PID/SerialNumber will never change during its existence, thus saving the device's "nature" on the Registry. 
With the introduction of PluggableUSB, a device can change its "composition" between a sketch and another if we include different headers. But the new device does not necessarily implement all the capabilities of the one that has been saved, leading to drivers not loading etc.

To solve this problem, two different approaches where tested:
- creating a S/N based on the descriptor length (collisions still possible, less overhead)
- craft a S/N string from the pluggable modules properties (no collision, no difference between different HID submodules) (this seems better)

A call has been added (`getShortName`) and it MUST be implemented by any library based on PluggableUSB. No effect on PluggableHID-based libraries.

The patchset is composed by two patches (which will be squashed afterwards) to show the first approach on AVR (first patch)

@NicoHood  @matthijskooijman @PaulStoffregen @cmaglie 
