### PR TITLE
Allow per-platform keywords.txt

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -117,7 +117,7 @@ public class Base {
   private List<JMenu> boardsCustomMenus;
   private List<JMenuItem> programmerMenus;
 
-  private final PdeKeywords pdeKeywords;
+  private PdeKeywords pdeKeywords;
   private final List<JMenuItem> recentSketchesMenuItems;
 
   static public void main(String args[]) throws Exception {
@@ -1250,8 +1250,24 @@ public class Base {
     }
   }
 
+  private static String priorPlatformFolder;
+
   public void onBoardOrPortChange() {
     BaseNoGui.onBoardOrPortChange();
+
+    // reload keywords when package/platform changes
+    TargetPlatform tp = BaseNoGui.getTargetPlatform();
+    if (tp != null) {
+      String platformFolder = tp.getFolder().getAbsolutePath();
+      if (priorPlatformFolder == null || !priorPlatformFolder.equals(platformFolder)) {
+        pdeKeywords = new PdeKeywords();
+        pdeKeywords.reload();
+        priorPlatformFolder = platformFolder;
+        for (Editor editor : editors) {
+          editor.updateKeywords(pdeKeywords);
+        }
+      }
+    }
 
     // Update editors status bar
     for (Editor editor : editors) {

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -40,6 +40,7 @@ import processing.app.forms.PasswordAuthorizationDialog;
 import processing.app.helpers.OSUtils;
 import processing.app.helpers.PreferencesMapException;
 import processing.app.legacy.PApplet;
+import processing.app.syntax.PdeKeywords;
 import processing.app.syntax.ArduinoTokenMakerFactory;
 import processing.app.syntax.SketchTextArea;
 import processing.app.tools.DiscourseFormat;
@@ -1058,6 +1059,15 @@ public class Editor extends JFrame implements RunnerListener {
 
     configurePopupMenu(textArea);
     return textArea;
+  }
+
+  public void updateKeywords(PdeKeywords keywords) {
+    // update GUI for "Find In Reference"
+    textarea.setKeywords(keywords);
+    // update document for syntax highlighting
+    RSyntaxDocument document = (RSyntaxDocument) textarea.getDocument();
+    document.setTokenMakerFactory(new ArduinoTokenMakerFactory(keywords));
+    document.setSyntaxStyle(RSyntaxDocument.SYNTAX_STYLE_CPLUSPLUS);
   }
 
   private JMenuItem createToolMenuItem(String className) {

--- a/app/src/processing/app/syntax/PdeKeywords.java
+++ b/app/src/processing/app/syntax/PdeKeywords.java
@@ -31,6 +31,7 @@ import org.fife.ui.rsyntaxtextarea.TokenTypes;
 import processing.app.Base;
 import processing.app.BaseNoGui;
 import processing.app.legacy.PApplet;
+import processing.app.debug.TargetPlatform;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -84,6 +85,11 @@ public class PdeKeywords {
   public void reload() {
     try {
       parseKeywordsTxt(new File(BaseNoGui.getContentFile("lib"), "keywords.txt"));
+      TargetPlatform tp = BaseNoGui.getTargetPlatform();
+      if (tp != null) {
+        File platformKeywords = new File(tp.getFolder(), "keywords.txt");
+        if (platformKeywords.exists()) parseKeywordsTxt(platformKeywords);
+      }
       for (ContributedLibrary lib : Base.getLibraries()) {
         File keywords = new File(lib.getInstalledFolder(), "keywords.txt");
         if (keywords.exists()) {

--- a/app/src/processing/app/syntax/SketchTextArea.java
+++ b/app/src/processing/app/syntax/SketchTextArea.java
@@ -74,11 +74,16 @@ public class SketchTextArea extends RSyntaxTextArea {
 
   private EditorListener editorListener;
 
-  private final PdeKeywords pdeKeywords;
+  private PdeKeywords pdeKeywords;
 
   public SketchTextArea(PdeKeywords pdeKeywords) throws IOException {
     this.pdeKeywords = pdeKeywords;
     installFeatures();
+  }
+
+  public void setKeywords(PdeKeywords keywords) {
+    pdeKeywords = keywords;
+    setLinkGenerator(new DocLinkGenerator(pdeKeywords));
   }
 
   private void installFeatures() throws IOException {


### PR DESCRIPTION
This patch allows platforms to define an keywords.txt file, to add their unique keywords.  When a board change also changes platforms, the keywords are reloaded and all editor windows updates with the new keywords.