### PR TITLE
Remove unused keywords from Wire libraries keywords.txt

### DIFF
--- a/hardware/arduino/avr/libraries/Wire/keywords.txt
+++ b/hardware/arduino/avr/libraries/Wire/keywords.txt
@@ -15,8 +15,6 @@ setClock	KEYWORD2
 beginTransmission	KEYWORD2
 endTransmission	KEYWORD2
 requestFrom	KEYWORD2
-send	KEYWORD2
-receive	KEYWORD2
 onReceive	KEYWORD2
 onRequest	KEYWORD2
 

--- a/hardware/arduino/sam/libraries/Wire/keywords.txt
+++ b/hardware/arduino/sam/libraries/Wire/keywords.txt
@@ -15,8 +15,6 @@ setClock	KEYWORD2
 beginTransmission	KEYWORD2
 endTransmission	KEYWORD2
 requestFrom	KEYWORD2
-send	KEYWORD2
-receive	KEYWORD2
 onReceive	KEYWORD2
 onRequest	KEYWORD2
 


### PR DESCRIPTION
These functions have been replaced by read() and write() since Arduino
1.0.