### PR TITLE
Show board name on generic "Error compiling" message

### DIFF
--- a/arduino-core/src/cc/arduino/Compiler.java
+++ b/arduino-core/src/cc/arduino/Compiler.java
@@ -269,7 +269,7 @@ public class Compiler implements MessageConsumer {
     }
 
     if (result != 0) {
-      RunnerException re = new RunnerException(tr("Error compiling."));
+      RunnerException re = new RunnerException(tr("Error compiling for ") + "\"" + board.getName() + "\"");
       re.hideStackTrace();
       throw re;
     }


### PR DESCRIPTION
As discussed on the developers mail list, this change adds the board name to the generic "Error compiling" message.

https://groups.google.com/a/arduino.cc/d/msg/developers/rs72zE8DuN0/B7elCSB-EQAJ

This generic error only appears when the IDE is unable to highlight a specific line in the editor.