### PR TITLE
Added callback support for USB host suspend/wake

### DIFF
--- a/hardware/arduino/avr/cores/arduino/USBAPI.h
+++ b/hardware/arduino/avr/cores/arduino/USBAPI.h
@@ -55,6 +55,8 @@ typedef unsigned long u32;
 #define EP_TYPE_ISOCHRONOUS_IN		((1<<EPTYPE0) | (1<<EPDIR))
 #define EP_TYPE_ISOCHRONOUS_OUT		(1<<EPTYPE0)
 
+typedef void (*usbDeviceCallBack)();
+
 class USBDevice_
 {
 public:
@@ -65,6 +67,10 @@ public:
 	void detach();	// Serial port goes down too...
 	void poll();
 	bool wakeupHost(); // returns false, when wakeup cannot be processed
+
+	void setWakeUpHandler(usbDeviceCallBack delegate);
+	void setSuspendHandler(usbDeviceCallBack delegate);
+	bool isSuspended();
 };
 extern USBDevice_ USBDevice;
 

--- a/hardware/arduino/avr/cores/arduino/USBCore.cpp
+++ b/hardware/arduino/avr/cores/arduino/USBCore.cpp
@@ -1,19 +1,19 @@
 
 
-/* Copyright (c) 2010, Peter Barrett  
-**  
-** Permission to use, copy, modify, and/or distribute this software for  
-** any purpose with or without fee is hereby granted, provided that the  
-** above copyright notice and this permission notice appear in all copies.  
-** 
-** THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL  
-** WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED  
-** WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR  
-** BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES  
-** OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,  
-** WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,  
-** ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS  
-** SOFTWARE.  
+/* Copyright (c) 2010, Peter Barrett
+**
+** Permission to use, copy, modify, and/or distribute this software for
+** any purpose with or without fee is hereby granted, provided that the
+** above copyright notice and this permission notice appear in all copies.
+**
+** THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+** WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+** WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+** BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+** OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+** WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+** ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+** SOFTWARE.
 */
 
 #include "USBAPI.h"
@@ -82,6 +82,9 @@ volatile u8 _usbConfiguration = 0;
 volatile u8 _usbCurrentStatus = 0; // meaning of bits see usb_20.pdf, Figure 9-4. Information Returned by a GetStatus() Request to a Device
 volatile u8 _usbSuspendState = 0; // copy of UDINT to check SUSPI and WAKEUPI bits
 
+volatile usbDeviceCallBack usbWakeUpDelegate;
+volatile usbDeviceCallBack usbSuspendDelegate;
+
 static inline void WaitIN(void)
 {
 	while (!(UEINTX & (1<<TXINI)))
@@ -115,9 +118,9 @@ static inline void Recv(volatile u8* data, u8 count)
 {
 	while (count--)
 		*data++ = UEDATX;
-	
+
 	RXLED1;					// light the RX LED
-	RxLEDPulse = TX_RX_LED_PULSE_MS;	
+	RxLEDPulse = TX_RX_LED_PULSE_MS;
 }
 
 static inline u8 Recv8()
@@ -125,7 +128,7 @@ static inline u8 Recv8()
 	RXLED1;					// light the RX LED
 	RxLEDPulse = TX_RX_LED_PULSE_MS;
 
-	return UEDATX;	
+	return UEDATX;
 }
 
 static inline void Send8(u8 d)
@@ -225,7 +228,7 @@ int USB_Recv(u8 ep, void* d, int len)
 {
 	if (!_usbConfiguration || len < 0)
 		return -1;
-	
+
 	LockEP lock(ep);
 	u8 n = FifoByteCount();
 	len = min(n,len);
@@ -235,7 +238,7 @@ int USB_Recv(u8 ep, void* d, int len)
 		*dst++ = Recv8();
 	if (len && !FifoByteCount())	// release empty buffer
 		ReleaseRX();
-	
+
 	return len;
 }
 
@@ -312,7 +315,7 @@ int USB_Send(u8 ep, const void* d, int len)
 u8 _initEndpoints[USB_ENDPOINTS] =
 {
 	0,                      // Control Endpoint
-	
+
 	EP_TYPE_INTERRUPT_IN,   // CDC_ENDPOINT_ACM
 	EP_TYPE_BULK_OUT,       // CDC_ENDPOINT_OUT
 	EP_TYPE_BULK_IN,        // CDC_ENDPOINT_IN
@@ -455,7 +458,7 @@ static
 bool SendConfiguration(int maxlen)
 {
 	//	Count and measure interfaces
-	InitControl(0);	
+	InitControl(0);
 	u8 interfaces = SendInterfaces();
 	ConfigDescriptor config = D_CONFIG(_cmark + sizeof(ConfigDescriptor),interfaces);
 
@@ -733,7 +736,7 @@ ISR(USB_GEN_vect)
 	if (udint & (1<<SOFI))
 	{
 		USB_Flush(CDC_TX);				// Send a tx frame if found
-		
+
 		// check whether the one-shot period has elapsed.  if so, turn off the LED
 		if (TxLEDPulse && !(--TxLEDPulse))
 			TXLED0;
@@ -753,6 +756,12 @@ ISR(USB_GEN_vect)
 		//USB_ClockEnable();
 		UDINT &= ~(1<<WAKEUPI);
 		_usbSuspendState = (_usbSuspendState & ~(1<<SUSPI)) | (1<<WAKEUPI);
+
+		if(usbWakeUpDelegate)
+		{
+			usbWakeUpDelegate();
+		}
+
 	}
 	else if (udint & (1<<SUSPI)) // only one of the WAKEUPI / SUSPI bits can be active at time
 	{
@@ -763,6 +772,11 @@ ISR(USB_GEN_vect)
 
 		UDINT &= ~((1<<WAKEUPI) | (1<<SUSPI)); // clear any already pending WAKEUP IRQs and the SUSPI request
 		_usbSuspendState = (_usbSuspendState & ~(1<<WAKEUPI)) | (1<<SUSPI);
+
+		if(usbSuspendDelegate)
+		{
+			usbSuspendDelegate();
+		}
 	}
 }
 
@@ -793,7 +807,7 @@ void USBDevice_::attach()
 
 	UDINT &= ~((1<<WAKEUPI) | (1<<SUSPI)); // clear already pending WAKEUP / SUSPEND requests
 	UDIEN = (1<<EORSTE) | (1<<SOFE) | (1<<SUSPE);	// Enable interrupts for EOR (End of Reset), SOF (start of frame) and SUSPEND
-	
+
 	TX_RX_LED_INIT;
 }
 
@@ -831,5 +845,21 @@ bool USBDevice_::wakeupHost()
 
 	return false;
 }
+
+void USBDevice_::setWakeUpHandler(usbDeviceCallBack delegate)
+{
+	usbWakeUpDelegate = delegate;
+}
+
+void USBDevice_::setSuspendHandler(usbDeviceCallBack delegate)
+{
+	usbSuspendDelegate = delegate;
+}
+
+bool USBDevice_::isSuspended()
+{
+	return (_usbSuspendState & (1 << SUSPI));
+}
+
 
 #endif /* if defined(USBCON) */


### PR DESCRIPTION
This patch allows the Arduino sketch to respond to USB Host suspend/wake by settings a callback functions or using the isSuspended() function on the USBDevice instance. The suspend handler will be called when the host PC is put to sleep (or shuts down), and the WakeUp handler is called when the PC resumes from sleep.

PS. I apologise for the changes in whitespace I was unable to avoid that.

Usage:
```
void setup()
{
 USBDevice.setWakeUpHandler(&handleWakeup); 
 USBDevice.setSuspendHandler(&handleSuspend);
}

...

void handleWakeup()
{
}

void handleSuspend()
{
}
```

or

```
void loop()
{
   if(USBDevice.isSuspended())
   {
     ....
   }
}
```