### PR TITLE
Fixed #4292 - Plotter scaling by adapting margin computation based on sign 

### DIFF
--- a/app/src/processing/app/SerialPlotter.java
+++ b/app/src/processing/app/SerialPlotter.java
@@ -87,12 +87,14 @@ public class SerialPlotter extends AbstractMonitor {
       minY = Double.POSITIVE_INFINITY;
       maxY = Double.NEGATIVE_INFINITY;
       for(Graph g : graphs) {
-        double bMin = g.buffer.min() / 2.0;
-        double bMax = g.buffer.max() * 2.0;
+        double bMin = g.buffer.min();
+        double bMax = g.buffer.max();
         minY = bMin < minY ? bMin : minY;
         maxY = bMax > maxY ? bMax : maxY;
       }
-      
+      minY = minY * ((minY<0)?2:0.5);
+      maxY = maxY * ((maxY<0)?0.5:2);
+
       Ticks ticks = new Ticks(minY, maxY, 3);
       minY = Math.min(minY, ticks.getTick(0));
       maxY = Math.max(maxY, ticks.getTick(ticks.getTickCount() - 1));


### PR DESCRIPTION
This is my proposed fix for #4292.
To reproduce the issue and check the fix, please use the following sketch and open Serial plotter. Cases 2 and 4 are correct only with the fix applied - see comparison in video: http://screencast.com/t/Wj0vxqjU

```c
#define PAUSE_MS 5

void setup() {
  Serial.begin(9600);
}

void loop() {

  // 20 positive sawtooth : OK
  for (int n = 0; n < 20; n++) {
    for(int value = 0; value < 100; value++) {
      Serial.println(value);
      delay(PAUSE_MS);
    }
  }

  // 20 negative sawtooth : NOK
  for (int n = 0; n < 20; n++) {
    for(int value = 0; value < 100; value++) {
      Serial.println(-value);
      delay(PAUSE_MS);
    }
  }

  // 20 sawtooth high in positive range: OK
  for (int n = 0; n < 20; n++) {
    for(int value = 100; value < 200; value++) {
      Serial.println(value);
      delay(PAUSE_MS);
    }
  }

  // 20 sawtooth low in negative range: NOK
  for (int n = 0; n < 20; n++) {
    for(int value = 100; value < 200; value++) {
      Serial.println(-value);
      delay(PAUSE_MS);
    }
  }
}
```