### PR TITLE
Fix compiler warnings in USBCore.cpp

### DIFF
--- a/hardware/arduino/avr/cores/arduino/CDC.cpp
+++ b/hardware/arduino/avr/cores/arduino/CDC.cpp
@@ -236,9 +236,11 @@ Serial_::operator bool() {
 
 unsigned long Serial_::baud() {
 	// Disable interrupts while reading a multi-byte value
+	uint32_t baudrate;
 	ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-		return _usbLineInfo.dwDTERate;
+		baudrate =  _usbLineInfo.dwDTERate;
 	}
+	return baudrate;
 }
 
 uint8_t Serial_::stopbits() {

--- a/hardware/arduino/avr/cores/arduino/Tone.cpp
+++ b/hardware/arduino/avr/cores/arduino/Tone.cpp
@@ -209,7 +209,7 @@ static int8_t toneBegin(uint8_t _pin)
         #if defined(WGM42)
           bitWrite(TCCR4B, WGM42, 1);
         #elif defined(CS43)
-          #warning this may not be correct
+          // TODO this may not be correct
           // atmega32u4
           bitWrite(TCCR4B, CS43, 1);
         #endif

--- a/hardware/arduino/avr/cores/arduino/USBCore.cpp
+++ b/hardware/arduino/avr/cores/arduino/USBCore.cpp
@@ -372,8 +372,8 @@ bool ClassInterfaceRequest(USBSetup& setup)
 	return false;
 }
 
-int _cmark;
-int _cend;
+static int _cmark;
+static int _cend;
 void InitControl(int end)
 {
 	SetEP(0);
@@ -438,7 +438,7 @@ int USB_RecvControl(void* d, int len)
 	return len;
 }
 
-int SendInterfaces()
+static u8 SendInterfaces()
 {
 	u8 interfaces = 0;
 
@@ -459,7 +459,7 @@ bool SendConfiguration(int maxlen)
 {
 	//	Count and measure interfaces
 	InitControl(0);	
-	int interfaces = SendInterfaces();
+	u8 interfaces = SendInterfaces();
 	ConfigDescriptor config = D_CONFIG(_cmark + sizeof(ConfigDescriptor),interfaces);
 
 	//	Now send them
@@ -469,7 +469,7 @@ bool SendConfiguration(int maxlen)
 	return true;
 }
 
-u8 _cdcComposite = 0;
+static u8 _cdcComposite = 0;
 
 static
 bool SendDescriptor(USBSetup& setup)

--- a/hardware/arduino/avr/cores/arduino/wiring.c
+++ b/hardware/arduino/avr/cores/arduino/wiring.c
@@ -312,8 +312,8 @@ void init()
 	sbi(TCCR2, CS22);
 #elif defined(TCCR2B) && defined(CS22)
 	sbi(TCCR2B, CS22);
-#else
-	#warning Timer 2 not finished (may not be present on this CPU)
+//#else
+	// Timer 2 not finished (may not be present on this CPU)
 #endif
 
 	// configure timer 2 for phase correct pwm (8-bit)
@@ -321,8 +321,8 @@ void init()
 	sbi(TCCR2, WGM20);
 #elif defined(TCCR2A) && defined(WGM20)
 	sbi(TCCR2A, WGM20);
-#else
-	#warning Timer 2 not finished (may not be present on this CPU)
+//#else
+	// Timer 2 not finished (may not be present on this CPU)
 #endif
 
 #if defined(TCCR3B) && defined(CS31) && defined(WGM30)

--- a/hardware/arduino/avr/cores/arduino/wiring.c
+++ b/hardware/arduino/avr/cores/arduino/wiring.c
@@ -303,8 +303,6 @@ void init()
 	// put timer 1 in 8-bit phase correct pwm mode
 #if defined(TCCR1A) && defined(WGM10)
 	sbi(TCCR1A, WGM10);
-#elif defined(TCCR1)
-	#warning this needs to be finished
 #endif
 
 	// set timer 2 prescale factor to 64


### PR DESCRIPTION
Removes a compiler warning and saves 14 bytes of flash. Also adds `static` to variables only found in the file.

As you can see an u8 value is created and returned as int, which is not needed.
If you also apply this correct u8 value to the `bool SendConfiguration(int maxlen)` function all warnings are removed and the code doesnt need an extra 2 byte return value.

Related resources to ensure all functions are u8:
https://github.com/arduino/Arduino/blob/master/hardware/arduino/avr/cores/arduino/USBCore.cpp#L457-L470
https://github.com/arduino/Arduino/blob/master/hardware/arduino/avr/cores/arduino/USBCore.cpp#L441-L452
https://github.com/arduino/Arduino/blob/master/hardware/arduino/avr/cores/arduino/USBCore.h#L146-L156
https://github.com/arduino/Arduino/blob/master/hardware/arduino/avr/cores/arduino/CDC.cpp
https://github.com/arduino/Arduino/blob/master/hardware/arduino/avr/cores/arduino/PluggableUSB.cpp