### PR TITLE
Fixed NPE in some rare combinations of JSON files

### DIFF
--- a/arduino-core/src/cc/arduino/contributions/packages/ContributedPlatform.java
+++ b/arduino-core/src/cc/arduino/contributions/packages/ContributedPlatform.java
@@ -108,6 +108,24 @@ public abstract class ContributedPlatform extends DownloadableContribution {
     }
 
     ContributedPlatform obj1 = (ContributedPlatform) obj;
-    return getParentPackage().getName().equals(obj1.getParentPackage().getName()) && getArchitecture().equals(obj1.getArchitecture()) && getVersion().equals(obj1.getVersion()) && getName().equals(obj1.getName());
+
+    ContributedPackage parentPackage = getParentPackage();
+    ContributedPackage parentPackage1 = obj1.getParentPackage();
+    if (parentPackage == null) {
+      if (parentPackage1 != null)
+        return false;
+    } else {
+      if (parentPackage1 == null)
+        return false;
+      if (!parentPackage.getName().equals(parentPackage1.getName()))
+        return false;
+    }
+    if (!getArchitecture().equals(obj1.getArchitecture())) {
+      return false;
+    }
+    if (!getVersion().equals(obj1.getVersion())) {
+      return false;
+    }
+    return getName().equals(obj1.getName());
   }
 }


### PR DESCRIPTION
The error triggered inside ContributioIndexer.mergeContributions() while trying to remove a platform:

    if (platform != null) {
      targetPackage.getPlatforms().remove(platform);
    }

the remove() method calls ContributedPlatform.equals() to find the element to remove but since the parentPackage fields are resolved *after* merging contributions, the equls() method will fail with
a NullPointerException.