### PR TITLE
Added SerialUSB alias for Serial on 32u4 boards

### DIFF
--- a/build/shared/revisions.txt
+++ b/build/shared/revisions.txt
@@ -15,6 +15,7 @@ ARDUINO 1.6.7
 
 [core]
 * Fixed wrong timings for HardwareSerial::flush() in SAM core. Thanks @borisff
+* Leonardo/Micro (and other atmega32u4 based boards) now have SerialUSB alias for Serial
 
 ARDUINO 1.6.6 - 2015.11.03
 

--- a/hardware/arduino/avr/variants/leonardo/pins_arduino.h
+++ b/hardware/arduino/avr/variants/leonardo/pins_arduino.h
@@ -356,4 +356,7 @@ const uint8_t PROGMEM analog_pin_to_channel_PGM[] = {
 #define SERIAL_PORT_HARDWARE       Serial1
 #define SERIAL_PORT_HARDWARE_OPEN  Serial1
 
+// Alias SerialUSB to Serial
+#define SerialUSB SERIAL_PORT_USBVIRTUAL
+
 #endif /* Pins_Arduino_h */


### PR DESCRIPTION
Allows the use of `SerialUSB` on Micro/Leonardo and other 32u4 derivatives.

`SerialUSB` doesn't replace but is added as an alias of `Serial`.
