### PR TITLE
Support extra parameter on `attachInterrupt()`

### DIFF
--- a/hardware/arduino/avr/cores/arduino/Arduino.h
+++ b/hardware/arduino/avr/cores/arduino/Arduino.h
@@ -148,6 +148,7 @@ void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t val);
 uint8_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder);
 
 void attachInterrupt(uint8_t, void (*)(void), int mode);
+void attachInterruptParam(uint8_t, void (*)(void*), int mode, void* param);
 void detachInterrupt(uint8_t);
 
 void setup(void);

--- a/hardware/arduino/avr/cores/arduino/wiring_private.h
+++ b/hardware/arduino/avr/cores/arduino/wiring_private.h
@@ -64,6 +64,7 @@ uint32_t countPulseASM(volatile uint8_t *port, uint8_t bit, uint8_t stateMask, u
 #endif
 
 typedef void (*voidFuncPtr)(void);
+typedef void (*voidFuncPtrParam)(void*);
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
When writing an arduino library, it is difficult to connect interrupt handlers with the component instance that should be notified.

In C, the common pattern to fix this is to specifying a `void*` parameter with the callback, where the listener can store any context necessary.

This patch adds the new function `attachInterruptParam()` to implement this pattern.
