### PR TITLE
SystemProfilerParse fix for OSX El Capitan

### DIFF
--- a/app/test/processing/app/macosx/SystemProfilerParserTest.java
+++ b/app/test/processing/app/macosx/SystemProfilerParserTest.java
@@ -74,6 +74,10 @@ public class SystemProfilerParserTest {
 
     output = getFileContent("system_profiler_output8.txt");
     assertEquals("0X03EB_0X2157", extractVIDAndPID(output, "/dev/tty.usbmodemfd132"));
+
+    // OSX El Capitan
+    output = getFileContent("system_profiler_output9.txt");
+    assertEquals("0X2341_0X8036", extractVIDAndPID(output, "/dev/tty.usbmodemFA121"));
   }
 
   private String getFileContent(String filename) throws IOException {

--- a/app/test/processing/app/macosx/SystemProfilerParserTest.java
+++ b/app/test/processing/app/macosx/SystemProfilerParserTest.java
@@ -33,50 +33,51 @@ import org.junit.Test;
 import processing.app.TestHelper;
 
 import static org.junit.Assert.assertEquals;
+import static processing.app.macosx.SystemProfilerParser.extractVIDAndPID;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 public class SystemProfilerParserTest {
 
   @Test
   public void shouldCorrectlyParse() throws Exception {
-    String output = TestHelper.inputStreamToString(SystemProfilerParserTest.class.getResourceAsStream("system_profiler_output.txt"));
+    String output = getFileContent("system_profiler_output.txt");
+    assertEquals("0X2341_0X0044", extractVIDAndPID(output, "/dev/cu.usbmodemfa121"));
+    assertEquals("0X2341_0X0044", extractVIDAndPID(output, "/dev/tty.usbmodemfa121"));
 
-    assertEquals("0X2341_0X0044", new SystemProfilerParser().extractVIDAndPID(output, "/dev/cu.usbmodemfa121"));
-    assertEquals("0X2341_0X0044", new SystemProfilerParser().extractVIDAndPID(output, "/dev/tty.usbmodemfa121"));
+    output = getFileContent("system_profiler_output2.txt");
+    assertEquals("0X2341_0X8036", extractVIDAndPID(output, "/dev/cu.usbmodemfd131"));
+    assertEquals("0X2341_0X8036", extractVIDAndPID(output, "/dev/tty.usbmodemfd131"));
 
-    output = TestHelper.inputStreamToString(SystemProfilerParserTest.class.getResourceAsStream("system_profiler_output2.txt"));
+    output = getFileContent("system_profiler_output3.txt");
+    assertEquals("0X2341_0X8041", extractVIDAndPID(output, "/dev/cu.usbmodemfd121"));
+    assertEquals("0X2341_0X8041", extractVIDAndPID(output, "/dev/tty.usbmodemfd121"));
 
-    assertEquals("0X2341_0X8036", new SystemProfilerParser().extractVIDAndPID(output, "/dev/cu.usbmodemfd131"));
-    assertEquals("0X2341_0X8036", new SystemProfilerParser().extractVIDAndPID(output, "/dev/tty.usbmodemfd131"));
+    output = getFileContent("system_profiler_output4.txt");
+    assertEquals("0X2341_0X0041", extractVIDAndPID(output, "/dev/cu.usbmodem411"));
+    assertEquals("0X2341_0X0041", extractVIDAndPID(output, "/dev/tty.usbmodem411"));
 
-    output = TestHelper.inputStreamToString(SystemProfilerParserTest.class.getResourceAsStream("system_profiler_output3.txt"));
+    output = getFileContent("system_profiler_output5.txt");
+    assertEquals("0X2341_0X8041", extractVIDAndPID(output, "/dev/cu.usbmodem621"));
+    assertEquals("0X2341_0X8041", extractVIDAndPID(output, "/dev/tty.usbmodem621"));
 
-    assertEquals("0X2341_0X8041", new SystemProfilerParser().extractVIDAndPID(output, "/dev/cu.usbmodemfd121"));
-    assertEquals("0X2341_0X8041", new SystemProfilerParser().extractVIDAndPID(output, "/dev/tty.usbmodemfd121"));
+    output = getFileContent("system_profiler_output6.txt");
+    assertEquals("0X2341_0X8041", extractVIDAndPID(output, "/dev/cu.usbmodem1421"));
+    assertEquals("0X2341_0X8041", extractVIDAndPID(output, "/dev/tty.usbmodem1421"));
 
-    output = TestHelper.inputStreamToString(SystemProfilerParserTest.class.getResourceAsStream("system_profiler_output4.txt"));
+    output = getFileContent("system_profiler_output7.txt");
+    assertEquals("0X2341_0X8036", extractVIDAndPID(output, "/dev/cu.usbmodem24131"));
+    assertEquals("0X2341_0X8036", extractVIDAndPID(output, "/dev/tty.usbmodem24131"));
+    assertEquals("0X0403_0X6015", extractVIDAndPID(output, "/dev/cu.usbserial-DN0031EV"));
+    assertEquals("0X0403_0X6015", extractVIDAndPID(output, "/dev/tty.usbserial-DN0031EV"));
 
-    assertEquals("0X2341_0X0041", new SystemProfilerParser().extractVIDAndPID(output, "/dev/cu.usbmodem411"));
-    assertEquals("0X2341_0X0041", new SystemProfilerParser().extractVIDAndPID(output, "/dev/tty.usbmodem411"));
+    output = getFileContent("system_profiler_output8.txt");
+    assertEquals("0X03EB_0X2157", extractVIDAndPID(output, "/dev/tty.usbmodemfd132"));
+  }
 
-    output = TestHelper.inputStreamToString(SystemProfilerParserTest.class.getResourceAsStream("system_profiler_output5.txt"));
-
-    assertEquals("0X2341_0X8041", new SystemProfilerParser().extractVIDAndPID(output, "/dev/cu.usbmodem621"));
-    assertEquals("0X2341_0X8041", new SystemProfilerParser().extractVIDAndPID(output, "/dev/tty.usbmodem621"));
-
-    output = TestHelper.inputStreamToString(SystemProfilerParserTest.class.getResourceAsStream("system_profiler_output6.txt"));
-
-    assertEquals("0X2341_0X8041", new SystemProfilerParser().extractVIDAndPID(output, "/dev/cu.usbmodem1421"));
-    assertEquals("0X2341_0X8041", new SystemProfilerParser().extractVIDAndPID(output, "/dev/tty.usbmodem1421"));
-
-    output = TestHelper.inputStreamToString(SystemProfilerParserTest.class.getResourceAsStream("system_profiler_output7.txt"));
-
-    assertEquals("0X2341_0X8036", new SystemProfilerParser().extractVIDAndPID(output, "/dev/cu.usbmodem24131"));
-    assertEquals("0X2341_0X8036", new SystemProfilerParser().extractVIDAndPID(output, "/dev/tty.usbmodem24131"));
-    assertEquals("0X0403_0X6015", new SystemProfilerParser().extractVIDAndPID(output, "/dev/cu.usbserial-DN0031EV"));
-    assertEquals("0X0403_0X6015", new SystemProfilerParser().extractVIDAndPID(output, "/dev/tty.usbserial-DN0031EV"));
-
-    output = TestHelper.inputStreamToString(SystemProfilerParserTest.class.getResourceAsStream("system_profiler_output8.txt"));
-
-    assertEquals("0X03EB_0X2157", new SystemProfilerParser().extractVIDAndPID(output, "/dev/tty.usbmodemfd132"));
+  private String getFileContent(String filename) throws IOException {
+    InputStream resource = SystemProfilerParserTest.class.getResourceAsStream(filename);
+    return TestHelper.inputStreamToString(resource);
   }
 }

--- a/app/test/processing/app/macosx/system_profiler_output9.txt
+++ b/app/test/processing/app/macosx/system_profiler_output9.txt
@@ -1,0 +1,117 @@
+USB:
+
+    USB 2.0 Bus:
+
+      Host Controller Driver: AppleUSBEHCIPCI
+      PCI Device ID: 0x1c2d 
+      PCI Revision ID: 0x0005 
+      PCI Vendor ID: 0x8086 
+
+        Hub:
+
+          Product ID: 0x2513
+          Vendor ID: 0x0424  (SMSC)
+          Version: b.b3
+          Speed: Up to 480 Mb/sec
+          Location ID: 0xfa100000 / 1
+          Current Available (mA): 1000
+          Current Required (mA): 2
+          Extra Operating Current (mA): 0
+          Built-In: Yes
+
+            Arduino Leonardo:
+
+              Product ID: 0x8036
+              Vendor ID: 0x2341
+              Version: 1.00
+              Speed: Up to 12 Mb/sec
+              Manufacturer: Arduino LLC
+              Location ID: 0xfa120000 / 3
+              Current Available (mA): 1000
+              Current Required (mA): 500
+              Extra Operating Current (mA): 0
+
+            BRCM20702 Hub:
+
+              Product ID: 0x4500
+              Vendor ID: 0x0a5c  (Broadcom Corp.)
+              Version: 1.00
+              Speed: Up to 12 Mb/sec
+              Manufacturer: Apple Inc.
+              Location ID: 0xfa110000 / 4
+              Current Available (mA): 1000
+              Current Required (mA): 94
+              Extra Operating Current (mA): 0
+              Built-In: Yes
+
+                Bluetooth USB Host Controller:
+
+                  Product ID: 0x8281
+                  Vendor ID: 0x05ac  (Apple Inc.)
+                  Version: 1.51
+                  Speed: Up to 12 Mb/sec
+                  Manufacturer: Apple Inc.
+                  Location ID: 0xfa113000 / 2
+                  Current Available (mA): 1000
+                  Current Required (mA): 0
+                  Extra Operating Current (mA): 0
+                  Built-In: Yes
+
+    USB 2.0 Bus:
+
+      Host Controller Driver: AppleUSBEHCIPCI
+      PCI Device ID: 0x1c26 
+      PCI Revision ID: 0x0005 
+      PCI Vendor ID: 0x8086 
+
+        Hub:
+
+          Product ID: 0x2513
+          Vendor ID: 0x0424  (SMSC)
+          Version: b.b3
+          Speed: Up to 480 Mb/sec
+          Location ID: 0xfd100000 / 1
+          Current Available (mA): 1000
+          Current Required (mA): 2
+          Extra Operating Current (mA): 0
+          Built-In: Yes
+
+            USB Keyboard:
+
+              Product ID: 0x2000
+              Vendor ID: 0x040b  (Weltrend Semiconductor)
+              Version: 2.05
+              Speed: Up to 1.5 Mb/sec
+              Manufacturer: Generic
+              Location ID: 0xfd130000 / 4
+              Current Available (mA): 1000
+              Current Required (mA): 100
+              Extra Operating Current (mA): 0
+
+            USB OPTICAL MOUSE:
+
+              Product ID: 0x2510
+              Vendor ID: 0x093a  (Pixart Imaging, Inc.)
+              Version: 1.00
+              Speed: Up to 1.5 Mb/sec
+              Manufacturer: PIXART
+              Location ID: 0xfd120000 / 3
+              Current Available (mA): 1000
+              Current Required (mA): 100
+              Extra Operating Current (mA): 0
+
+            IR Receiver:
+
+              Product ID: 0x8242
+              Vendor ID: 0x05ac  (Apple Inc.)
+              Version: 0.16
+              Speed: Up to 1.5 Mb/sec
+              Manufacturer: Apple Computer, Inc.
+              Location ID: 0xfd110000 / 2
+              Current Available (mA): 1000
+              Current Required (mA): 100
+              Extra Operating Current (mA): 0
+              Built-In: Yes
+
+
+

--- a/arduino-core/src/processing/app/macosx/Platform.java
+++ b/arduino-core/src/processing/app/macosx/Platform.java
@@ -172,7 +172,7 @@ public class Platform extends processing.app.Platform {
     }
 
     try {
-      String vidPid = new SystemProfilerParser().extractVIDAndPID(devicesListOutput, serial);
+      String vidPid = SystemProfilerParser.extractVIDAndPID(devicesListOutput, serial);
 
       if (vidPid == null) {
         return super.resolveDeviceAttachedTo(serial, packages, devicesListOutput);

--- a/arduino-core/src/processing/app/macosx/SystemProfilerParser.java
+++ b/arduino-core/src/processing/app/macosx/SystemProfilerParser.java
@@ -19,19 +19,12 @@ public class SystemProfilerParser {
   private static final String DEV_TTY_USBMODEM = "/dev/tty.usbmodem";
   private static final String DEV_CU_USBMODEM = "/dev/cu.usbmodem";
 
-  private final Pattern vidRegex;
-  private final Pattern serialNumberRegex;
-  private final Pattern locationRegex;
-  private final Pattern pidRegex;
+  private static final Pattern serialNumberRegex = Pattern.compile("^Serial Number: (.+)$");
+  private static final Pattern locationRegex = Pattern.compile("^Location ID: (.+)$");
+  private static final Pattern pidRegex = Pattern.compile("^Product ID: (.+)$");
+  private static final Pattern vidRegex = Pattern.compile("^Vendor ID: (.+)$");
 
-  public SystemProfilerParser() {
-    this.serialNumberRegex = Pattern.compile("^Serial Number: (.+)$");
-    this.locationRegex = Pattern.compile("^Location ID: (.+)$");
-    this.pidRegex = Pattern.compile("^Product ID: (.+)$");
-    this.vidRegex = Pattern.compile("^Vendor ID: (.+)$");
-  }
-
-  public String extractVIDAndPID(String output, String serial) throws IOException {
+  public synchronized static String extractVIDAndPID(String output, String serial) throws IOException {
     BufferedReader reader = new BufferedReader(new StringReader(output));
 
     String devicePrefix;

--- a/arduino-core/src/processing/app/macosx/SystemProfilerParser.java
+++ b/arduino-core/src/processing/app/macosx/SystemProfilerParser.java
@@ -73,7 +73,7 @@ public class SystemProfilerParser {
           String computedDevicePath = device.get(DEVICE_PATH);
           String computedDevicePathMinusChar = computedDevicePath.substring(0, computedDevicePath.length() - 1);
           String serialMinusChar = serial.substring(0, serial.length() - 1);
-          if (computedDevicePath.equals(serial) || computedDevicePathMinusChar.equals(serialMinusChar)) {
+          if (computedDevicePath.equalsIgnoreCase(serial) || computedDevicePathMinusChar.equalsIgnoreCase(serialMinusChar)) {
             return (device.get(VID) + "_" + device.get(PID)).toUpperCase();
           }
         }


### PR DESCRIPTION
This PR contains:

- a small refactoring of SystemProfilerParser class
- a fix for serial port detection for OSX El Capitan

should alleviate #3928.
/cc @facchinm 
