### PR TITLE
Java warnings

### DIFF
--- a/app/src/processing/app/Sketch.java
+++ b/app/src/processing/app/Sketch.java
@@ -27,7 +27,6 @@ import cc.arduino.Compiler;
 import cc.arduino.CompilerProgressListener;
 import cc.arduino.UploaderUtils;
 import cc.arduino.packages.Uploader;
-import org.apache.commons.codec.digest.DigestUtils;
 import processing.app.debug.RunnerException;
 import processing.app.forms.PasswordAuthorizationDialog;
 import processing.app.helpers.FileUtils;

--- a/arduino-core/src/cc/arduino/packages/uploaders/GenericNetworkUploader.java
+++ b/arduino-core/src/cc/arduino/packages/uploaders/GenericNetworkUploader.java
@@ -38,8 +38,6 @@ import processing.app.helpers.StringReplacer;
 import java.io.File;
 import java.util.List;
 
-import static processing.app.I18n.tr;
-
 public class GenericNetworkUploader extends Uploader {
 
   private final BoardPort port;

--- a/arduino-core/src/cc/arduino/utils/network/FileDownloader.java
+++ b/arduino-core/src/cc/arduino/utils/network/FileDownloader.java
@@ -207,8 +207,10 @@ public class FileDownloader extends Observable {
         file.write(buffer, 0, read);
         setDownloaded(getDownloaded() + read);
 
-        if (Thread.interrupted())
+        if (Thread.interrupted()) {
+          file.close();
           throw new InterruptedException();
+        }
       }
 
       if (getDownloadSize() != null) {

--- a/arduino-core/src/processing/app/I18n.java
+++ b/arduino-core/src/processing/app/I18n.java
@@ -70,11 +70,6 @@ public class I18n {
     PROMPT_BROWSE = tr("Browse");
   }
 
-  @Deprecated
-  public static String _(String s) {
-    return tr(s);
-  }
-
   public static String tr(String s) {
     String res;
     try {

--- a/arduino-core/src/processing/app/SketchCode.java
+++ b/arduino-core/src/processing/app/SketchCode.java
@@ -28,7 +28,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/arduino-core/src/processing/app/linux/Platform.java
+++ b/arduino-core/src/processing/app/linux/Platform.java
@@ -22,18 +22,10 @@
 
 package processing.app.linux;
 
-import org.apache.commons.exec.CommandLine;
-import org.apache.commons.exec.DefaultExecutor;
-import org.apache.commons.exec.Executor;
-import org.apache.commons.exec.PumpStreamHandler;
 import processing.app.PreferencesData;
-import processing.app.debug.TargetPackage;
 import processing.app.legacy.PConstants;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.IOException;
-import java.util.Map;
 
 
 /**

--- a/arduino-core/src/processing/app/macosx/Platform.java
+++ b/arduino-core/src/processing/app/macosx/Platform.java
@@ -29,7 +29,6 @@ import org.apache.commons.exec.DefaultExecutor;
 import org.apache.commons.exec.Executor;
 import org.apache.commons.exec.PumpStreamHandler;
 import org.apache.commons.lang3.StringUtils;
-import processing.app.debug.TargetPackage;
 import processing.app.legacy.PApplet;
 import processing.app.legacy.PConstants;
 
@@ -41,7 +40,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 
 /**

--- a/arduino-core/src/processing/app/windows/Platform.java
+++ b/arduino-core/src/processing/app/windows/Platform.java
@@ -24,16 +24,9 @@ package processing.app.windows;
 
 import cc.arduino.os.windows.FolderFinderInWindowsEnvVar;
 import cc.arduino.os.windows.FolderFinderInWindowsRegistry;
-import org.apache.commons.exec.CommandLine;
-import org.apache.commons.exec.DefaultExecutor;
-import org.apache.commons.exec.Executor;
-import org.apache.commons.exec.PumpStreamHandler;
-import processing.app.BaseNoGui;
-import processing.app.debug.TargetPackage;
 import processing.app.legacy.PApplet;
 import processing.app.legacy.PConstants;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -41,7 +34,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 
 public class Platform extends processing.app.Platform {


### PR DESCRIPTION
This fixes a few warnings in the java code. Some of them have been around for a while, but a recent commit seems to have introduced a lot of extra unused imports, which are removed here.