### PR TITLE
[PluggableUSB] rename two class

### DIFF
--- a/hardware/arduino/avr/cores/arduino/PluggableUSB.cpp
+++ b/hardware/arduino/avr/cores/arduino/PluggableUSB.cpp
@@ -28,7 +28,7 @@ extern uint8_t _initEndpoints[];
 int PluggableUSB_::getInterface(uint8_t* interfaceCount)
 {
 	int sent = 0;
-	PUSBListNode* node;
+	PluggableUSBModule* node;
 	for (node = rootNode; node; node = node->next) {
 		int res = node->getInterface(interfaceCount);
 		if (res < 0)
@@ -40,7 +40,7 @@ int PluggableUSB_::getInterface(uint8_t* interfaceCount)
 
 int PluggableUSB_::getDescriptor(USBSetup& setup)
 {
-	PUSBListNode* node;
+	PluggableUSBModule* node;
 	for (node = rootNode; node; node = node->next) {
 		int ret = node->getDescriptor(setup);
 		// ret!=0 -> request has been processed
@@ -52,7 +52,7 @@ int PluggableUSB_::getDescriptor(USBSetup& setup)
 
 bool PluggableUSB_::setup(USBSetup& setup)
 {
-	PUSBListNode* node;
+	PluggableUSBModule* node;
 	for (node = rootNode; node; node = node->next) {
 		if (node->setup(setup)) {
 			return true;
@@ -61,7 +61,7 @@ bool PluggableUSB_::setup(USBSetup& setup)
 	return false;
 }
 
-bool PluggableUSB_::plug(PUSBListNode *node)
+bool PluggableUSB_::plug(PluggableUSBModule *node)
 {
 	if ((lastEp + node->numEndpoints) > USB_ENDPOINTS) {
 		return false;
@@ -70,7 +70,7 @@ bool PluggableUSB_::plug(PUSBListNode *node)
 	if (!rootNode) {
 		rootNode = node;
 	} else {
-		PUSBListNode *current = rootNode;
+		PluggableUSBModule *current = rootNode;
 		while (current->next) {
 			current = current->next;
 		}

--- a/hardware/arduino/avr/cores/arduino/PluggableUSB.h
+++ b/hardware/arduino/avr/cores/arduino/PluggableUSB.h
@@ -25,9 +25,9 @@
 
 #if defined(USBCON)
 
-class PUSBListNode {
+class PluggableUSBModule {
 public:
-  PUSBListNode(uint8_t numEps, uint8_t numIfs, uint8_t *epType) :
+  PluggableUSBModule(uint8_t numEps, uint8_t numIfs, uint8_t *epType) :
     numEndpoints(numEps), numInterfaces(numIfs), endpointType(epType)
   { }
 
@@ -43,7 +43,7 @@ protected:
   const uint8_t numInterfaces;
   const uint8_t *endpointType;
 
-  PUSBListNode *next = NULL;
+  PluggableUSBModule *next = NULL;
 
   friend class PluggableUSB_;
 };
@@ -51,7 +51,7 @@ protected:
 class PluggableUSB_ {
 public:
   PluggableUSB_();
-  bool plug(PUSBListNode *node);
+  bool plug(PluggableUSBModule *node);
   int getInterface(uint8_t* interfaceCount);
   int getDescriptor(USBSetup& setup);
   bool setup(USBSetup& setup);
@@ -59,7 +59,7 @@ public:
 private:
   uint8_t lastIf;
   uint8_t lastEp;
-  PUSBListNode* rootNode;
+  PluggableUSBModule* rootNode;
 };
 
 // Replacement for global singleton.

--- a/hardware/arduino/avr/libraries/HID/HID.cpp
+++ b/hardware/arduino/avr/libraries/HID/HID.cpp
@@ -128,7 +128,7 @@ bool HID_::setup(USBSetup& setup)
 	return false;
 }
 
-HID_::HID_(void) : PUSBListNode(1, 1, epType),
+HID_::HID_(void) : PluggableUSBModule(1, 1, epType),
                    rootNode(NULL), descriptorSize(0),
                    protocol(1), idle(1)
 {

--- a/hardware/arduino/avr/libraries/HID/HID.cpp
+++ b/hardware/arduino/avr/libraries/HID/HID.cpp
@@ -47,7 +47,7 @@ int HID_::getDescriptor(USBSetup& setup)
 	if (setup.wIndex != pluggedInterface) { return 0; }
 
 	int total = 0;
-	HIDDescriptorListNode* node;
+	HIDSubDescriptor* node;
 	for (node = rootNode; node; node = node->next) {
 		int res = USB_SendControl(TRANSFER_PGM, node->data, node->length);
 		if (res == -1)
@@ -57,12 +57,12 @@ int HID_::getDescriptor(USBSetup& setup)
 	return total;
 }
 
-void HID_::AppendDescriptor(HIDDescriptorListNode *node)
+void HID_::AppendDescriptor(HIDSubDescriptor *node)
 {
 	if (!rootNode) {
 		rootNode = node;
 	} else {
-		HIDDescriptorListNode *current = rootNode;
+		HIDSubDescriptor *current = rootNode;
 		while (current->next) {
 			current = current->next;
 		}

--- a/hardware/arduino/avr/libraries/HID/HID.h
+++ b/hardware/arduino/avr/libraries/HID/HID.h
@@ -83,7 +83,7 @@ public:
   const uint16_t length;
 };
 
-class HID_ : public PUSBListNode
+class HID_ : public PluggableUSBModule
 {
 public:
   HID_(void);
@@ -92,7 +92,7 @@ public:
   void AppendDescriptor(HIDDescriptorListNode* node);
 
 protected:
-  // Implementation of the PUSBListNode
+  // Implementation of the PluggableUSBModule
   int getInterface(uint8_t* interfaceCount);
   int getDescriptor(USBSetup& setup);
   bool setup(USBSetup& setup);

--- a/hardware/arduino/avr/libraries/HID/HID.h
+++ b/hardware/arduino/avr/libraries/HID/HID.h
@@ -74,10 +74,10 @@ typedef struct
   EndpointDescriptor  in;
 } HIDDescriptor;
 
-class HIDDescriptorListNode {
+class HIDSubDescriptor {
 public:
-  HIDDescriptorListNode *next = NULL;
-  HIDDescriptorListNode(const void *d, const uint16_t l) : data(d), length(l) { }
+  HIDSubDescriptor *next = NULL;
+  HIDSubDescriptor(const void *d, const uint16_t l) : data(d), length(l) { }
 
   const void* data;
   const uint16_t length;
@@ -89,7 +89,7 @@ public:
   HID_(void);
   int begin(void);
   void SendReport(uint8_t id, const void* data, int len);
-  void AppendDescriptor(HIDDescriptorListNode* node);
+  void AppendDescriptor(HIDSubDescriptor* node);
 
 protected:
   // Implementation of the PluggableUSBModule
@@ -100,7 +100,7 @@ protected:
 private:
   uint8_t epType[1];
 
-  HIDDescriptorListNode* rootNode;
+  HIDSubDescriptor* rootNode;
   uint16_t descriptorSize;
 
   uint8_t protocol;

--- a/libraries/Keyboard/src/Keyboard.cpp
+++ b/libraries/Keyboard/src/Keyboard.cpp
@@ -62,7 +62,7 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
 
 Keyboard_::Keyboard_(void) 
 {
-	static HIDDescriptorListNode node(_hidReportDescriptor, sizeof(_hidReportDescriptor));
+	static HIDSubDescriptor node(_hidReportDescriptor, sizeof(_hidReportDescriptor));
 	HID().AppendDescriptor(&node);
 }
 

--- a/libraries/Mouse/src/Mouse.cpp
+++ b/libraries/Mouse/src/Mouse.cpp
@@ -62,7 +62,7 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
 
 Mouse_::Mouse_(void) : _buttons(0)
 {
-    static HIDDescriptorListNode node(_hidReportDescriptor, sizeof(_hidReportDescriptor));
+    static HIDSubDescriptor node(_hidReportDescriptor, sizeof(_hidReportDescriptor));
     HID().AppendDescriptor(&node);
 }
 


### PR DESCRIPTION
As discussed here #3931 this pull request renames:

* PUSBListNode to PluggableUSBModule
* HIDDescriptorListNode to HIDSubDescriptor

These changes are final and close the PUSB API for the first release.

/cc @NicoHood @facchinm 