### PR TITLE
Remove temporary files when updating library_index.json

### DIFF
--- a/arduino-core/src/cc/arduino/contributions/GZippedJsonDownloader.java
+++ b/arduino-core/src/cc/arduino/contributions/GZippedJsonDownloader.java
@@ -53,8 +53,13 @@ public class GZippedJsonDownloader {
     try {
       new JsonDownloader(downloader, gzippedUrl).download(tmpFile, progress, statusText, progressListener);
       File gzipTmpFile = new File(tmpFile.getParentFile(), GzipUtils.getCompressedFilename(tmpFile.getName()));
+      // remove eventual leftovers from previous downloads
+      if (gzipTmpFile.exists()) {
+        gzipTmpFile.delete();
+      }
       tmpFile.renameTo(gzipTmpFile);
       decompress(gzipTmpFile, tmpFile);
+      gzipTmpFile.delete();
     } catch (Exception e) {
       new JsonDownloader(downloader, url).download(tmpFile, progress, statusText, progressListener);
     }

--- a/arduino-core/src/cc/arduino/contributions/GZippedJsonDownloader.java
+++ b/arduino-core/src/cc/arduino/contributions/GZippedJsonDownloader.java
@@ -51,13 +51,12 @@ public class GZippedJsonDownloader {
 
   public void download(File tmpFile, Progress progress, String statusText, ProgressListener progressListener) throws Exception {
     try {
-      new JsonDownloader(downloader, gzippedUrl).download(tmpFile, progress, statusText, progressListener);
       File gzipTmpFile = new File(tmpFile.getParentFile(), GzipUtils.getCompressedFilename(tmpFile.getName()));
       // remove eventual leftovers from previous downloads
       if (gzipTmpFile.exists()) {
         gzipTmpFile.delete();
       }
-      tmpFile.renameTo(gzipTmpFile);
+      new JsonDownloader(downloader, gzippedUrl).download(gzipTmpFile, progress, statusText, progressListener);
       decompress(gzipTmpFile, tmpFile);
       gzipTmpFile.delete();
     } catch (Exception e) {


### PR DESCRIPTION
This is a tentatve fix for #4272 #4332, following @vicnevicne hint.

I'm not able to reproduce the bug, @vicnevicne @MichaelJonker if you can reproduce it, by any chanche, can you try the fix? (ArduinoBot should make a build in a moment...)