### PR TITLE
Print negative numbers as negative numbers regardless of base

### DIFF
--- a/hardware/arduino/avr/cores/arduino/Print.cpp
+++ b/hardware/arduino/avr/cores/arduino/Print.cpp
@@ -88,14 +88,12 @@ size_t Print::print(long n, int base)
 {
   if (base == 0) {
     return write(n);
-  } else if (base == 10) {
+  } else {
     if (n < 0) {
       int t = print('-');
       n = -n;
-      return printNumber(n, 10) + t;
+      return printNumber(n, base) + t;
     }
-    return printNumber(n, 10);
-  } else {
     return printNumber(n, base);
   }
 }


### PR DESCRIPTION
Base 10 is not special.  Printing a negative number such as -15 in base 16 should show -F, not FFFFFFF1.  For the result with the many Fs, the number should be converted to unsigned long (or unsigned int for fewer Fs).
Issue #4460 complains about the behavior of `print` for negative ints (which prints them as unsigned *long*), and I think the best solution would be to be consistent with what negative integers actually represent rather than with what printf does in C.