### PR TITLE
eeprom_clear example: Set pinMode of LED pin

### DIFF
--- a/hardware/arduino/avr/libraries/EEPROM/examples/eeprom_clear/eeprom_clear.ino
+++ b/hardware/arduino/avr/libraries/EEPROM/examples/eeprom_clear/eeprom_clear.ino
@@ -11,7 +11,9 @@
 #include <EEPROM.h>
 
 void setup() {
-
+  // initialize the LED pin as an output.
+  pinMode(13, OUTPUT);
+  
   /***
     Iterate through each byte of the EEPROM storage.
 


### PR DESCRIPTION
This was originally reported in https://github.com/arduino/Arduino/issues/1054 and was closed by @shfitz who states in the [Google Code issue](https://code.google.com/p/arduino/issues/detail?id=1054) that the example was updated but the GitHub commit history shows no evidence this ever happened.

Reported at: http://forum.arduino.cc/index.php?topic=361650.0