### PR TITLE
[PHID] Fixes protocol on reenumeration

### DIFF
--- a/hardware/arduino/avr/libraries/HID/HID.cpp
+++ b/hardware/arduino/avr/libraries/HID/HID.cpp
@@ -54,6 +54,11 @@ int HID_::getDescriptor(USBSetup& setup)
 			return -1;
 		total += res;
 	}
+	
+	// Reset the protocol on reenumeration. Normally the host should not assume the state of the protocol
+	// due to the USB specs, but Windows and Linux just assumes its in report mode.
+	protocol = HID_REPORT_PROTOCOL;
+	
 	return total;
 }
 
@@ -130,7 +135,7 @@ bool HID_::setup(USBSetup& setup)
 
 HID_::HID_(void) : PluggableUSBModule(1, 1, epType),
                    rootNode(NULL), descriptorSize(0),
-                   protocol(1), idle(1)
+                   protocol(HID_REPORT_PROTOCOL), idle(1)
 {
 	epType[0] = EP_TYPE_INTERRUPT_IN;
 	PluggableUSB().plug(this);


### PR DESCRIPTION
Additional notes:

The USB Core should also made more disconnect proof. If the device suddenly disconnects the usb might hang forever. Other bugs occur at reenumeration. This is mostly a problem if you power the Arduino from external power/battery.

This PR makes "no sense/use" at all since the get protocol is not implemented. But since we have the variable, we should at least correct this bug or fully remove it. If you fully remove it I suggest to comment the lines to let others know that this feature should exist. I'd vote for implementing the get request so its fully usb compatible. Send8() must then be placed inside some header file.

Just for debugging reasons here a small debug output on reenumeration:
```
Start
[cold start, plugging in now]
getI
getI
getI
getI
Set
SI
0
GetD
Set
SR
0
Set
SR
1

[replugging]

getI
getI
getI
getI
Set
SI
0
GetD
Set
SR
0
Set
SR
1
```

```cpp
/*
Copyright (c) 2014-2015 NicoHood
See the readme for credit to other people.

Permission is hereby granted, free of charge, to any person obtaining a copy
of this software and associated documentation files (the "Software"), to deal
in the Software without restriction, including without limitation the rights
to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
copies of the Software, and to permit persons to whom the Software is
furnished to do so, subject to the following conditions:

The above copyright notice and this permission notice shall be included in
all copies or substantial portions of the Software.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
THE SOFTWARE.
*/

#include "BootKeyboard.h"

static const uint8_t _hidReportDescriptorKeyboard[] PROGMEM = {
    //  Keyboard
    0x05, 0x01,                      /* USAGE_PAGE (Generic Desktop)	  47 */
    0x09, 0x06,                      /* USAGE (Keyboard) */
    0xa1, 0x01,                      /* COLLECTION (Application) */
    0x05, 0x07,                      /*   USAGE_PAGE (Keyboard) */

    /* Keyboard Modifiers (shift, alt, ...) */
    0x19, 0xe0,                      /*   USAGE_MINIMUM (Keyboard LeftControl) */
    0x29, 0xe7,                      /*   USAGE_MAXIMUM (Keyboard Right GUI) */
    0x15, 0x00,                      /*   LOGICAL_MINIMUM (0) */
    0x25, 0x01,                      /*   LOGICAL_MAXIMUM (1) */
    0x75, 0x01,                      /*   REPORT_SIZE (1) */
	0x95, 0x08,                      /*   REPORT_COUNT (8) */
    0x81, 0x02,                      /*   INPUT (Data,Var,Abs) */

    /* Reserved byte TODO consumer and or system */
    0x95, 0x01,                      /*   REPORT_COUNT (1) */
    0x75, 0x08,                      /*   REPORT_SIZE (8) */
    0x81, 0x03,                      /*   INPUT (Cnst,Var,Abs) */

	/* 5 LEDs for num lock etc, 3 left for advanced, custom usage */
	0x05, 0x08,						 /*   USAGE_PAGE (LEDs) */
	0x19, 0x01,						 /*   USAGE_MINIMUM (Num Lock) */
	0x29, 0x05,						 /*   USAGE_MAXIMUM (Kana) TODO*/
	0x95, 0x08,						 /*   REPORT_COUNT (8) */
	0x75, 0x01,						 /*   REPORT_SIZE (1) */
	0x91, 0x02,						 /*   OUTPUT (Data,Var,Abs) */
	/*  Reserved 3 bits TODO */
	//0x95, 0x01,						 /*   REPORT_COUNT (1) */
	//0x75, 0x03,						 /*   REPORT_SIZE (3) */
	//0x91, 0x03,						 /*   OUTPUT (Cnst,Var,Abs) */

    /* 6 Keyboard keys */
    0x95, 0x06,                      /*   REPORT_COUNT (6) */
    0x75, 0x08,                      /*   REPORT_SIZE (8) */
    0x15, 0x00,                      /*   LOGICAL_MINIMUM (0) */
    0x26, 0xE7, 0x00,                /*   LOGICAL_MAXIMUM (231) */
    0x05, 0x07,                      /*   USAGE_PAGE (Keyboard) */
    0x19, 0x00,                      /*   USAGE_MINIMUM (Reserved (no event indicated)) */
    0x29, 0xE7,                      /*   USAGE_MAXIMUM (Keyboard Right GUI) */
    0x81, 0x00,                      /*   INPUT (Data,Ary,Abs) */

    /* End */
    0xc0                            /* END_COLLECTION */
};

BootKeyboard_::BootKeyboard_(void) : PluggableUSBModule(1, 1, epType), protocol(1), idle(1), leds(0)
{
	epType[0] = EP_TYPE_INTERRUPT_IN;
	PluggableUSB().plug(this);
}

int BootKeyboard_::getInterface(uint8_t* interfaceCount)
{
Serial1.println("getI");
	*interfaceCount += 1; // uses 1
	HIDDescriptor hidInterface = {
		D_INTERFACE(pluggedInterface, 1, USB_DEVICE_CLASS_HUMAN_INTERFACE, HID_SUBCLASS_BOOT_INTERFACE, HID_PROTOCOL_KEYBOARD),
		D_HIDREPORT(sizeof(_hidReportDescriptorKeyboard)),
		D_ENDPOINT(USB_ENDPOINT_IN(pluggedEndpoint), USB_ENDPOINT_TYPE_INTERRUPT, USB_EP_SIZE, 0x01)
	};
	return USB_SendControl(0, &hidInterface, sizeof(hidInterface));
}

int BootKeyboard_::getDescriptor(USBSetup& setup)
{
	// Check if this is a HID Class Descriptor request
	if (setup.bmRequestType != REQUEST_DEVICETOHOST_STANDARD_INTERFACE) { return 0; }
	if (setup.wValueH != HID_REPORT_DESCRIPTOR_TYPE) { return 0; }

	// In a HID Class Descriptor wIndex cointains the interface number
	if (setup.wIndex != pluggedInterface) { return 0; }
Serial1.println("GetD");
	return USB_SendControl(TRANSFER_PGM, _hidReportDescriptorKeyboard, sizeof(_hidReportDescriptorKeyboard));
}

bool BootKeyboard_::setup(USBSetup& setup)
{
	if (pluggedInterface != setup.wIndex) {
		return false;
	}
Serial1.println("Set");
	uint8_t request = setup.bRequest;
	uint8_t requestType = setup.bmRequestType;

	if (requestType == REQUEST_DEVICETOHOST_CLASS_INTERFACE)
	{
		if (request == HID_GET_REPORT) {
			// TODO: HID_GetReport();
			Serial1.println("GR");
			return true;
		}
		if (request == HID_GET_PROTOCOL) {
		Serial1.println("GP");
			UEDATX = protocol;
			return true;
		}
		if (request == HID_GET_IDLE) {
		Serial1.println("GI");
			UEDATX = idle;
			return true;
		}
	}

	if (requestType == REQUEST_HOSTTODEVICE_CLASS_INTERFACE)
	{
		if (request == HID_SET_PROTOCOL) {
		Serial1.println("SP");
		Serial1.println(setup.wValueL);
			protocol = setup.wValueL;
			return true;
		}
		if (request == HID_SET_IDLE) {
		Serial1.println("SI");
		Serial1.println(setup.wValueL);
			idle = setup.wValueL;
			return true;
		}
		if (request == HID_SET_REPORT)
		{
		Serial1.println("SR");
			// Check if data has the correct length
			auto length = setup.wLength;
			if(length == sizeof(leds)){
				USB_RecvControl(&leds, length);
				Serial1.println(leds, HEX);
			}
		}
	}

	return false;
}

uint8_t BootKeyboard_::getLeds(void){
    return leds;
}

uint8_t BootKeyboard_::getProtocol(void){
    return protocol;
}

void BootKeyboard_::SendReport(void* data, int length){
	USB_Send(pluggedEndpoint | TRANSFER_RELEASE, data, length);
}

BootKeyboard_ BootKeyboard;


```