### PR TITLE
Extend Usb recv control + some HID definitions

### DIFF
--- a/hardware/arduino/avr/cores/arduino/USBCore.cpp
+++ b/hardware/arduino/avr/cores/arduino/USBCore.cpp
@@ -425,13 +425,24 @@ static bool USB_SendStringDescriptor(const u8*string_P, u8 string_len, uint8_t f
 }
 
 //	Does not timeout or cross fifo boundaries
-//	Will only work for transfers <= 64 bytes
-//	TODO
 int USB_RecvControl(void* d, int len)
 {
-	WaitOUT();
-	Recv((u8*)d,len);
-	ClearOUT();
+	auto length = len;
+	while(length)
+	{
+		// Dont receive more than the USB Control EP has to offer
+		// Use fixed 64 because control EP always have 64 bytes even on 16u2.
+		auto recvLength = length;
+		if(recvLength > 64){
+			recvLength = 64;
+		}
+
+		// Write data to fit to the end (not the beginning) of the array
+		WaitOUT();
+		Recv((u8*)d + len - length, recvLength);
+		ClearOUT();
+		length -= recvLength;
+	}
 	return len;
 }
 

--- a/hardware/arduino/avr/libraries/HID/HID.h
+++ b/hardware/arduino/avr/libraries/HID/HID.h
@@ -54,6 +54,11 @@
 #define HID_BOOT_PROTOCOL	0
 #define HID_REPORT_PROTOCOL	1
 
+// HID Request Type HID1.11 Page 51 7.2.1 Get_Report Request
+#define HID_REPORT_TYPE_INPUT   1
+#define HID_REPORT_TYPE_OUTPUT  2
+#define HID_REPORT_TYPE_FEATURE 3
+
 typedef struct
 {
   uint8_t len;      // 9


### PR DESCRIPTION
In order to implement some fancy feature/out requests/reports I need to read more than 64 bytes from the control pipe. I could work around this to implement this in my own library, but since this was marked as TODO why not add it? There is still no timeout in the function, expecting the user is knowing what he is doing.

The HID definitions are required to differentiate between those 3 types.

FYI:
You can abuse a Keyboard this way under linux, that it works almost like a raw hid device, just passive. Meaning you can send data from the PC and request data. You just cannot active send data. not idea about windows though. With consumer keys in the reserved byte and bios compatibility the Keyboard gets REALLY powerful now. Just different keylayouts are missing yet.
https://github.com/NicoHood/HID/commit/a8c292a7bd08b30a6d26183ee28ca73b53c0363a
https://github.com/NicoHood/HID/commit/0487754e109a9f45ad671927544f1861e6dffb07
(Hyperion patch is not published yet, but it doesnt require much. You can use this as quick and reliable ambilight!)

However we should really consider to renew the USB Core API this time. If you really want to use some basic functions, they are a) not visible via .h file, only via .cpp file or b) not useful/unclear. Any chance to see some updates here?

@cmaglie @facchinm 