### PR TITLE
Add missing cast to SoftwareSerial::peek() when returning buffered value

### DIFF
--- a/hardware/arduino/avr/libraries/SoftwareSerial/src/SoftwareSerial.cpp
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/src/SoftwareSerial.cpp
@@ -482,5 +482,5 @@ int SoftwareSerial::peek()
     return -1;
 
   // Read from "head"
-  return _receive_buffer[_receive_buffer_head];
+  return (uint8_t)_receive_buffer[_receive_buffer_head];
 }

--- a/hardware/arduino/avr/libraries/SoftwareSerial/src/SoftwareSerial.cpp
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/src/SoftwareSerial.cpp
@@ -48,7 +48,7 @@ http://arduiniana.org.
 // Statics
 //
 SoftwareSerial *SoftwareSerial::active_object = 0;
-char SoftwareSerial::_receive_buffer[_SS_MAX_RX_BUFF]; 
+uint8_t SoftwareSerial::_receive_buffer[_SS_MAX_RX_BUFF]; 
 volatile uint8_t SoftwareSerial::_receive_buffer_tail = 0;
 volatile uint8_t SoftwareSerial::_receive_buffer_head = 0;
 
@@ -482,5 +482,5 @@ int SoftwareSerial::peek()
     return -1;
 
   // Read from "head"
-  return (uint8_t)_receive_buffer[_receive_buffer_head];
+  return _receive_buffer[_receive_buffer_head];
 }

--- a/hardware/arduino/avr/libraries/SoftwareSerial/src/SoftwareSerial.h
+++ b/hardware/arduino/avr/libraries/SoftwareSerial/src/SoftwareSerial.h
@@ -66,7 +66,7 @@ private:
   uint16_t _inverse_logic:1;
 
   // static data
-  static char _receive_buffer[_SS_MAX_RX_BUFF]; 
+  static uint8_t _receive_buffer[_SS_MAX_RX_BUFF]; 
   static volatile uint8_t _receive_buffer_tail;
   static volatile uint8_t _receive_buffer_head;
   static SoftwareSerial *active_object;


### PR DESCRIPTION
Resolves #2858.

Prior to this, ```read``` and ```peek``` would return different values if the byte value was greater than 127.

For example, if the buffered byte was ```180```, ```read``` would return ```180```, but ```peek``` would return ```-76```.