### PR TITLE
SD library: Declare path parameter on all functions as `const`

### DIFF
--- a/libraries/SD/src/SD.cpp
+++ b/libraries/SD/src/SD.cpp
@@ -58,7 +58,7 @@ namespace SDLib {
 #define MAX_COMPONENT_LEN 12 // What is max length?
 #define PATH_COMPONENT_BUFFER_LEN MAX_COMPONENT_LEN+1
 
-bool getNextPathComponent(char *path, unsigned int *p_offset,
+bool getNextPathComponent(const char *path, unsigned int *p_offset,
 			  char *buffer) {
   /*
 
@@ -117,9 +117,9 @@ bool getNextPathComponent(char *path, unsigned int *p_offset,
 
 
 
-boolean walkPath(char *filepath, SdFile& parentDir,
+boolean walkPath(const char *filepath, SdFile& parentDir,
 		 boolean (*callback)(SdFile& parentDir,
-				     char *filePathComponent,
+				     const char *filePathComponent,
 				     boolean isLastComponent,
 				     void *object),
 		 void *object = NULL) {
@@ -232,7 +232,7 @@ boolean walkPath(char *filepath, SdFile& parentDir,
 
  */
 
-boolean callback_pathExists(SdFile& parentDir, char *filePathComponent, 
+boolean callback_pathExists(SdFile& parentDir, const char *filePathComponent, 
 			    boolean isLastComponent, void *object) {
   /*
 
@@ -255,7 +255,7 @@ boolean callback_pathExists(SdFile& parentDir, char *filePathComponent,
 
 
 
-boolean callback_makeDirPath(SdFile& parentDir, char *filePathComponent, 
+boolean callback_makeDirPath(SdFile& parentDir, const char *filePathComponent, 
 			     boolean isLastComponent, void *object) {
   /*
 
@@ -310,7 +310,7 @@ boolean callback_openPath(SdFile& parentDir, char *filePathComponent,
 
 
 
-boolean callback_remove(SdFile& parentDir, char *filePathComponent, 
+boolean callback_remove(SdFile& parentDir, const char *filePathComponent, 
 			boolean isLastComponent, void *object) {
   if (isLastComponent) {
     return SdFile::remove(parentDir, filePathComponent);
@@ -318,7 +318,7 @@ boolean callback_remove(SdFile& parentDir, char *filePathComponent,
   return true;
 }
 
-boolean callback_rmdir(SdFile& parentDir, char *filePathComponent, 
+boolean callback_rmdir(SdFile& parentDir, const char *filePathComponent, 
 			boolean isLastComponent, void *object) {
   if (isLastComponent) {
     SdFile f;
@@ -517,7 +517,7 @@ File SDClass::open(char *filepath, uint8_t mode) {
 //}
 
 
-boolean SDClass::exists(char *filepath) {
+boolean SDClass::exists(const char *filepath) {
   /*
 
      Returns true if the supplied file path exists.
@@ -538,7 +538,7 @@ boolean SDClass::exists(char *filepath) {
 //}
 
 
-boolean SDClass::mkdir(char *filepath) {
+boolean SDClass::mkdir(const char *filepath) {
   /*
   
     Makes a single directory or a heirarchy of directories.
@@ -549,7 +549,7 @@ boolean SDClass::mkdir(char *filepath) {
   return walkPath(filepath, root, callback_makeDirPath);
 }
 
-boolean SDClass::rmdir(char *filepath) {
+boolean SDClass::rmdir(const char *filepath) {
   /*
   
     Remove a single directory or a heirarchy of directories.
@@ -560,7 +560,7 @@ boolean SDClass::rmdir(char *filepath) {
   return walkPath(filepath, root, callback_rmdir);
 }
 
-boolean SDClass::remove(char *filepath) {
+boolean SDClass::remove(const char *filepath) {
   return walkPath(filepath, root, callback_remove);
 }
 

--- a/libraries/SD/src/SD.h
+++ b/libraries/SD/src/SD.h
@@ -76,19 +76,19 @@ public:
   File open(const String &filename, uint8_t mode = FILE_READ) { return open( filename.c_str(), mode ); }
 
   // Methods to determine if the requested file path exists.
-  boolean exists(char *filepath);
+  boolean exists(const char *filepath);
   boolean exists(const String &filepath) { return exists(filepath.c_str()); }
 
   // Create the requested directory heirarchy--if intermediate directories
   // do not exist they will be created.
-  boolean mkdir(char *filepath);
+  boolean mkdir(const char *filepath);
   boolean mkdir(const String &filepath) { return mkdir(filepath.c_str()); }
   
   // Delete the file.
-  boolean remove(char *filepath);
+  boolean remove(const char *filepath);
   boolean remove(const String &filepath) { return remove(filepath.c_str()); }
   
-  boolean rmdir(char *filepath);
+  boolean rmdir(const char *filepath);
   boolean rmdir(const String &filepath) { return rmdir(filepath.c_str()); }
 
 private:
@@ -101,7 +101,7 @@ private:
   int fileOpenMode;
   
   friend class File;
-  friend boolean callback_openPath(SdFile&, char *, boolean, void *); 
+  friend boolean callback_openPath(SdFile&, const char *, boolean, void *); 
 };
 
 extern SDClass SD;


### PR DESCRIPTION
This way we will avoid some warnings when using paths as constants in #define's.

For example:

```c++
#define MY_FILE "file.txt"
SD.exists(MY_FILE);
```

Raises this warning using the `-Wwrite-string` option of compiler:
`warning: deprecated conversion from string constant to 'char*'`

After adding those `const`, this warning desappears.

Existing code is not affected by these minor changes in any case.