### PR TITLE
Providing a more fair servicing of multiple clients by not picking lowest numbered socket in available()

### DIFF
--- a/libraries/Ethernet/src/EthernetServer.cpp
+++ b/libraries/Ethernet/src/EthernetServer.cpp
@@ -52,13 +52,17 @@ EthernetClient EthernetServer::available()
 {
   accept();
 
-  for (int sock = 0; sock < MAX_SOCK_NUM; sock++) {
-    EthernetClient client(sock);
-    if (EthernetClass::_server_port[sock] == _port) {
+  for (int i = 0; i < MAX_SOCK_NUM; i++) {
+    // increment _lastReturnedSocket to avoid returning the same socket again
+    _lastReturnedSocket = (_lastReturnedSocket + 1) % MAX_SOCK_NUM;
+
+    EthernetClient client(_lastReturnedSocket);
+    if (EthernetClass::_server_port[_lastReturnedSocket] == _port) {
       uint8_t s = client.status();
       if (s == SnSR::ESTABLISHED || s == SnSR::CLOSE_WAIT) {
         if (client.available()) {
-          // XXX: don't always pick the lowest numbered socket.
+          // doesn't always pick the lowest numbered socket, because of
+          // _lastReturnedSocket + 1 at the beginning
           return client;
         }
       }

--- a/libraries/Ethernet/src/EthernetServer.h
+++ b/libraries/Ethernet/src/EthernetServer.h
@@ -10,6 +10,7 @@ public Server {
 private:
   uint16_t _port;
   void accept();
+  int _lastReturnedSocket = -1; 
 public:
   EthernetServer(uint16_t);
   EthernetClient available();


### PR DESCRIPTION
I modified `EthernetServer::available()` such that it will not always pick the
lowest numbered socket by introducing an internal index `int _sock` which is incremented by one every time `available()` is called. (I suppose the previous comment *XXX: don't always pick the lowest numbered socket.* was to be understood as a TODO)