### PR TITLE
Clean up comments in Ethernet library examples

### DIFF
--- a/libraries/Ethernet/examples/AdvancedChatServer/AdvancedChatServer.ino
+++ b/libraries/Ethernet/examples/AdvancedChatServer/AdvancedChatServer.ino
@@ -3,13 +3,12 @@
 
  A more advanced server that distributes any incoming messages
  to all connected clients but the client the message comes from.
- To use telnet to  your device's IP address and type.
+ To use, telnet to your device's IP address and type.
  You can see the client's input in the serial monitor as well.
  Using an Arduino Wiznet Ethernet shield.
 
  Circuit:
  * Ethernet shield attached to pins 10, 11, 12, 13
- * Analog inputs attached to pins A0 through A5 (optional)
 
  created 18 Dec 2009
  by David A. Mellis
@@ -41,7 +40,7 @@ EthernetServer server(23);
 EthernetClient clients[4];
 
 void setup() {
-  // initialize the ethernet device
+  // initialize the Ethernet device
   Ethernet.begin(mac, ip, myDns, gateway, subnet);
   // start listening for clients
   server.begin();
@@ -77,7 +76,7 @@ void loop() {
       for (byte i = 0; i < 4; i++) {
         if (!clients[i] && clients[i] != client) {
           clients[i] = client;
-          // clead out the input buffer:
+          // clear out the input buffer:
           client.flush();
           Serial.println("We have a new client");
           client.print("Hello, client number: ");

--- a/libraries/Ethernet/examples/BarometricPressureWebServer/BarometricPressureWebServer.ino
+++ b/libraries/Ethernet/examples/BarometricPressureWebServer/BarometricPressureWebServer.ino
@@ -26,7 +26,7 @@
 #include <SPI.h>
 
 
-// assign a MAC address for the ethernet controller.
+// assign a MAC address for the Ethernet controller.
 // fill in your address here:
 byte mac[] = {
   0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED

--- a/libraries/Ethernet/examples/ChatServer/ChatServer.ino
+++ b/libraries/Ethernet/examples/ChatServer/ChatServer.ino
@@ -1,14 +1,13 @@
 /*
- Chat  Server
+ Chat Server
 
  A simple server that distributes any incoming messages to all
- connected clients.  To use telnet to  your device's IP address and type.
+ connected clients.  To use, telnet to your device's IP address and type.
  You can see the client's input in the serial monitor as well.
  Using an Arduino Wiznet Ethernet shield.
 
  Circuit:
  * Ethernet shield attached to pins 10, 11, 12, 13
- * Analog inputs attached to pins A0 through A5 (optional)
 
  created 18 Dec 2009
  by David A. Mellis
@@ -59,7 +58,7 @@ void loop() {
   // when the client sends the first byte, say hello:
   if (client) {
     if (!alreadyConnected) {
-      // clead out the input buffer:
+      // clear out the input buffer:
       client.flush();
       Serial.println("We have a new client");
       client.println("Hello, client!");

--- a/libraries/Ethernet/examples/DhcpChatServer/DhcpChatServer.ino
+++ b/libraries/Ethernet/examples/DhcpChatServer/DhcpChatServer.ino
@@ -2,7 +2,7 @@
  DHCP Chat  Server
 
  A simple server that distributes any incoming messages to all
- connected clients.  To use telnet to  your device's IP address and type.
+ connected clients.  To use, telnet to your device's IP address and type.
  You can see the client's input in the serial monitor as well.
  Using an Arduino Wiznet Ethernet shield.
 
@@ -51,7 +51,7 @@ void setup() {
   Serial.println("Trying to get an IP address using DHCP");
   if (Ethernet.begin(mac) == 0) {
     Serial.println("Failed to configure Ethernet using DHCP");
-    // initialize the ethernet device not using DHCP:
+    // initialize the Ethernet device not using DHCP:
     Ethernet.begin(mac, ip, myDns, gateway, subnet);
   }
   // print your local IP address:

--- a/libraries/Ethernet/examples/TelnetClient/TelnetClient.ino
+++ b/libraries/Ethernet/examples/TelnetClient/TelnetClient.ino
@@ -34,7 +34,7 @@ IPAddress server(1, 1, 1, 1);
 // Initialize the Ethernet client library
 // with the IP address and port of the server
 // that you want to connect to (port 23 is default for telnet;
-// if you're using Processing's ChatServer, use  port 10002):
+// if you're using Processing's ChatServer, use port 10002):
 EthernetClient client;
 
 void setup() {

--- a/libraries/Ethernet/examples/UDPSendReceiveString/UDPSendReceiveString.ino
+++ b/libraries/Ethernet/examples/UDPSendReceiveString/UDPSendReceiveString.ino
@@ -1,5 +1,5 @@
 /*
-  UDPSendReceive.pde:
+ UDPSendReceiveString:
  This sketch receives UDP message strings, prints them to the serial port
  and sends an "acknowledge" string back to the sender
 
@@ -28,7 +28,7 @@ IPAddress ip(192, 168, 1, 177);
 unsigned int localPort = 8888;      // local port to listen on
 
 // buffers for receiving and sending data
-char packetBuffer[UDP_TX_PACKET_MAX_SIZE]; //buffer to hold incoming packet,
+char packetBuffer[UDP_TX_PACKET_MAX_SIZE];  //buffer to hold incoming packet,
 char  ReplyBuffer[] = "acknowledged";       // a string to send back
 
 // An EthernetUDP instance to let us send and receive packets over UDP
@@ -64,7 +64,7 @@ void loop() {
     Serial.println("Contents:");
     Serial.println(packetBuffer);
 
-    // send a reply, to the IP address and port that sent us the packet we received
+    // send a reply to the IP address and port that sent us the packet we received
     Udp.beginPacket(Udp.remoteIP(), Udp.remotePort());
     Udp.write(ReplyBuffer);
     Udp.endPacket();

--- a/libraries/Ethernet/examples/UdpNtpClient/UdpNtpClient.ino
+++ b/libraries/Ethernet/examples/UdpNtpClient/UdpNtpClient.ino
@@ -66,8 +66,8 @@ void loop() {
     // We've received a packet, read the data from it
     Udp.read(packetBuffer, NTP_PACKET_SIZE); // read the packet into the buffer
 
-    //the timestamp starts at byte 40 of the received packet and is four bytes,
-    // or two words, long. First, esxtract the two words:
+    // the timestamp starts at byte 40 of the received packet and is four bytes,
+    // or two words, long. First, extract the two words:
 
     unsigned long highWord = word(packetBuffer[40], packetBuffer[41]);
     unsigned long lowWord = word(packetBuffer[42], packetBuffer[43]);

--- a/libraries/Ethernet/examples/WebClient/WebClient.ino
+++ b/libraries/Ethernet/examples/WebClient/WebClient.ino
@@ -43,7 +43,6 @@ void setup() {
   // start the Ethernet connection:
   if (Ethernet.begin(mac) == 0) {
     Serial.println("Failed to configure Ethernet using DHCP");
-    // no point in carrying on, so do nothing forevermore:
     // try to congifure using IP address instead of DHCP:
     Ethernet.begin(mac, ip);
   }
@@ -60,7 +59,7 @@ void setup() {
     client.println("Connection: close");
     client.println();
   } else {
-    // kf you didn't get a connection to the server:
+    // if you didn't get a connection to the server:
     Serial.println("connection failed");
   }
 }


### PR DESCRIPTION
- Fix typos and formatting.
- Remove analog inputs part of Circuit comment in ChatServer and
AdvancedChatServer. The examples don't use these analog inputs.