### PR TITLE
Port Scheduler library to Arduino Zero.

### DIFF
--- a/libraries/Scheduler/library.properties
+++ b/libraries/Scheduler/library.properties
@@ -1,9 +1,9 @@
 name=Scheduler
-version=0.4.3
+version=0.4.4
 author=Arduino
 maintainer=Arduino <info@arduino.cc>
-sentence=Allows multiple tasks to run at the same time, without interrupting each other. For Arduino DUE only.
-paragraph=The Scheduler library enables the Arduino Due to run multiple functions at the same time. This allows tasks to happen without interrupting each other.</br>This is a cooperative scheduler in that the CPU switches from one task to another. The library includes methods for passing control between tasks.
+sentence=Allows multiple tasks to run at the same time, without interrupting each other. For Arduino sam and samd architectures only (Due, Zero...).
+paragraph=The Scheduler library enables the Arduino to run multiple functions at the same time. This allows tasks to happen without interrupting each other.</br>This is a cooperative scheduler in that the CPU switches from one task to another. The library includes methods for passing control between tasks.
 category=Other
 url=http://www.arduino.cc/en/Reference/Scheduler
-architectures=sam
+architectures=sam,samd


### PR DESCRIPTION
The library from the Due does not work as is on the Zero because it loads and stores the processor state using ldmia/stmia. On cortex m0, these instructions only work with the 'low' registers (r0-r7).

I made an implementation that loads the registers in the low registers first, and then moves them into the high regs.
Tested with MultipleBlink sketch.
Some feedback review on the code is desirable.
See [forum](http://forum.arduino.cc/index.php?topic=352408.0)