### PR TITLE
Half duplex support

### DIFF
--- a/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.h
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/SoftwareSerial.h
@@ -51,6 +51,7 @@ private:
   uint8_t _receivePin;
   uint8_t _receiveBitMask;
   volatile uint8_t *_receivePortRegister;
+  uint8_t _transmitPin;
   uint8_t _transmitBitMask;
   volatile uint8_t *_transmitPortRegister;
   volatile uint8_t *_pcint_maskreg;
@@ -64,6 +65,7 @@ private:
 
   uint16_t _buffer_overflow:1;
   uint16_t _inverse_logic:1;
+  uint16_t _full_duplex:1;
 
   // static data
   static char _receive_buffer[_SS_MAX_RX_BUFF]; 
@@ -86,7 +88,7 @@ private:
 
 public:
   // public methods
-  SoftwareSerial(uint8_t receivePin, uint8_t transmitPin, bool inverse_logic = false);
+  SoftwareSerial(uint8_t receivePin, uint8_t transmitPin, bool inverse_logic = false, bool full_duplex = true);
   ~SoftwareSerial();
   void begin(long speed);
   bool listen();


### PR DESCRIPTION
Adds a parameter to the Software Serial library to enable a half-duplex mode. This allows using 1 line for RX and TX. 
It does this by setting the transmit pin by default to input, with the pull-up set. When transmitting, the pin temporarily switches to an output until the byte is sent, then flips back to input. When a module 
is receiving it should not be able to transmit, and vice-versa. 
Based on the following fork: https://github.com/nickstedman/SoftwareSerialWithHalfDuplex

The circuit described in the following post makes sure the writes aren't read back in: http://nerdralph.blogspot.ca/2014/01/avr-half-duplex-software-uart.html