### PR TITLE
Update from USB 2.0 to USB 2.1

### DIFF
--- a/hardware/arduino/avr/cores/arduino/USBCore.h
+++ b/hardware/arduino/avr/cores/arduino/USBCore.h
@@ -130,7 +130,7 @@
 typedef struct {
 	u8 len;				// 18
 	u8 dtype;			// 1 USB_DEVICE_DESCRIPTOR_TYPE
-	u16 usbVersion;		// 0x200
+	u16 usbVersion;		// 0x210
 	u8	deviceClass;
 	u8	deviceSubClass;
 	u8	deviceProtocol;
@@ -260,7 +260,7 @@ typedef struct
 
 
 #define D_DEVICE(_class,_subClass,_proto,_packetSize0,_vid,_pid,_version,_im,_ip,_is,_configs) \
-	{ 18, 1, 0x200, _class,_subClass,_proto,_packetSize0,_vid,_pid,_version,_im,_ip,_is,_configs }
+	{ 18, 1, 0x210, _class,_subClass,_proto,_packetSize0,_vid,_pid,_version,_im,_ip,_is,_configs }
 
 #define D_CONFIG(_totalLength,_interfaces) \
 	{ 9, 2, _totalLength,_interfaces, 1, 0, USB_CONFIG_BUS_POWERED | USB_CONFIG_REMOTE_WAKEUP, USB_CONFIG_POWER_MA(500) }


### PR DESCRIPTION
Let's update USB Version from 2.0 to 2.1 so that the host could tell if the USB device exposes a [Binary Object Store descriptor](http://blogs.msdn.com/b/usbcoreblog/archive/2013/04/11/usb-2-1-2-0-1-1-device-enumeration-changes-in-windows-8.aspx) or not. 
For info, this is where the [WebUSB](https://github.com/WICG/webusb) descriptor (and Microsoft OS Descriptor 2.0) reading sequence starts.
