### PR TITLE
Added return value to HID SendReport

### DIFF
--- a/hardware/arduino/avr/libraries/HID/HID.cpp
+++ b/hardware/arduino/avr/libraries/HID/HID.cpp
@@ -88,10 +88,11 @@ void HID_::AppendDescriptor(HIDSubDescriptor *node)
 
 int HID_::SendReport(uint8_t id, const void* data, int len)
 {
-    int ret = 0;
-	ret += USB_Send(pluggedEndpoint, &id, 1);
-	ret += USB_Send(pluggedEndpoint | TRANSFER_RELEASE, data, len);
-	return ret;
+    auto ret = USB_Send(pluggedEndpoint, &id, 1);
+    if(ret >= 0){
+        ret += USB_Send(pluggedEndpoint | TRANSFER_RELEASE, data, len);
+    }
+    return ret;
 }
 
 bool HID_::setup(USBSetup& setup)

--- a/hardware/arduino/avr/libraries/HID/HID.cpp
+++ b/hardware/arduino/avr/libraries/HID/HID.cpp
@@ -86,10 +86,12 @@ void HID_::AppendDescriptor(HIDSubDescriptor *node)
 	descriptorSize += node->length;
 }
 
-void HID_::SendReport(uint8_t id, const void* data, int len)
+int HID_::SendReport(uint8_t id, const void* data, int len)
 {
-	USB_Send(pluggedEndpoint, &id, 1);
-	USB_Send(pluggedEndpoint | TRANSFER_RELEASE, data, len);
+    int ret = 0;
+	ret += USB_Send(pluggedEndpoint, &id, 1);
+	ret += USB_Send(pluggedEndpoint | TRANSFER_RELEASE, data, len);
+	return ret;
 }
 
 bool HID_::setup(USBSetup& setup)

--- a/hardware/arduino/avr/libraries/HID/HID.h
+++ b/hardware/arduino/avr/libraries/HID/HID.h
@@ -88,7 +88,7 @@ class HID_ : public PluggableUSBModule
 public:
   HID_(void);
   int begin(void);
-  void SendReport(uint8_t id, const void* data, int len);
+  int SendReport(uint8_t id, const void* data, int len);
   void AppendDescriptor(HIDSubDescriptor* node);
 
 protected:


### PR DESCRIPTION
This is required for a good API to check if the send failed or not (e.g. device disconnected from USB to not block with waiting for timeouts).