### PR TITLE
fix delay/yield avr

### DIFF
--- a/hardware/arduino/avr/cores/arduino/wiring.c
+++ b/hardware/arduino/avr/cores/arduino/wiring.c
@@ -105,11 +105,11 @@ unsigned long micros() {
 
 void delay(unsigned long ms)
 {
-	uint16_t start = (uint16_t)micros();
+	uint32_t start = micros();
 
 	while (ms > 0) {
 		yield();
-		if (((uint16_t)micros() - start) >= 1000) {
+		while ( ms > 0 && (micros() - start) >= 1000) {
 			ms--;
 			start += 1000;
 		}


### PR DESCRIPTION
fix issues #4320 delay/yield, when the yield function takes more than a millisecond the delay fails.
Only for avr.