### PR TITLE
Fix indent and un-indent keyboard shortcuts on OS X.

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -44,6 +44,7 @@ import processing.app.legacy.PApplet;
 import processing.app.syntax.ArduinoTokenMakerFactory;
 import processing.app.syntax.PdeKeywords;
 import processing.app.syntax.SketchTextArea;
+import processing.app.syntax.SketchTextAreaEditorKit;
 import processing.app.tools.DiscourseFormat;
 import processing.app.tools.MenuScroller;
 import processing.app.tools.Tool;
@@ -1866,28 +1867,8 @@ public class Editor extends JFrame implements RunnerListener {
 
   private void handleIndentOutdent(boolean indent) {
     if (indent) {
-
-      int caretPosition = textarea.getCaretPosition();
-      boolean noSelec = !textarea.isSelectionActive();
-
-      // if no selection, focus on first char.
-      if (noSelec) {
-        try {
-          int line = textarea.getCaretLineNumber();
-          int startOffset = textarea.getLineStartOffset(line);
-          textarea.setCaretPosition(startOffset);
-        } catch (BadLocationException e) {
-        }
-      }
-
-      // Insert Tab or Spaces..
-      Action action = textarea.getActionMap().get(RSyntaxTextAreaEditorKit.insertTabAction);
+      Action action = textarea.getActionMap().get(SketchTextAreaEditorKit.rtaIncreaseIndentAction);
       action.actionPerformed(null);
-
-      if (noSelec) {
-        textarea.setCaretPosition(caretPosition);
-      }
-
     } else {
       Action action = textarea.getActionMap().get(RSyntaxTextAreaEditorKit.rstaDecreaseIndentAction);
       action.actionPerformed(null);

--- a/app/src/processing/app/syntax/SketchTextAreaDefaultInputMap.java
+++ b/app/src/processing/app/syntax/SketchTextAreaDefaultInputMap.java
@@ -45,8 +45,8 @@ public class SketchTextAreaDefaultInputMap extends RSyntaxTextAreaDefaultInputMa
 
       remove(KeyStroke.getKeyStroke(KeyEvent.VK_J, defaultModifier));
 
-      put(KeyStroke.getKeyStroke(KeyEvent.VK_OPEN_BRACKET, defaultModifier), DefaultEditorKit.insertTabAction);
-      put(KeyStroke.getKeyStroke(KeyEvent.VK_CLOSE_BRACKET, defaultModifier), RSyntaxTextAreaEditorKit.rstaDecreaseIndentAction);
+      put(KeyStroke.getKeyStroke(KeyEvent.VK_OPEN_BRACKET, defaultModifier), RSyntaxTextAreaEditorKit.rstaDecreaseIndentAction);
+      put(KeyStroke.getKeyStroke(KeyEvent.VK_CLOSE_BRACKET, defaultModifier), SketchTextAreaEditorKit.rtaIncreaseIndentAction);
 
       put(KeyStroke.getKeyStroke(KeyEvent.VK_UP, defaultModifier | shift), DefaultEditorKit.selectionBeginAction);
       put(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, defaultModifier | shift), DefaultEditorKit.selectionEndAction);

--- a/app/src/processing/app/syntax/SketchTextAreaEditorKit.java
+++ b/app/src/processing/app/syntax/SketchTextAreaEditorKit.java
@@ -13,10 +13,12 @@ public class SketchTextAreaEditorKit extends RSyntaxTextAreaEditorKit {
 
   public static final String rtaDeleteNextWordAction = "RTA.DeleteNextWordAction";
   public static final String rtaDeleteLineToCursorAction = "RTA.DeleteLineToCursorAction";
+  public static final String rtaIncreaseIndentAction = "RTA.IncreaseIndentAction";
 
   private static final Action[] defaultActions = {
     new DeleteNextWordAction(),
     new DeleteLineToCursorAction(),
+    new IncreaseIndentAction(),
     new SelectWholeLineAction(),
     new ToggleCommentAction()
   };
@@ -101,6 +103,39 @@ public class SketchTextAreaEditorKit extends RSyntaxTextAreaEditorKit {
       return rtaDeleteLineToCursorAction;
     }
 
+  }
+
+  /**
+   * Increases the indent of the selected or current line(s).
+   */
+  public static class IncreaseIndentAction extends RSyntaxTextAreaEditorKit.InsertTabAction {
+
+    public IncreaseIndentAction() {
+      super(rtaIncreaseIndentAction);
+    }
+
+    @Override
+    public void actionPerformedImpl(ActionEvent e, RTextArea textArea) {
+      int caretPosition = textArea.getCaretPosition();
+      boolean noSelec = textArea.getSelectedText() == null;
+
+      // if no selection, focus on first char.
+      if (noSelec) {
+        try {
+          int line = textArea.getCaretLineNumber();
+          int startOffset = textArea.getLineStartOffset(line);
+          textArea.setCaretPosition(startOffset);
+        } catch (BadLocationException ex) {
+        }
+      }
+
+      // Insert Tab or Spaces..
+      super.actionPerformedImpl(e, textArea);
+
+      if (noSelec) {
+        textArea.setCaretPosition(caretPosition + (textArea.getTabsEmulated() ? textArea.getTabSize() : 1));
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
That is, the Cmd+[ and Cmd+] shortcuts. Also fix a small bug on all operating systems, in which Edit > Increase Indent failed to move the cursor with the text (as the indent was increased when no text was selected).