### PR TITLE
[AVR] Fixed USB_SendControl for buffer size > 64

### DIFF
--- a/hardware/arduino/avr/cores/arduino/USBCore.cpp
+++ b/hardware/arduino/avr/cores/arduino/USBCore.cpp
@@ -425,31 +425,21 @@ static bool USB_SendStringDescriptor(const u8*string_P, u8 string_len, uint8_t f
 }
 
 //	Does not timeout or cross fifo boundaries
-//	Will only work for transfers <= 64 bytes
-//	Use USB_RecvControlLong for longer transfers
 int USB_RecvControl(void* d, int len)
 {
-	WaitOUT();
-	Recv((u8*)d,len);
-	ClearOUT();
-	return len;
-}
-
-//	Does not timeout or cross fifo boundaries
-int USB_RecvControlLong(void* d, int len)
-{
-	auto bytesleft = len;
-	while(bytesleft > 0)
-	{
-		// Dont receive more than the USB Control EP has to offer
-		// Use fixed 64 because control EP always have 64 bytes even on 16u2.
-		auto recvLength = bytesleft;
-		if(recvLength > 64){
-			recvLength = 64;
+	uint8_t *buff = (uint8_t *)d;
+	int remaining = len;
+	while (remaining > 0) {
+		WaitOUT();
+		if (remaining > 64) {
+			Recv(buff, 64);
+			buff += 64;
+			remaining -= 64;
+		} else {
+			Recv(buff, remaining);
+			remaining = 0;
 		}
-
-		// Write data to fit to the beginning of the array
-		bytesleft -= USB_RecvControl((u8*)d + len - bytesleft, recvLength);
+		ClearOUT();
 	}
 	return len;
 }


### PR DESCRIPTION
This is the best implementation I've got so far, this add 52 bytes (of ~3900 total) to the empty sketch.

I have **not** tested with transfers > 64 bytes, @NicoHood may you give it a try?

related to #4317 
/cc @facchinm
