### PR TITLE
Remove dependency on Sd2PinMap.h

### DIFF
--- a/libraries/SD/src/utility/Sd2Card.h
+++ b/libraries/SD/src/utility/Sd2Card.h
@@ -23,7 +23,7 @@
  * \file
  * Sd2Card class
  */
-#include "Sd2PinMap.h"
+#include "pins_arduino.h"
 #include "SdInfo.h"
 /** Set SCK to max rate of F_CPU/2. See Sd2Card::setSckRate(). */
 uint8_t const SPI_FULL_SPEED = 0;
@@ -62,14 +62,14 @@ uint8_t const SPI_QUARTER_SPEED = 2;
  * master unless SS is set to output mode.
  */
 /** The default chip select pin for the SD card is SS. */
-uint8_t const  SD_CHIP_SELECT_PIN = SS_PIN;
+uint8_t const  SD_CHIP_SELECT_PIN = SS;
 // The following three pins must not be redefined for hardware SPI.
 /** SPI Master Out Slave In pin */
-uint8_t const  SPI_MOSI_PIN = MOSI_PIN;
+uint8_t const  SPI_MOSI_PIN = MOSI;
 /** SPI Master In Slave Out pin */
-uint8_t const  SPI_MISO_PIN = MISO_PIN;
+uint8_t const  SPI_MISO_PIN = MISO;
 /** SPI Clock pin */
-uint8_t const  SPI_SCK_PIN = SCK_PIN;
+uint8_t const  SPI_SCK_PIN = SCK;
 /** optimize loops for hardware SPI */
 #ifndef USE_SPI_LIB
 #define OPTIMIZE_HARDWARE_SPI


### PR DESCRIPTION
Sd2PinMap.h contains a legacy implementation of the information provided in pins_arduino.h, and is only used by Sd2Card.h.

This commit removes the #include "Sd2PinMap.h", and redefines the SD SPI interface to pin names provided by pins_arduino.h.

The file Sd2PinMap.h should also be removed as it is no longer relevant.