### PR TITLE
ability to set a stepper's rpm via float

### DIFF
--- a/libraries/Stepper/src/Stepper.cpp
+++ b/libraries/Stepper/src/Stepper.cpp
@@ -175,7 +175,7 @@ Stepper::Stepper(int number_of_steps, int motor_pin_1, int motor_pin_2,
 /*
  * Sets the speed in revs per minute
  */
-void Stepper::setSpeed(long whatSpeed)
+void Stepper::setSpeed(float whatSpeed)
 {
   this->step_delay = 60L * 1000L * 1000L / this->number_of_steps / whatSpeed;
 }

--- a/libraries/Stepper/src/Stepper.h
+++ b/libraries/Stepper/src/Stepper.h
@@ -91,7 +91,7 @@ class Stepper {
                                  int motor_pin_5);
 
     // speed setter method:
-    void setSpeed(long whatSpeed);
+    void setSpeed(float whatSpeed);
 
     // mover method:
     void step(int number_of_steps);


### PR DESCRIPTION
Stepper can currently only set rotations per minute as integer. This is not a problem for fast motors, as 1200 rpm is not much different from 1200.5 rpm. For slow motors it's a big deal.

Having no way to go slower than 1 rpm or nothing in between 1 rpm and 2 rpm means people have to resort to workarounds like setting a different (wrong) number of steps instead. To illustrate this more clearly: right now, i have to choose if a single revolution takes 60 seconds or 30 seconds or 20 seconds. There is nothing in between.

I added `setSpeed(float)` as a second signature to not break backwards compatibility.
