### PR TITLE
Allow spaces in IDE install path on Linux

### DIFF
--- a/build/linux/dist/arduino
+++ b/build/linux/dist/arduino
@@ -3,9 +3,9 @@
 APPDIR="$(dirname -- "$(readlink -f -- "${0}")" )"
 
 for LIB in \
-    $APPDIR/java/lib/rt.jar \
-    $APPDIR/java/lib/tools.jar \
-    $APPDIR/lib/*.jar \
+    "$APPDIR"/java/lib/rt.jar \
+    "$APPDIR"/java/lib/tools.jar \
+    "$APPDIR"/lib/*.jar \
     ;
 do
     CLASSPATH="${CLASSPATH}:${LIB}"
@@ -17,18 +17,19 @@ export LD_LIBRARY_PATH
 
 export PATH="${APPDIR}/java/bin:${PATH}"
 
-if [[ "$@" == *"--upload"* || "$@" == *"--verify"* || "$@" == *"--get-pref"* || "$@" == *"--install-board"* || "$@" == *"--install-library"* ]] ; then
-	SPLASH=""
-else
-	SPLASH="-splash:$APPDIR/lib/splash.png"
-fi
-
 export JAVA_TOOL_OPTIONS=`echo $JAVA_TOOL_OPTIONS | sed 's|-javaagent:/usr/share/java/jayatanaag.jar||g'`
 
 JAVA=java
-if [ -x $APPDIR/java/bin/java ]; then
+if [ -x "$APPDIR/java/bin/java" ]; then
   JAVA=$APPDIR/java/bin/java
 fi
 
-$JAVA -DAPP_DIR="$APPDIR" -Dswing.defaultlaf=com.sun.java.swing.plaf.gtk.GTKLookAndFeel $SPLASH processing.app.Base "$@"
+# Collect options to java in an array, to properly handle whitespace in options
+JAVA_OPTIONS=("-DAPP_DIR=$APPDIR" "-Dswing.defaultlaf=com.sun.java.swing.plaf.gtk.GTKLookAndFeel")
+
+if [[ "$@" != *"--upload"* && "$@" != *"--verify"* && "$@" != *"--get-pref"* && "$@" != *"--install-board"* && "$@" != *"--install-library"* ]] ; then
+	JAVA_OPTIONS+=("-splash:$APPDIR/lib/splash.png")
+fi
+
+$JAVA "${JAVA_OPTIONS[@]}" processing.app.Base "$@"
 


### PR DESCRIPTION
The startup bash script lacked quotes in some places, causing it to
interpret part of the path to the splash image as the main class and
fail to start:

arduino: line 29: [: /home/a/Arduino: binary operator expected
Error: Could not find or load main class IDE.lib.splash.png

For the -splash option, simply adding quotes was not sufficient. If no
splash screen was to be used (so when $SPLASH was empty), using
"$SPLASH" would result in an empty argument being passed to java, which
was then interpreted by java as the name of the base class.

To allow spaces to occur in the -splash option, but also allow it to be
omitted entirely, options to java are now passed through the
$JAVA_OPTIONS array. By using the special "${JAVA_OPTIONS[@]}" syntax,
each element in the array is expanded into a single argument, even when
spaces are present inside (this is identical to what happens with "$@").

This fixes #3950