### PR TITLE
Virtual destructor for base class "Print"

### DIFF
--- a/hardware/arduino/avr/cores/arduino/Print.h
+++ b/hardware/arduino/avr/cores/arduino/Print.h
@@ -41,6 +41,7 @@ class Print
     void setWriteError(int err = 1) { write_error = err; }
   public:
     Print() : write_error(0) {}
+    virtual ~Print() {}
   
     int getWriteError() { return write_error; }
     void clearWriteError() { setWriteError(0); }


### PR DESCRIPTION
Abstract classes must have virtual destructors, so when you delete an object through a pointer the proper destructor can be called.

Avoids two compiler warnings in some situations:
- deleting object of abstract class type 'Print' which has non-virtual destructor will cause undefined behaviour [-Wdelete-non-virtual-dtor]
- deleting object of polymorphic class type '...' which has non-virtual destructor might cause undefined behaviour [-Wdelete-non-virtual-dtor]

More info: http://stackoverflow.com/a/461224/1852787

Example of undefined behaviour code without the virtual destructor:

```cpp
#include <SoftwareSerial.h>

void setup()
{
  Print* printStream = new SoftwareSerial(1, 2);
  delete printStream;// will not call destructor for SoftwareSerial

  SoftwareSerial* serial = new SoftwareSerial(3, 4);
  delete serial;// this causes another warning because of undefined behaviour
}
void loop() { }
```

This pull request fixes both possible warnings.