### PR TITLE
Remove Raw HID definitions at wrong place

### DIFF
--- a/hardware/arduino/avr/libraries/HID/HID.cpp
+++ b/hardware/arduino/avr/libraries/HID/HID.cpp
@@ -27,16 +27,7 @@ static u8 HID_ENDPOINT_INT;
 
 //================================================================================
 //================================================================================
-
-//	HID report descriptor
-
-#define LSB(_x) ((_x) & 0xFF)
-#define MSB(_x) ((_x) >> 8)
-
-#define RAWHID_USAGE_PAGE	0xFFC0
-#define RAWHID_USAGE		0x0C00
-#define RAWHID_TX_SIZE 64
-#define RAWHID_RX_SIZE 64
+//	HID Interface
 
 static u8 HID_INTERFACE;
 


### PR DESCRIPTION
Raw HID is not used. And if someone (like me) want to create a library for this he can and should define those definitions himself. This code is a leftover from the old USB-Core where the raw HID also never got used.