### PR TITLE
Fix compile errors after renaming files, related to unsaved changes in the sketch

### DIFF
--- a/app/src/processing/app/Sketch.java
+++ b/app/src/processing/app/Sketch.java
@@ -1119,7 +1119,7 @@ public class Sketch {
   }
 
   private String saveSketchInTempFolder() throws IOException {
-    File tempFolder = FileUtils.createTempFolder("arduino_", DigestUtils.md5Hex(data.getMainFilePath()));
+    File tempFolder = FileUtils.createTempFolder("arduino_modified_sketch_");
     FileUtils.copy(getFolder(), tempFolder);
 
     for (SketchCode sc : Stream.of(data.getCodes()).filter(SketchCode::isModified).collect(Collectors.toList())) {

--- a/arduino-core/src/processing/app/SketchCode.java
+++ b/arduino-core/src/processing/app/SketchCode.java
@@ -91,14 +91,13 @@ public class SketchCode {
   }
 
 
-  protected boolean deleteFile(Path tempBuildFolder, Path tempUnsavedSketchPath) throws IOException {
+  protected boolean deleteFile(Path tempBuildFolder) throws IOException {
     if (!file.delete()) {
       return false;
     }
 
-    List<Path> tempBuildFolders = Stream.of(tempBuildFolder, tempBuildFolder.resolve("sketch"), tempUnsavedSketchPath)
-      .filter(path -> Files.exists(path))
-      .collect(Collectors.toList());
+    List<Path> tempBuildFolders = Stream.of(tempBuildFolder, tempBuildFolder.resolve("sketch"))
+        .filter(path -> Files.exists(path)).collect(Collectors.toList());
 
     for (Path folder : tempBuildFolders) {
       if (!deleteCompiledFilesFrom(folder)) {


### PR DESCRIPTION
Fix #4335 by always deleting the temporary sketch copy after every build. With that, the name of that directory can be random again, instead of needing to be deterministic using a hash of the main sketch filename.