### PR TITLE
Added Long USB RecvControl call for >64 bytes

### DIFF
--- a/hardware/arduino/avr/cores/arduino/USBAPI.h
+++ b/hardware/arduino/avr/cores/arduino/USBAPI.h
@@ -193,6 +193,7 @@ bool	CDC_Setup(USBSetup& setup);
 
 int USB_SendControl(uint8_t flags, const void* d, int len);
 int USB_RecvControl(void* d, int len);
+int USB_RecvControlLong(void* d, int len);
 
 uint8_t	USB_Available(uint8_t ep);
 uint8_t USB_SendSpace(uint8_t ep);


### PR DESCRIPTION
This PR replaces the 2nd commit of https://github.com/arduino/Arduino/pull/4105

It makes more sense to integrate this (wrapper) function into the core instead of my project, since I use it 3 times and other people might need it too.

**It doesnt break anything, just a new function was added**

cc @facchinm 