### PR TITLE
Mouse and Keyboard are supported on the Micro

### DIFF
--- a/arduino-core/src/cc/arduino/Compiler.java
+++ b/arduino-core/src/cc/arduino/Compiler.java
@@ -549,12 +549,12 @@ public class Compiler implements MessageConsumer {
       }
 
       if (error.trim().equals("'Mouse' was not declared in this scope")) {
-        error = tr("'Mouse' only supported on the Arduino Leonardo");
+        error = tr("'Mouse' only supported on the Arduino Leonardo, Micro and other ATmega32U4 based devices");
         //msg = _("\nThe 'Mouse' class is only supported on the Arduino Leonardo.\n\n");
       }
 
       if (error.trim().equals("'Keyboard' was not declared in this scope")) {
-        error = tr("'Keyboard' only supported on the Arduino Leonardo");
+        error = tr("'Keyboard' only supported on the Arduino Leonardo, Micro and other ATmega3U4 based devices");
         //msg = _("\nThe 'Keyboard' class is only supported on the Arduino Leonardo.\n\n");
       }
 


### PR DESCRIPTION
The new Mouse and Keyboard error messages were inaccurate and misleading.

I'm thrilled that we're now warning users when they try to make a non-32u4 into a HID device. But we shouldn't steer them only toward one specific board when there are multiple totally legitimate official Arduino/Genuino boards that will work.