### PR TITLE
Fix wrong buffer read from Pluggable USB

### DIFF
--- a/hardware/arduino/avr/cores/arduino/PluggableUSB.cpp
+++ b/hardware/arduino/avr/cores/arduino/PluggableUSB.cpp
@@ -87,7 +87,7 @@ int8_t PUSB_AddFunction(PUSBListNode *node, u8* interface)
 	*interface = lastIf;
 	lastIf += node->cb->numInterfaces;
 	for ( u8 i = 0; i< node->cb->numEndpoints; i++) {
-		_initEndpoints[lastEp] = node->cb->endpointType[i];
+		_initEndpoints[lastEp] = node->cb->endpointType[1];
 		lastEp++;
 	}
 	modules_count++;


### PR DESCRIPTION
I just stumbled about this. I havent tested this, since I am reqriting the Pluggable USB.
And in my rewrite I replaced the useless pointer to a real uint8_t and noticed that this reads out of bounds, since the endpoint will always be 1 byte array and not longer.

This worked so far since Serial is not pluggable and HID the only device used.

This PR is more though as note for you, because I try to rewrite the API itself to make it even more pluggable.