### PR TITLE
Bug fix in WiFiClient::read()

### DIFF
--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -116,7 +116,9 @@ int WiFiClient::read() {
   if (!available())
     return -1;
 
-  ServerDrv::getData(_sock, &b);
+  if (!ServerDrv::getData(_sock, &b))
+    return -1;
+
   return b;
 }
 


### PR DESCRIPTION
The method should return failure if ServerDrv::getData() failed.