### PR TITLE
USB: fixed compiler warning "control reach end of non-void function"

### DIFF
--- a/hardware/arduino/avr/cores/arduino/CDC.cpp
+++ b/hardware/arduino/avr/cores/arduino/CDC.cpp
@@ -235,10 +235,12 @@ Serial_::operator bool() {
 }
 
 unsigned long Serial_::baud() {
+	unsigned long baudrate;
 	// Disable interrupts while reading a multi-byte value
 	ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-		return _usbLineInfo.dwDTERate;
+		baudrate = _usbLineInfo.dwDTERate;
 	}
+	return baudrate;
 }
 
 uint8_t Serial_::stopbits() {


### PR DESCRIPTION
If we enable all warnings, for some reason the compiler is unable to detect the atomic block as always-executed and produce a "control reach end of non-void function".

The solution is to cache the result out of the atomic block where the dataflow analisys is handled correctly.

/cc @matthijskooijman 