### PR TITLE
Handling gracefully upload failure

### DIFF
--- a/app/src/processing/app/Sketch.java
+++ b/app/src/processing/app/Sketch.java
@@ -1200,7 +1200,11 @@ public class Sketch {
     } while (uploader.requiresAuthorization() && !success);
 
     if (!success) {
-      editor.statusError(uploader.getFailureMessage());
+      String errorMessage = uploader.getFailureMessage();
+      if (errorMessage.equals("")) {
+        errorMessage = tr("An error occurred while uploading the sketch");
+      }
+      editor.statusError(errorMessage);
     }
 
     return success;

--- a/app/src/processing/app/Sketch.java
+++ b/app/src/processing/app/Sketch.java
@@ -1164,7 +1164,8 @@ public class Sketch {
 
   private boolean upload(String buildPath, String suggestedClassName, boolean usingProgrammer) throws Exception {
 
-    Uploader uploader = new UploaderUtils().getUploaderByPreferences(false);
+    UploaderUtils uploaderInstance = new UploaderUtils();
+    Uploader uploader = uploaderInstance.getUploaderByPreferences(false);
 
     boolean success = false;
     do {
@@ -1183,7 +1184,7 @@ public class Sketch {
 
       List<String> warningsAccumulator = new LinkedList<>();
       try {
-        success = new UploaderUtils().upload(data, uploader, buildPath, suggestedClassName, usingProgrammer, false, warningsAccumulator);
+        success = uploaderInstance.upload(data, uploader, buildPath, suggestedClassName, usingProgrammer, false, warningsAccumulator);
       } finally {
         if (uploader.requiresAuthorization() && !success) {
           PreferencesData.remove(uploader.getAuthorizationKey());
@@ -1197,6 +1198,10 @@ public class Sketch {
       }
 
     } while (uploader.requiresAuthorization() && !success);
+
+    if (!success) {
+      editor.statusError(uploader.getFailureMessage());
+    }
 
     return success;
   }

--- a/arduino-core/src/cc/arduino/packages/Uploader.java
+++ b/arduino-core/src/cc/arduino/packages/Uploader.java
@@ -130,13 +130,11 @@ public abstract class Uploader implements MessageConsumer {
       e.printStackTrace();
     }
 
-    if (error != null) {
-      RunnerException exception = new RunnerException(error);
-      exception.hideStackTrace();
-      throw exception;
-    }
-
     return result == 0;
+  }
+
+  public String getFailureMessage() {
+    return error;
   }
 
   public void message(String s) {
@@ -148,8 +146,9 @@ public abstract class Uploader implements MessageConsumer {
     System.err.print(s);
 
     // ignore cautions
-    if (s.contains("Error")) {
+    if (s.toLowerCase().contains("error")) {
       notFoundError = true;
+      error = s;
       return;
     }
     if (notFoundError) {

--- a/arduino-core/src/cc/arduino/packages/Uploader.java
+++ b/arduino-core/src/cc/arduino/packages/Uploader.java
@@ -85,7 +85,7 @@ public abstract class Uploader implements MessageConsumer {
   }
 
   private void init(boolean nup) {
-    this.error = null;
+    this.error = "";
     this.notFoundError = false;
     this.noUploadPort = nup;
   }

--- a/arduino-core/src/cc/arduino/packages/uploaders/SSHUploader.java
+++ b/arduino-core/src/cc/arduino/packages/uploaders/SSHUploader.java
@@ -135,7 +135,7 @@ public class SSHUploader extends Uploader {
       return runUploadTool(ssh, prefs);
     } catch (JSchException e) {
       String message = e.getMessage();
-      if ("Auth cancel".equals(message) || "Auth fail".equals(message)) {
+      if (message.contains("Auth cancel") || message.contains("Auth fail") || message.contains("authentication fail")) {
         return false;
       }
       if (e.getMessage().contains("Connection refused")) {


### PR DESCRIPTION
The current code to handle upload failures if quite old and too avrdude dependant.
Actually, the 101 sketchUploader triggers a funny situation with strings being replaced and displayed with nonsense results.

This PR handles these situations by returning gracefully (without generating an exception) and then deciding which is the "right" string to display.