### PR TITLE
Expose optional DHCP timeout parameters to Ethernet::begin()

### DIFF
--- a/libraries/Ethernet/src/Ethernet.cpp
+++ b/libraries/Ethernet/src/Ethernet.cpp
@@ -8,7 +8,7 @@ uint8_t EthernetClass::_state[MAX_SOCK_NUM] = {
 uint16_t EthernetClass::_server_port[MAX_SOCK_NUM] = { 
   0, 0, 0, 0 };
 
-int EthernetClass::begin(uint8_t *mac_address)
+int EthernetClass::begin(uint8_t *mac_address, unsigned long timeout, unsigned long responseTimeout)
 {
   static DhcpClass s_dhcp;
   _dhcp = &s_dhcp;
@@ -22,7 +22,7 @@ int EthernetClass::begin(uint8_t *mac_address)
   SPI.endTransaction();
 
   // Now try to get our config info from a DHCP server
-  int ret = _dhcp->beginWithDHCP(mac_address);
+  int ret = _dhcp->beginWithDHCP(mac_address, timeout, responseTimeout);
   if(ret == 1)
   {
     // We've successfully found a DHCP server and got our configuration info, so set things

--- a/libraries/Ethernet/src/Ethernet.h
+++ b/libraries/Ethernet/src/Ethernet.h
@@ -20,7 +20,7 @@ public:
   // Initialise the Ethernet shield to use the provided MAC address and gain the rest of the
   // configuration through DHCP.
   // Returns 0 if the DHCP configuration failed, and 1 if it succeeded
-  int begin(uint8_t *mac_address);
+  int begin(uint8_t *mac_address, unsigned long timeout = 60000, unsigned long responseTimeout = 4000);
   void begin(uint8_t *mac_address, IPAddress local_ip);
   void begin(uint8_t *mac_address, IPAddress local_ip, IPAddress dns_server);
   void begin(uint8_t *mac_address, IPAddress local_ip, IPAddress dns_server, IPAddress gateway);


### PR DESCRIPTION
A no brainer update.
Exposes optional timeout parameter values of dhcp for user to adjust on
their code.
Currently if dhcp server is not available, code will block inside
DhcpClass::request_DHCP_lease() for 60s. Having this parameters exposed
user can specify their timeout requirements without changing the lib
code.
Change is backward compatible as parameters are optional and defaults to
existing values.