### PR TITLE
Use "$@" instead of bare $@ to protect arguments

### DIFF
--- a/build/shared/manpage.adoc
+++ b/build/shared/manpage.adoc
@@ -289,7 +289,7 @@ afterwards:
      #!/bin/bash
      Xvfb :1 -nolisten tcp -screen :1 1280x800x24 &
      xvfb="$!"
-     DISPLAY=:1 arduino $@
+     DISPLAY=:1 arduino "$@"
      kill -9 $xvfb
 
 Save the script as *arduino-headless* and run it with the options described above.


### PR DESCRIPTION
Bash expands bare $@, and then do word-splitting and file-globing. It breaks command-line arguments for arduino if command-line arguments for the wrapper script contain $IFS, '*', '?' and etc. characters.

Use "$@" in this case.