### PR TITLE
Speed and size improvement in Print::printFloat()

### DIFF
--- a/hardware/arduino/avr/cores/arduino/Print.cpp
+++ b/hardware/arduino/avr/cores/arduino/Print.cpp
@@ -257,7 +257,7 @@ size_t Print::printFloat(double number, uint8_t digits)
   while (digits-- > 0)
   {
     remainder *= 10.0;
-    int toPrint = int(remainder);
+    unsigned toPrint = unsigned(remainder);
     n += print(toPrint);
     remainder -= toPrint; 
   } 


### PR DESCRIPTION
Avoid using the overload of print() for signed integer since a negative value is not allowed here.
This results in a smaller (unless print(int) is used somewhere else in the program) and faster code because the overload for unsigned integer is simpler.