### PR TITLE
Make analogWrite(255) generate a PWM of 99.6%

### DIFF
--- a/hardware/arduino/avr/cores/arduino/wiring_analog.c
+++ b/hardware/arduino/avr/cores/arduino/wiring_analog.c
@@ -105,11 +105,11 @@ void analogWrite(uint8_t pin, int val)
 	// for consistenty with Wiring, which doesn't require a pinMode
 	// call for the analog output pins.
 	pinMode(pin, OUTPUT);
-	if (val == 0)
+	if (val <= 0)
 	{
 		digitalWrite(pin, LOW);
 	}
-	else if (val == 255)
+	else if (val >= 256)
 	{
 		digitalWrite(pin, HIGH);
 	}


### PR DESCRIPTION
Writing 255 on OCRxx generates a PWM of 99.6% (255/256).  However, analogWrite(255) sets the pin permanently high, which is equivalent to a PWM of 100% (256/256), so there's a bigger step between analogWrite(254) and analogWrite(255) than any other analogWrite(x) and analogWrite(x+1).
This patch changes the range of analogWrite() from 0..255 to 0..256.  Additionally, it makes out of range values (<0, >256) be treated always as a digital write rather than "overflowing" as they do now.