### PR TITLE
[PluggableHID] API simplification proposal

### DIFF
--- a/hardware/arduino/avr/libraries/HID/HID.cpp
+++ b/hardware/arduino/avr/libraries/HID/HID.cpp
@@ -61,7 +61,7 @@ int HID_GetDescriptor(int8_t t)
 		HIDDescriptorListNode* current = rootNode;
 		int total = 0;
 		while(current != NULL) {
-			total += USB_SendControl(TRANSFER_PGM,current->cb->descriptor,current->cb->length);
+			total += USB_SendControl(TRANSFER_PGM,current->descriptor->data,current->descriptor->length);
 			current = current->next;
 		}
 		return total;
@@ -82,7 +82,7 @@ void HID_::AppendDescriptor(HIDDescriptorListNode *node)
 		current->next = node;
 	}
 	modules_count++;
-	sizeof_hidReportDescriptor += (uint16_t)node->cb->length;
+	sizeof_hidReportDescriptor += (uint16_t)node->descriptor->length;
 }
 
 void HID_::SendReport(u8 id, const void* data, int len)

--- a/hardware/arduino/avr/libraries/HID/HID.cpp
+++ b/hardware/arduino/avr/libraries/HID/HID.cpp
@@ -61,7 +61,7 @@ int HID_GetDescriptor(int8_t t)
 		HIDDescriptorListNode* current = rootNode;
 		int total = 0;
 		while(current != NULL) {
-			total += USB_SendControl(TRANSFER_PGM,current->descriptor->data,current->descriptor->length);
+			total += USB_SendControl(TRANSFER_PGM,current->data,current->length);
 			current = current->next;
 		}
 		return total;
@@ -82,7 +82,7 @@ void HID_::AppendDescriptor(HIDDescriptorListNode *node)
 		current->next = node;
 	}
 	modules_count++;
-	sizeof_hidReportDescriptor += (uint16_t)node->descriptor->length;
+	sizeof_hidReportDescriptor += (uint16_t)node->length;
 }
 
 void HID_::SendReport(u8 id, const void* data, int len)

--- a/hardware/arduino/avr/libraries/HID/HID.h
+++ b/hardware/arduino/avr/libraries/HID/HID.h
@@ -44,16 +44,13 @@
 #define HID_REPORT_DESCRIPTOR_TYPE      0x22
 #define HID_PHYSICAL_DESCRIPTOR_TYPE    0x23
 
-typedef struct __attribute__((packed)) {
-  uint16_t length;
-  const void* data;
-} HID_Descriptor;
-
 class HIDDescriptorListNode {
 public:
   HIDDescriptorListNode *next = NULL;
-  const HID_Descriptor *descriptor;
-  HIDDescriptorListNode(const HID_Descriptor *d) : descriptor(d) { }
+  HIDDescriptorListNode(const void *d, uint16_t l) : data(d), length(l) { }
+
+  const void* data;
+  uint16_t length;
 };
 
 class HID_

--- a/hardware/arduino/avr/libraries/HID/HID.h
+++ b/hardware/arduino/avr/libraries/HID/HID.h
@@ -46,14 +46,14 @@
 
 typedef struct __attribute__((packed)) {
   uint16_t length;
-  const void* descriptor;
+  const void* data;
 } HID_Descriptor;
 
 class HIDDescriptorListNode {
 public:
   HIDDescriptorListNode *next = NULL;
-  const HID_Descriptor * cb;
-  HIDDescriptorListNode(const HID_Descriptor *ncb) {cb = ncb;}
+  const HID_Descriptor *descriptor;
+  HIDDescriptorListNode(const HID_Descriptor *d) : descriptor(d) { }
 };
 
 class HID_

--- a/hardware/arduino/sam/libraries/HID/HID.cpp
+++ b/hardware/arduino/sam/libraries/HID/HID.cpp
@@ -68,7 +68,7 @@ int HID_GetDescriptor(int8_t t)
 		HIDDescriptorListNode* current = rootNode;
 		int total = 0;
 		while(current != NULL) {
-			total += USBD_SendControl(0,current->cb->descriptor,current->cb->length);
+			total += USBD_SendControl(0,current->descriptor->data,current->descriptor->length);
 			current = current->next;
 		}
 		return total;
@@ -89,7 +89,7 @@ void HID_::AppendDescriptor(HIDDescriptorListNode *node)
 		current->next = node;
 	}
 	modules_count++;
-	sizeof_hidReportDescriptor += node->cb->length;
+	sizeof_hidReportDescriptor += node->descriptor->length;
 }
 
 void HID_::SendReport(uint8_t id, const void* data, int len)

--- a/hardware/arduino/sam/libraries/HID/HID.cpp
+++ b/hardware/arduino/sam/libraries/HID/HID.cpp
@@ -68,7 +68,7 @@ int HID_GetDescriptor(int8_t t)
 		HIDDescriptorListNode* current = rootNode;
 		int total = 0;
 		while(current != NULL) {
-			total += USBD_SendControl(0,current->descriptor->data,current->descriptor->length);
+			total += USBD_SendControl(0,current->data,current->length);
 			current = current->next;
 		}
 		return total;
@@ -89,7 +89,7 @@ void HID_::AppendDescriptor(HIDDescriptorListNode *node)
 		current->next = node;
 	}
 	modules_count++;
-	sizeof_hidReportDescriptor += node->descriptor->length;
+	sizeof_hidReportDescriptor += node->length;
 }
 
 void HID_::SendReport(uint8_t id, const void* data, int len)

--- a/hardware/arduino/sam/libraries/HID/HID.h
+++ b/hardware/arduino/sam/libraries/HID/HID.h
@@ -42,16 +42,12 @@
 #define HID_REPORT_DESCRIPTOR_TYPE      0x22
 #define HID_PHYSICAL_DESCRIPTOR_TYPE    0x23
 
-typedef struct __attribute__((packed)) {
-  uint8_t length;
-  const void* data;
-} HID_Descriptor;
-
 class HIDDescriptorListNode {
 public:
   HIDDescriptorListNode *next = NULL;
-  const HID_Descriptor *descriptor;
-  HIDDescriptorListNode(const HID_Descriptor *d) : descriptor(d) { }
+  HIDDescriptorListNode(const void *d, uint16_t l) : data(d), length(l) { }
+  uint8_t length;
+  const void* data;
 };
 
 class HID_

--- a/hardware/arduino/sam/libraries/HID/HID.h
+++ b/hardware/arduino/sam/libraries/HID/HID.h
@@ -44,14 +44,14 @@
 
 typedef struct __attribute__((packed)) {
   uint8_t length;
-  const void* descriptor;
+  const void* data;
 } HID_Descriptor;
 
 class HIDDescriptorListNode {
 public:
   HIDDescriptorListNode *next = NULL;
-  const HID_Descriptor * cb;
-  HIDDescriptorListNode(const HID_Descriptor *ncb) {cb = ncb;}
+  const HID_Descriptor *descriptor;
+  HIDDescriptorListNode(const HID_Descriptor *d) : descriptor(d) { }
 };
 
 class HID_

--- a/libraries/Keyboard/src/Keyboard.cpp
+++ b/libraries/Keyboard/src/Keyboard.cpp
@@ -62,11 +62,11 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
 
 Keyboard_::Keyboard_(void) 
 {
-	static HID_Descriptor cb = {
+	static HID_Descriptor descriptor = {
 		.length = sizeof(_hidReportDescriptor),
-		.descriptor = _hidReportDescriptor,
+		.data   = _hidReportDescriptor,
 	};
-	static HIDDescriptorListNode node(&cb);
+	static HIDDescriptorListNode node(&descriptor);
 	HID.AppendDescriptor(&node);
 }
 

--- a/libraries/Keyboard/src/Keyboard.cpp
+++ b/libraries/Keyboard/src/Keyboard.cpp
@@ -62,11 +62,7 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
 
 Keyboard_::Keyboard_(void) 
 {
-	static HID_Descriptor descriptor = {
-		.length = sizeof(_hidReportDescriptor),
-		.data   = _hidReportDescriptor,
-	};
-	static HIDDescriptorListNode node(&descriptor);
+	static HIDDescriptorListNode node(_hidReportDescriptor, sizeof(_hidReportDescriptor));
 	HID.AppendDescriptor(&node);
 }
 

--- a/libraries/Mouse/src/Mouse.cpp
+++ b/libraries/Mouse/src/Mouse.cpp
@@ -62,11 +62,7 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
 
 Mouse_::Mouse_(void) : _buttons(0)
 {
-    const static HID_Descriptor descriptor = {
-        .length = sizeof(_hidReportDescriptor),
-        .data   = _hidReportDescriptor,
-    };
-    static HIDDescriptorListNode node(&descriptor);
+    static HIDDescriptorListNode node(_hidReportDescriptor, sizeof(_hidReportDescriptor));
     HID.AppendDescriptor(&node);
 }
 

--- a/libraries/Mouse/src/Mouse.cpp
+++ b/libraries/Mouse/src/Mouse.cpp
@@ -62,11 +62,11 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
 
 Mouse_::Mouse_(void) : _buttons(0)
 {
-    const static HID_Descriptor cb = {
+    const static HID_Descriptor descriptor = {
         .length = sizeof(_hidReportDescriptor),
-        .descriptor = _hidReportDescriptor,
+        .data   = _hidReportDescriptor,
     };
-    static HIDDescriptorListNode node(&cb);
+    static HIDDescriptorListNode node(&descriptor);
     HID.AppendDescriptor(&node);
 }
 


### PR DESCRIPTION
Since the PluggableHID is not yet officially released maybe we could make some makeup on the API?
This is a **breaking change for the early adopters** of the Pluggable HID, but if we decide to merge it better doing it now that the library is not published.

The most ugly part for me is how the HID "modules" are defined, for example:

```C++
Keyboard_::Keyboard_(void) 
{
	static HID_Descriptor cb = {
		.length = sizeof(_hidReportDescriptor),
		.descriptor = _hidReportDescriptor,
	};
	static HIDDescriptorListNode node(&cb);
	HID.AppendDescriptor(&node);
}
```

IMHO the HID_Descriptor is a useless level of abstraction and can be eliminated.
After this PR the initialization becomes:

```C++
Mouse_::Mouse_(void) : _buttons(0)
{
    static HIDDescriptorListNode node(_hidReportDescriptor, sizeof(_hidReportDescriptor));
    HID.AppendDescriptor(&node);
}
```

This give us also a small gain in performance and in flash and ram usage as well.

/cc @NicoHood @facchinm @matthijskooijman 
