### PR TITLE
fix pulseInLong considering overflow

### DIFF
--- a/hardware/arduino/avr/cores/arduino/wiring_pulse.c
+++ b/hardware/arduino/avr/cores/arduino/wiring_pulse.c
@@ -69,22 +69,24 @@ unsigned long pulseInLong(uint8_t pin, uint8_t state, unsigned long timeout)
 	uint8_t port = digitalPinToPort(pin);
 	uint8_t stateMask = (state ? bit : 0);
 
-	unsigned long maxMicros = micros() + timeout;
+	unsigned long startMicros = micros();
 
 	// wait for any previous pulse to end
-	while ((*portInputRegister(port) & bit) == stateMask)
-		if (micros() > maxMicros)
+	while ((*portInputRegister(port) & bit) == stateMask) {
+		if (micros() - startMicros > timeout)
 			return 0;
+	}
 
 	// wait for the pulse to start
-	while ((*portInputRegister(port) & bit) != stateMask)
-		if (micros() > maxMicros)
+	while ((*portInputRegister(port) & bit) != stateMask) {
+		if (micros() - startMicros > timeout)
 			return 0;
+	}
 
 	unsigned long start = micros();
 	// wait for the pulse to stop
 	while ((*portInputRegister(port) & bit) == stateMask) {
-		if (micros() > maxMicros)
+		if (micros() - startMicros > timeout)
 			return 0;
 	}
 	return micros() - start;

--- a/hardware/arduino/sam/cores/arduino/wiring_pulse.cpp
+++ b/hardware/arduino/sam/cores/arduino/wiring_pulse.cpp
@@ -69,22 +69,24 @@ uint32_t pulseInLong(uint8_t pin, uint8_t state, unsigned long timeout)
 	uint32_t bit = p.ulPin;
 	uint32_t stateMask = state ? bit : 0;
 
-	unsigned long maxMicros = micros() + timeout;
+	unsigned long startMicros = micros();
 
 	// wait for any previous pulse to end
-	while ((p.pPort->PIO_PDSR & bit) == stateMask)
-		if (micros() > maxMicros)
+	while ((p.pPort->PIO_PDSR & bit) == stateMask) {
+		if (micros() - startMicros > timeout)
 			return 0;
+	}
 
 	// wait for the pulse to start
-	while ((p.pPort->PIO_PDSR & bit) != stateMask)
-		if (micros() > maxMicros)
+	while ((p.pPort->PIO_PDSR & bit) != stateMask) {
+		if (micros() - startMicros > timeout)
 			return 0;
+	}
 
 	unsigned long start = micros();
 	// wait for the pulse to stop
 	while ((p.pPort->PIO_PDSR & bit) == stateMask) {
-		if (micros() > maxMicros)
+		if (micros() - startMicros > timeout)
 			return 0;
 	}
 	return micros() - start;


### PR DESCRIPTION
fixes #3830

adding `__attribute__((optimize("O1")))` the total overhead is only 24 bytes (against +72 bytes with this implementation) (gcc 4.8.1)

For safety reasons this PR does not include this optimization