### PR TITLE
Support extra parameter on `attachInterrupt()`

### DIFF
--- a/hardware/arduino/avr/cores/arduino/Arduino.h
+++ b/hardware/arduino/avr/cores/arduino/Arduino.h
@@ -139,6 +139,7 @@ void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t val);
 uint8_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder);
 
 void attachInterrupt(uint8_t, void (*)(void), int mode);
+void attachInterruptParam(uint8_t, void (*)(void*), int mode, void* param);
 void detachInterrupt(uint8_t);
 
 void setup(void);

--- a/hardware/arduino/avr/cores/arduino/wiring_private.h
+++ b/hardware/arduino/avr/cores/arduino/wiring_private.h
@@ -63,6 +63,7 @@ extern "C"{
 #endif
 
 typedef void (*voidFuncPtr)(void);
+typedef void (*voidFuncPtrParam)(void*);
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
When writing an arduino library, it is difficult to connect interrupt handlers with the component instance that should be notified.

In C, the common pattern to fix this is to specifying a `void*` parameter with the callback, where the listener can store any context necessary.

This patch adds a new function, `attachInterruptParam()`, which does exactly.