### PR TITLE
Small fix in Wire.cpp

### DIFF
--- a/hardware/arduino/avr/libraries/Wire/Wire.cpp
+++ b/hardware/arduino/avr/libraries/Wire/Wire.cpp
@@ -169,7 +169,7 @@ void TwoWire::beginTransmission(int address)
 uint8_t TwoWire::endTransmission(uint8_t sendStop)
 {
   // transmit buffer (blocking)
-  int8_t ret = twi_writeTo(txAddress, txBuffer, txBufferLength, 1, sendStop);
+  uint8_t ret = twi_writeTo(txAddress, txBuffer, txBufferLength, 1, sendStop);
   // reset tx buffer iterator vars
   txBufferIndex = 0;
   txBufferLength = 0;


### PR DESCRIPTION
Removed implicit conversions from unsigned, to signed, back to unsigned.