### PR TITLE
Add --help and fallback to CLI interface

### DIFF
--- a/arduino-core/src/processing/app/helpers/CommandlineParser.java
+++ b/arduino-core/src/processing/app/helpers/CommandlineParser.java
@@ -16,7 +16,7 @@ import static processing.app.I18n.tr;
 public class CommandlineParser {
 
   private enum ACTION {
-    GUI, NOOP, VERIFY("--verify"), UPLOAD("--upload"), GET_PREF("--get-pref"), INSTALL_BOARD("--install-boards"), INSTALL_LIBRARY("--install-library");
+    GUI, NOOP, VERIFY("--verify"), UPLOAD("--upload"), GET_PREF("--get-pref"), INSTALL_BOARD("--install-boards"), INSTALL_LIBRARY("--install-library"), HELP("--help");
 
     private final String value;
 
@@ -52,6 +52,7 @@ public class CommandlineParser {
     actions.put("--get-pref", ACTION.GET_PREF);
     actions.put("--install-boards", ACTION.INSTALL_BOARD);
     actions.put("--install-library", ACTION.INSTALL_LIBRARY);
+    actions.put("--help", ACTION.HELP);
   }
 
   public void parseArgumentsPhase1() {
@@ -83,6 +84,14 @@ public class CommandlineParser {
             BaseNoGui.showError(null, I18n.format(tr("Argument required for {0}"), a.value), 3);
           }
           libraryToInstall = args[i];
+        }
+        if (a == ACTION.HELP) {
+          Set<String> strings = actions.keySet();
+          String[] valid = strings.toArray(new String[strings.size()]);
+          String actions = PApplet.join(valid, "\n");
+          String actionFilemame = "FILE.ino";
+          String mess = I18n.format(tr("Actions:\n{0}\n{1}"), actionFilemame, actions);
+          BaseNoGui.showError(null, mess, 3);
         }
         action = a;
         continue;
@@ -185,7 +194,7 @@ public class CommandlineParser {
         continue;
       }
       if (args[i].startsWith("--"))
-        BaseNoGui.showError(null, I18n.format(tr("unknown option: {0}"), args[i]), 3);
+        BaseNoGui.showError(null, I18n.format(tr("unknown action/option: {0}, use --help"), args[i]), 3);
 
       filenames.add(args[i]);
     }

--- a/build/shared/manpage.adoc
+++ b/build/shared/manpage.adoc
@@ -33,6 +33,8 @@ SYNOPSIS
 
 *arduino* [*--install-library* __library name__[:__version__][,__library name__[:__version__],__library name__[:__version__]]
 
+*arduino* [*--help*]
+
 DESCRIPTION
 -----------
 The 'arduino' integrated development environment allows editing,
@@ -63,7 +65,7 @@ meaning it is pretty useless if you want any feedback or to be able to keep log 
 automated testing, etc.
 
 ACTIONS
-
+-------
 *--verify*::
 	Build the sketch.
 
@@ -82,6 +84,9 @@ ACTIONS
 *--install-library* __library name__[:__version__]::
 	Fetches available libraries list and install the specified one. If __version__ is omitted, the latest is installed. If a library with the same version is already installed, nothing is installed and program exits with exit code 1. If a library with a different version is already installed, it's replaced.
 	Multiple libraries can be specified, separated by a comma.
+
+*--help*::
+	Shows list of available actions.
 
 OPTIONS
 -------


### PR DESCRIPTION
I improved  user friendliness of command line -
1) I added "--help" action, which shows available actions.
2) When non valid action/option used, a message is shown to user to use --help.
3) Updated man page.

https://github.com/arduino/Arduino/issues/4709
