### PR TITLE
Track if a USB ZLP is needed on flush

### DIFF
--- a/hardware/arduino/avr/cores/arduino/USBCore.cpp
+++ b/hardware/arduino/avr/cores/arduino/USBCore.cpp
@@ -302,9 +302,15 @@ int USB_Send(u8 ep, const void* d, int len)
 				while (n--)
 					Send8(*data++);
 			}
-			_sendZlp[ep & USB_ENDPOINTS_MASK] = !ReadWriteAllowed() && (len == 0);
-			if (!ReadWriteAllowed() || ((len == 0) && (ep & TRANSFER_RELEASE)))	// Release full buffer
+			_sendZlp[ep & USB_ENDPOINTS_MASK] = !ReadWriteAllowed() && (len == 0) && !(ep & TRANSFER_RELEASE);
+
+			if (!ReadWriteAllowed())	// Release full buffer
 				ReleaseTX();
+
+			if ((len == 0) && (ep & TRANSFER_RELEASE)) {
+				while(!ReadWriteAllowed());
+				ReleaseTX();
+			}
 		}
 	}
 	TXLED1;					// light the TX LED

--- a/hardware/arduino/avr/cores/arduino/USBCore.cpp
+++ b/hardware/arduino/avr/cores/arduino/USBCore.cpp
@@ -204,7 +204,7 @@ public:
 	LockEP(u8 ep) : _sreg(SREG)
 	{
 		cli();
-		SetEP(ep & 7);
+		SetEP(ep & USB_ENDPOINTS_MASK);
 	}
 	~LockEP()
 	{

--- a/hardware/arduino/avr/cores/arduino/USBDesc.h
+++ b/hardware/arduino/avr/cores/arduino/USBDesc.h
@@ -23,6 +23,7 @@
 #else
 #define USB_ENDPOINTS 5 // AtMegaxxU2
 #endif
+#define USB_ENDPOINTS_MASK 7
 
 #define ISERIAL_MAX_LEN     20
 


### PR DESCRIPTION
Resolves #3946. This patch tracks if a USB ZLP (zero length packet) is needed to flush data.

A ZLP is needed to indicate end of transfer, if the size of data sent is a multiple of ```USB_EP_SIZE``` (64 bytes on AVR).

If a ZLP is needed, ```USB_Flush``` waits for the current endpoint's FIFO bank to be available before doing a release.