### PR TITLE
Increase wait for upload port timeout to 5s on all platforms

### DIFF
--- a/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
+++ b/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
@@ -247,11 +247,10 @@ public class SerialUploader extends Uploader {
       Thread.sleep(250);
       elapsed += 250;
 
-      // On Windows, it can take a long time for the port to disappear and
-      // come back, so use a longer time out before assuming that the
-      // selected
-      // port is the bootloader (not the sketch).
-      if (((!OSUtils.isWindows() && elapsed >= 500) || elapsed >= 5000) && now.contains(uploadPort)) {
+      // On Windows and OS X, it can take a few seconds for the port to disappear and
+      // come back, so use a time out before assuming that the selected port is the
+      // bootloader (not the sketch).
+      if (elapsed >= 5000 && now.contains(uploadPort)) {
         if (verbose)
           System.out.println("Uploading using selected port: " + uploadPort);
         return uploadPort;

--- a/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
+++ b/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
@@ -136,12 +136,11 @@ public class SerialUploader extends Uploader {
           // it happened within 250 ms. So we wait until the reset should
           // have already occured before we start scanning.
           actualUploadPort = waitForUploadPort(userSelectedUploadPort, before);
-          
-          if (OSUtils.isMacOS()) {
-        	  // on OS X, if the port is opened too quickly after it is detected,
-        	  // a "Resource busy" error occurs, add a delay to workaround this
-        	  Thread.sleep(250);
-          }
+
+    	  // on OS X, if the port is opened too quickly after it is detected,
+    	  // a "Resource busy" error occurs, add a delay to workaround this,
+          // apply to other platforms as well.
+    	  Thread.sleep(250);
         }
       } catch (SerialException e) {
         throw new RunnerException(e);

--- a/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
+++ b/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
@@ -136,6 +136,12 @@ public class SerialUploader extends Uploader {
           // it happened within 250 ms. So we wait until the reset should
           // have already occured before we start scanning.
           actualUploadPort = waitForUploadPort(userSelectedUploadPort, before);
+          
+          if (OSUtils.isMacOS()) {
+        	  // on OS X, if the port is opened too quickly after it is detected,
+        	  // a "Resource busy" error occurs, add a delay to workaround this
+        	  Thread.sleep(250);
+          }
         }
       } catch (SerialException e) {
         throw new RunnerException(e);


### PR DESCRIPTION
OS X 10.11 seems to be slower (with Arduino Zero native port), increasing timeout to 5s on all platforms to keep things simple.

This helps address https://github.com/arduino/ArduinoCore-samd/issues/62.