### PR TITLE
Update Sd2Card.h to use pins_arduino.h definitions

### DIFF
--- a/libraries/SD/src/utility/Sd2Card.h
+++ b/libraries/SD/src/utility/Sd2Card.h
@@ -54,6 +54,10 @@ uint8_t const SPI_QUARTER_SPEED = 2;
 //
 #ifndef SOFTWARE_SPI
 // hardware pin defs
+
+// include pins_arduino.h or variant.h depending on architecture, via Arduino.h
+#include <Arduino.h>
+
 /**
  * SD Chip Select pin
  *
@@ -62,14 +66,17 @@ uint8_t const SPI_QUARTER_SPEED = 2;
  * master unless SS is set to output mode.
  */
 /** The default chip select pin for the SD card is SS. */
-uint8_t const  SD_CHIP_SELECT_PIN = SS_PIN;
-// The following three pins must not be redefined for hardware SPI.
+uint8_t const  SD_CHIP_SELECT_PIN = SS;
+
+// The following three pins must not be redefined for hardware SPI,
+// so ensure that they are taken from pins_arduino.h or variant.h, depending on architecture.
 /** SPI Master Out Slave In pin */
-uint8_t const  SPI_MOSI_PIN = MOSI_PIN;
+uint8_t const  SPI_MOSI_PIN = MOSI;
 /** SPI Master In Slave Out pin */
-uint8_t const  SPI_MISO_PIN = MISO_PIN;
+uint8_t const  SPI_MISO_PIN = MISO;
 /** SPI Clock pin */
-uint8_t const  SPI_SCK_PIN = SCK_PIN;
+uint8_t const  SPI_SCK_PIN = SCK;
+
 /** optimize loops for hardware SPI */
 #ifndef USE_SPI_LIB
 #define OPTIMIZE_HARDWARE_SPI


### PR DESCRIPTION
Update Sd2Card.h to use pins_arduino.h or variant.h definitions, depending on architecture, when Hardware SPI is in use.

The definitions for Software SPI pins (for ATmega1280 and ATmega2560 etc) remain unchanged as defined in Sd2PinMap.h.