### PR TITLE
Removed unnecessary invocation of Ethernet.maintain()

### DIFF
--- a/libraries/Ethernet/examples/WebServer/WebServer.ino
+++ b/libraries/Ethernet/examples/WebServer/WebServer.ino
@@ -97,7 +97,6 @@ void loop() {
     // close the connection:
     client.stop();
     Serial.println("client disconnected");
-    Ethernet.maintain();
   }
 }
 


### PR DESCRIPTION
Since this example utilizes a statically assigned IP address, it is not necessary to call Ethernet.maintain().

I tested this against a Linux VM running dhcpd and a VM running Extreme Networks XOS with its DHCP server enabled with 30 second DHCP leases. I monitored the Rx with Wireshark and no DHCP-related packets were ever sent from my Arduino ethernet shield (renewal requests, or otherwise.)

As an additional investigation, I also tried the switch statement from the DhcpAddressPrinter.ino example and it fell through to default case, indicating that Ethernet.maintain() returned DHCP_CHECK_NONE.

As far as I can tell, this function call isn't necessary, although I suppose that it is possible there is some feature I am not aware out there related to DHCP that would need to be enabled server-side.