### PR TITLE
Use "$@" in shell script

### DIFF
--- a/build/cmd/dist/processing
+++ b/build/cmd/dist/processing
@@ -1,4 +1,4 @@
- #!/bin/sh
+#!/bin/sh
  
 APPDIR="$(dirname -- "${0}")"
 
@@ -17,4 +17,4 @@ export PATH="${APPDIR}/java/bin:${PATH}"
 
 #java processing.app.Commander $*
 # if you know a better way to do this, submit it to dev.processing.org/bugs
-java processing.app.Commander "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9"
+java processing.app.Commander "$@"


### PR DESCRIPTION
Use "$@" in this shell script instead of "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9".
(Is this file still used?)
