### PR TITLE
Check TXEMPTY flag instead of TXRDY flag on Serial.flush()

### DIFF
--- a/hardware/arduino/sam/cores/arduino/UARTClass.cpp
+++ b/hardware/arduino/sam/cores/arduino/UARTClass.cpp
@@ -138,7 +138,7 @@ void UARTClass::flush( void )
 {
   while (_tx_buffer->_iHead != _tx_buffer->_iTail); //wait for transmit data to be sent
   // Wait for transmission to complete
-  while ((_pUart->UART_SR & UART_SR_TXRDY) != UART_SR_TXRDY)
+  while ((_pUart->UART_SR & UART_SR_TXEMPTY) != UART_SR_TXEMPTY)
    ;
 }
 


### PR DESCRIPTION
As suggested by @borisff in #4128.

From section "34.5.3.3 Transmitter Control" in the SAM3 data sheet:

> When both the Shift Register and UART_THR are empty, i.e., all the characters written in UART_THR have been processed, the TXEMPTY bit rises after the last stop bit has been completed.