### PR TITLE
AVR recipe.ar.pattern backwards compatibility

### DIFF
--- a/hardware/arduino/avr/platform.txt
+++ b/hardware/arduino/avr/platform.txt
@@ -62,6 +62,7 @@ recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} -m
 recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.S.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.S.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Create archives
+archive_file_path={build.path}/{archive_file}
 recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{archive_file_path}" "{object_file}"
 
 ## Combine gc-sections, archives, and objects


### PR DESCRIPTION
Define `archive_file_path` in Arduino AVR Boards platform.txt to provide backwards compatibility with IDE versions previous to 1.6.6. Using Arduino AVR Boards 1.6.9+ with IDE < 1.6.6 causes an error when compiling(https://github.com/arduino/Arduino/issues/4114):
```
avr-gcc: error: C:\Users\per\AppData\Local\Temp\build670390283184799432.tmp/core.a: No such file or directory
```
The `archive_file_path` value set in platform.txt is overridden in IDE 1.6.6+. This produces avr-ar commands identical to the previous behavior.