### PR TITLE
Upload Verify option added

### DIFF
--- a/arduino-core/src/cc/arduino/packages/Uploader.java
+++ b/arduino-core/src/cc/arduino/packages/Uploader.java
@@ -69,6 +69,7 @@ public abstract class Uploader implements MessageConsumer {
   }
 
   protected final boolean verbose;
+  protected final boolean verifyUpload;
 
   private String error;
   protected boolean notFoundError;
@@ -76,11 +77,13 @@ public abstract class Uploader implements MessageConsumer {
 
   protected Uploader() {
     this.verbose = PreferencesData.getBoolean("upload.verbose");
+    this.verifyUpload = PreferencesData.getBoolean("upload.verify");
     init(false);
   }
 
   protected Uploader(boolean nup) {
     this.verbose = PreferencesData.getBoolean("upload.verbose");
+    this.verifyUpload = PreferencesData.getBoolean("upload.verify");
     init(nup);
   }
 

--- a/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
+++ b/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
@@ -92,6 +92,11 @@ public class SerialUploader extends Uploader {
       else
         prefs.put("upload.verbose", prefs.getOrExcept("upload.params.quiet"));
 
+      if (verifyUpload)
+        prefs.put("upload.verify", prefs.get("upload.params.verify", ""));
+      else
+        prefs.put("upload.verify", prefs.get("upload.params.noverify", ""));
+	
       boolean uploadResult;
       try {
         String pattern = prefs.getOrExcept("upload.pattern");
@@ -159,6 +164,11 @@ public class SerialUploader extends Uploader {
     } else {
       prefs.put("upload.verbose", prefs.getOrExcept("upload.params.quiet"));
     }
+
+    if (verifyUpload)
+      prefs.put("upload.verify", prefs.get("upload.params.verify", ""));
+    else
+      prefs.put("upload.verify", prefs.get("upload.params.noverify", ""));
 
     boolean uploadResult;
     try {
@@ -283,6 +293,11 @@ public class SerialUploader extends Uploader {
       prefs.put("program.verbose", prefs.getOrExcept("program.params.verbose"));
     else
       prefs.put("program.verbose", prefs.getOrExcept("program.params.quiet"));
+
+    if (verifyUpload)
+      prefs.put("program.verify", prefs.get("program.params.verify", ""));
+    else
+      prefs.put("program.verify", prefs.get("program.params.noverify", ""));
 
     try {
       // if (prefs.get("program.disable_flushing") == null

--- a/hardware/arduino/avr/platform.txt
+++ b/hardware/arduino/avr/platform.txt
@@ -97,11 +97,13 @@ tools.avrdude.config.path={path}/etc/avrdude.conf
 
 tools.avrdude.upload.params.verbose=-v
 tools.avrdude.upload.params.quiet=-q -q
-tools.avrdude.upload.pattern="{cmd.path}" "-C{config.path}" {upload.verbose} -p{build.mcu} -c{upload.protocol} -P{serial.port} -b{upload.speed} -D "-Uflash:w:{build.path}/{build.project_name}.hex:i"
+tools.avrdude.upload.params.noverify=-V
+tools.avrdude.upload.pattern="{cmd.path}" "-C{config.path}" {upload.verbose} {upload.verify} -p{build.mcu} -c{upload.protocol} -P{serial.port} -b{upload.speed} -D "-Uflash:w:{build.path}/{build.project_name}.hex:i"
 
 tools.avrdude.program.params.verbose=-v
 tools.avrdude.program.params.quiet=-q -q
-tools.avrdude.program.pattern="{cmd.path}" "-C{config.path}" {program.verbose} -p{build.mcu} -c{protocol} {program.extra_params} "-Uflash:w:{build.path}/{build.project_name}.hex:i"
+tools.avrdude.program.params.noverify=-V
+tools.avrdude.program.pattern="{cmd.path}" "-C{config.path}" {program.verbose} {program.verify} -p{build.mcu} -c{protocol} {program.extra_params} "-Uflash:w:{build.path}/{build.project_name}.hex:i"
 
 tools.avrdude.erase.params.verbose=-v
 tools.avrdude.erase.params.quiet=-q -q


### PR DESCRIPTION
This change picks up the upload.verify preference from the preferences dialog/preferences.txt and allows you to use this with your USB/Serial upload tool of choice. Configuration is already added for avrdude. 

It uses PreferencesMap.get to avoid an exception if the config is not found in platforms.txt - this should avoid problems with other cores.
