### PR TITLE
Add support for repeated starts in slave mode

### DIFF
--- a/hardware/arduino/sam/libraries/Wire/Wire.cpp
+++ b/hardware/arduino/sam/libraries/Wire/Wire.cpp
@@ -321,27 +321,25 @@ void TwoWire::onService(void) {
 		}
 	}
 
-	if (status != SLAVE_IDLE) {
-		if (TWI_STATUS_TXCOMP(sr) && TWI_STATUS_EOSACC(sr)) {
-			if (status == SLAVE_RECV && onReceiveCallback) {
-				// Copy data into rxBuffer
-				// (allows to receive another packet while the
-				// user program reads actual data)
-				for (uint8_t i = 0; i < srvBufferLength; ++i)
-					rxBuffer[i] = srvBuffer[i];
-				rxBufferIndex = 0;
-				rxBufferLength = srvBufferLength;
+	if (status != SLAVE_IDLE && TWI_STATUS_EOSACC(sr)) {
+		if (status == SLAVE_RECV && onReceiveCallback) {
+			// Copy data into rxBuffer
+			// (allows to receive another packet while the
+			// user program reads actual data)
+			for (uint8_t i = 0; i < srvBufferLength; ++i)
+				rxBuffer[i] = srvBuffer[i];
+			rxBufferIndex = 0;
+			rxBufferLength = srvBufferLength;
 
-				// Alert calling program
-				onReceiveCallback( rxBufferLength);
-			}
-
-			// Transfer completed
-			TWI_EnableIt(twi, TWI_SR_SVACC);
-			TWI_DisableIt(twi, TWI_IDR_RXRDY | TWI_IDR_GACC | TWI_IDR_NACK
-					| TWI_IDR_EOSACC | TWI_IDR_SCL_WS | TWI_IER_TXCOMP);
-			status = SLAVE_IDLE;
+			// Alert calling program
+			onReceiveCallback( rxBufferLength);
 		}
+
+		// Transfer completed
+		TWI_EnableIt(twi, TWI_SR_SVACC);
+		TWI_DisableIt(twi, TWI_IDR_RXRDY | TWI_IDR_GACC | TWI_IDR_NACK
+				| TWI_IDR_EOSACC | TWI_IDR_SCL_WS | TWI_IER_TXCOMP);
+		status = SLAVE_IDLE;
 	}
 
 	if (status == SLAVE_RECV) {


### PR DESCRIPTION
From the [SAM3X Datasheet](http://www.atmel.com/Images/Atmel-11057-32-bit-Cortex-M3-Microcontroller-SAM3X-SAM3A_Datasheet.pdf) 

Section 33.11.6:
```
TXCOMP used in Slave mode:
0 = As soon as a Start is detected.
1 = After a Stop or a Repeated Start + an address different from SADR is detected.
```

With a repeated start and same address it will not be set, however EOSACC will be as shown in Figure 33-30 and 33-31.

This change removes the check for TXCOMP, and only checks for EOSACC to be set when not idle, to return back to the idle state. This enables support repeated starts for both RX and TX in slave mode.