### PR TITLE
Send a ZLP if data size is multiple of the endpoint size for USB sends in SAM core

### DIFF
--- a/hardware/arduino/sam/cores/arduino/USB/USBCore.cpp
+++ b/hardware/arduino/sam/cores/arduino/USB/USBCore.cpp
@@ -195,6 +195,7 @@ uint32_t USBD_Send(uint32_t ep, const void* d, uint32_t len)
 {
     uint32_t n;
 	int r = len;
+	uint32_t epSize = (ep==0) ? EP0_SIZE : EPX_SIZE;
 	const uint8_t* data = (const uint8_t*)d;
 
     if (!_usbConfiguration)
@@ -205,8 +206,7 @@ uint32_t USBD_Send(uint32_t ep, const void* d, uint32_t len)
 
 	while (len)
 	{
-        if(ep==0) n = EP0_SIZE;
-        else n =  EPX_SIZE;
+		n = epSize;
 		if (n > len)
 			n = len;
 		len -= n;

--- a/hardware/arduino/sam/cores/arduino/USB/USBCore.cpp
+++ b/hardware/arduino/sam/cores/arduino/USB/USBCore.cpp
@@ -214,6 +214,10 @@ uint32_t USBD_Send(uint32_t ep, const void* d, uint32_t len)
 		UDD_Send(ep & 0xF, data, n);
 		data += n;
     }
+
+	if ((r != 0) && (r % epSize) == 0)
+		UDD_Send(ep & 0xF, NULL, 0);
+
 	//TXLED1;					// light the TX LED
 	//TxLEDPulse = TX_RX_LED_PULSE_MS;
 	return r;


### PR DESCRIPTION
Resolves #3946 for SAM/Due.

**Note**: The CDC endpoint size on SAM is 512 bytes (not 64 bytes).
