### PR TITLE
Stepper: avoid division by zero

### DIFF
--- a/libraries/Stepper/src/Stepper.cpp
+++ b/libraries/Stepper/src/Stepper.cpp
@@ -87,7 +87,10 @@ Stepper::Stepper(int number_of_steps, int motor_pin_1, int motor_pin_2)
   this->step_number = 0;    // which step the motor is on
   this->direction = 0;      // motor direction
   this->last_step_time = 0; // time stamp in us of the last step taken
-  this->number_of_steps = number_of_steps; // total number of steps for this motor
+  if (number_of_steps)
+    this->number_of_steps = number_of_steps;    // total number of steps for this motor
+  else
+    this->number_of_steps = 1;
 
   // Arduino pins for the motor control connection:
   this->motor_pin_1 = motor_pin_1;
@@ -117,7 +120,10 @@ Stepper::Stepper(int number_of_steps, int motor_pin_1, int motor_pin_2,
   this->step_number = 0;    // which step the motor is on
   this->direction = 0;      // motor direction
   this->last_step_time = 0; // time stamp in us of the last step taken
-  this->number_of_steps = number_of_steps; // total number of steps for this motor
+  if (number_of_steps)
+    this->number_of_steps = number_of_steps;    // total number of steps for this motor
+  else
+    this->number_of_steps = 1;
 
   // Arduino pins for the motor control connection:
   this->motor_pin_1 = motor_pin_1;
@@ -149,7 +155,10 @@ Stepper::Stepper(int number_of_steps, int motor_pin_1, int motor_pin_2,
   this->step_number = 0;    // which step the motor is on
   this->direction = 0;      // motor direction
   this->last_step_time = 0; // time stamp in us of the last step taken
-  this->number_of_steps = number_of_steps; // total number of steps for this motor
+  if (number_of_steps)
+    this->number_of_steps = number_of_steps;    // total number of steps for this motor
+  else
+    this->number_of_steps = 1;
 
   // Arduino pins for the motor control connection:
   this->motor_pin_1 = motor_pin_1;
@@ -174,6 +183,8 @@ Stepper::Stepper(int number_of_steps, int motor_pin_1, int motor_pin_2,
  */
 void Stepper::setSpeed(long whatSpeed)
 {
+  if (whatSpeed == 0)
+    whatSpeed = 1;
   this->step_delay = 60L * 1000L * 1000L / this->number_of_steps / whatSpeed;
 }
 


### PR DESCRIPTION
Check for inputs of 0 and set it to 1 as the minimum

Was added here for Particle devices: https://github.com/kennethlimcp/spark-stepper/pull/2

Signed-off-by: Kenneth Lim kennethlimcp@gmail.com
