### PR TITLE
Simplify some examples

### DIFF
--- a/build/shared/examples/02.Digital/BlinkWithoutDelay/BlinkWithoutDelay.ino
+++ b/build/shared/examples/02.Digital/BlinkWithoutDelay/BlinkWithoutDelay.ino
@@ -54,11 +54,7 @@ void loop() {
     previousMillis = currentMillis;
 
     // if the LED is off turn it on and vice-versa:
-    if (ledState == LOW) {
-      ledState = HIGH;
-    } else {
-      ledState = LOW;
-    }
+    ledState ^= HIGH;
 
     // set the LED with the ledState of the variable:
     digitalWrite(ledPin, ledState);

--- a/build/shared/examples/02.Digital/Button/Button.ino
+++ b/build/shared/examples/02.Digital/Button/Button.ino
@@ -29,9 +29,6 @@
 const int buttonPin = 2;     // the number of the pushbutton pin
 const int ledPin =  13;      // the number of the LED pin
 
-// variables will change:
-int buttonState = 0;         // variable for reading the pushbutton status
-
 void setup() {
   // initialize the LED pin as an output:
   pinMode(ledPin, OUTPUT);
@@ -40,16 +37,6 @@ void setup() {
 }
 
 void loop() {
-  // read the state of the pushbutton value:
-  buttonState = digitalRead(buttonPin);
-
-  // check if the pushbutton is pressed.
-  // if it is, the buttonState is HIGH:
-  if (buttonState == HIGH) {
-    // turn LED on:
-    digitalWrite(ledPin, HIGH);
-  } else {
-    // turn LED off:
-    digitalWrite(ledPin, LOW);
-  }
+  // If the button is pressed, light up the LED:
+  digitalWrite(ledPin, digitalRead(buttonPin);
 }

--- a/build/shared/examples/02.Digital/DigitalInputPullup/DigitalInputPullup.ino
+++ b/build/shared/examples/02.Digital/DigitalInputPullup/DigitalInputPullup.ino
@@ -40,11 +40,7 @@ void loop() {
   // logic is inverted. It goes HIGH when it's open,
   // and LOW when it's pressed. Turn on pin 13 when the
   // button's pressed, and off when it's not:
-  if (sensorVal == HIGH) {
-    digitalWrite(13, LOW);
-  } else {
-    digitalWrite(13, HIGH);
-  }
+  digitalWrite(13, !sensorVal);
 }
 
 

--- a/build/shared/examples/02.Digital/StateChangeDetection/StateChangeDetection.ino
+++ b/build/shared/examples/02.Digital/StateChangeDetection/StateChangeDetection.ino
@@ -75,12 +75,7 @@ void loop() {
   // checking the modulo of the button push counter.
   // the modulo function gives you the remainder of
   // the division of two numbers:
-  if (buttonPushCounter % 4 == 0) {
-    digitalWrite(ledPin, HIGH);
-  } else {
-    digitalWrite(ledPin, LOW);
-  }
-
+  digitalWrite(ledPin, buttonPushCounter % 4 == 0);
 }
 
 


### PR DESCRIPTION
I noticed that some of the examples could have been written in a more concise way. This made them easier to read and shorter.

The general trend that I noticed was this:
```
if(variable==HIGH)
    digitalWrite(pin,HIGH);
else
   digitalWrite(pin,LOW);
```

Why not just do this instead:
```
digitalWrite(pin,variable);
```
 
