### PR TITLE
Add specifier to generated tool property keys

### DIFF
--- a/arduino-core/src/cc/arduino/contributions/packages/ContributedPlatform.java
+++ b/arduino-core/src/cc/arduino/contributions/packages/ContributedPlatform.java
@@ -80,6 +80,7 @@ public abstract class ContributedPlatform extends DownloadableContribution {
       if (tool == null) {
         System.err.println("Index error: could not find referenced tool " + dep);
       } else {
+        tool.usetUserArchitecture(this.getParentPackage().getName()+"."+this.getArchitecture());
         resolvedToolReferences.put(dep, tool);
       }
     }

--- a/arduino-core/src/cc/arduino/contributions/packages/ContributedTool.java
+++ b/arduino-core/src/cc/arduino/contributions/packages/ContributedTool.java
@@ -32,6 +32,7 @@ package cc.arduino.contributions.packages;
 import cc.arduino.contributions.DownloadableContribution;
 import processing.app.Platform;
 
+import java.util.LinkedList;
 import java.util.List;
 
 public abstract class ContributedTool {
@@ -41,6 +42,20 @@ public abstract class ContributedTool {
   public abstract String getVersion();
 
   public abstract List<HostDependentDownloadableContribution> getSystems();
+
+  private LinkedList<String> users = null;
+  public void usetUserArchitecture(String vendorAndArch) {
+    if (users == null) {
+      users = new LinkedList<>();
+    }
+    if (!users.contains(vendorAndArch)) {
+      users.add(vendorAndArch);
+    }
+  }
+
+  public List<String> ugetUserArchitectures() {
+    return users;
+  }
 
   public DownloadableContribution getDownloadableContribution(Platform platform) {
     for (HostDependentDownloadableContribution c : getSystems()) {

--- a/arduino-core/src/cc/arduino/packages/uploaders/GenericNetworkUploader.java
+++ b/arduino-core/src/cc/arduino/packages/uploaders/GenericNetworkUploader.java
@@ -93,7 +93,8 @@ public class GenericNetworkUploader extends Uploader {
       pattern = prefs.get("upload.network_pattern");
       if(pattern == null)
         pattern = prefs.getOrExcept("upload.pattern");
-      String[] cmd = StringReplacer.formatAndSplit(pattern, prefs, true);
+      String arch = targetPlatform.getContainerPackage().getId()+"."+targetPlatform.getId();
+      String[] cmd = StringReplacer.formatAndSplit(pattern, prefs, arch, true);
       uploadResult = executeUploadCommand(cmd);
     } catch (RunnerException e) {
       throw e;

--- a/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
+++ b/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
@@ -110,7 +110,8 @@ public class SerialUploader extends Uploader {
       boolean uploadResult;
       try {
         String pattern = prefs.getOrExcept("upload.pattern");
-        String[] cmd = StringReplacer.formatAndSplit(pattern, prefs, true);
+        String arch = targetPlatform.getContainerPackage().getId()+"."+targetPlatform.getId();
+        String[] cmd = StringReplacer.formatAndSplit(pattern, prefs, arch, true);
         uploadResult = executeUploadCommand(cmd);
       } catch (Exception e) {
         throw new RunnerException(e);
@@ -204,8 +205,10 @@ public class SerialUploader extends Uploader {
 
     boolean uploadResult;
     try {
+      // Architecture field formatted as "arduino.avr" to prepend runtime vars
       String pattern = prefs.getOrExcept("upload.pattern");
-      String[] cmd = StringReplacer.formatAndSplit(pattern, prefs, true);
+      String arch = targetPlatform.getContainerPackage().getId()+"."+targetPlatform.getId();
+      String[] cmd = StringReplacer.formatAndSplit(pattern, prefs, arch, true);
       uploadResult = executeUploadCommand(cmd);
     } catch (RunnerException e) {
       throw e;
@@ -341,7 +344,8 @@ public class SerialUploader extends Uploader {
       // }
 
       String pattern = prefs.getOrExcept("program.pattern");
-      String[] cmd = StringReplacer.formatAndSplit(pattern, prefs, true);
+      String arch = targetPlatform.getContainerPackage().getId()+"."+targetPlatform.getId();
+      String[] cmd = StringReplacer.formatAndSplit(pattern, prefs, arch, true);
       return executeUploadCommand(cmd);
     } catch (RunnerException e) {
       throw e;
@@ -404,12 +408,13 @@ public class SerialUploader extends Uploader {
     new LoadVIDPIDSpecificPreferences().load(prefs);
 
     String pattern = prefs.getOrExcept("erase.pattern");
-    String[] cmd = StringReplacer.formatAndSplit(pattern, prefs, true);
+    String arch = targetPlatform.getContainerPackage().getId()+"."+targetPlatform.getId();
+    String[] cmd = StringReplacer.formatAndSplit(pattern, prefs, arch, true);
     if (!executeUploadCommand(cmd))
       return false;
 
     pattern = prefs.getOrExcept("bootloader.pattern");
-    cmd = StringReplacer.formatAndSplit(pattern, prefs, true);
+    cmd = StringReplacer.formatAndSplit(pattern, prefs, arch, true);
     return executeUploadCommand(cmd);
   }
 }

--- a/arduino-core/src/processing/app/BaseNoGui.java
+++ b/arduino-core/src/processing/app/BaseNoGui.java
@@ -862,6 +862,10 @@ public class BaseNoGui {
       }
       PreferencesData.set(prefix + tool.getName() + ".path", absolutePath);
       PreferencesData.set(prefix + tool.getName() + "-" + tool.getVersion() + ".path", absolutePath);
+      for (String userArch : tool.ugetUserArchitectures()) {
+        PreferencesData.set(prefix + tool.getName() + ".path." + userArch, absolutePath);
+        PreferencesData.set(prefix + tool.getName() + "-" + tool.getVersion() + ".path." + userArch, absolutePath);
+      }
     }
   }
 

--- a/arduino-core/src/processing/app/helpers/StringReplacer.java
+++ b/arduino-core/src/processing/app/helpers/StringReplacer.java
@@ -29,12 +29,17 @@ public class StringReplacer {
 
   public static String[] formatAndSplit(String src, Map<String, String> dict,
                                         boolean recursive) throws Exception {
+    return formatAndSplit(src, dict, "", recursive);
+  }
+
+  public static String[] formatAndSplit(String src, Map<String, String> dict, String arch,
+                                        boolean recursive) throws Exception {
     String res;
 
     // Recursive replace with a max depth of 10 levels.
     for (int i = 0; i < 10; i++) {
       // Do a replace with dictionary
-      res = StringReplacer.replaceFromMapping(src, dict);
+      res = StringReplacer.replaceFromMapping(src, dict, arch);
       if (!recursive)
         break;
       if (res.equals(src))
@@ -85,16 +90,30 @@ public class StringReplacer {
     return res.toArray(new String[0]);
   }
 
+  public static String replaceFromMapping(String src, Map<String, String> map, String arch) {
+    return replaceFromMapping(src, map, "{", "}", arch);
+  }
+
   public static String replaceFromMapping(String src, Map<String, String> map) {
-    return replaceFromMapping(src, map, "{", "}");
+    return replaceFromMapping(src, map, "{", "}", "");
   }
 
   public static String replaceFromMapping(String src, Map<String, String> map,
                                           String leftDelimiter,
-                                          String rightDelimiter) {
+                                          String rightDelimiter,
+                                          String footer) {
     for (Map.Entry<String, String> entry : map.entrySet()) {
       String keyword = leftDelimiter + entry.getKey() + rightDelimiter;
-      if (entry.getValue() != null && keyword != null) {
+      String value = null;
+
+      // if {entry.getKey()+"."+footer} key exists, use it instead
+      if (map.containsKey(entry.getKey()+"."+footer)) {
+          value = map.get(entry.getKey()+"."+footer);
+      } else {
+          value = entry.getValue();
+      }
+
+      if (value != null && keyword != null) {
           src = src.replace(keyword, entry.getValue());
       }
     }


### PR DESCRIPTION
By doing so, runtime variable are resolved by using the board specific tools

real life example:
- Intel i585 defines sketchUploader (version 1.6.2)
- Intel arc32 defines sketchUploader (version 1.6.4)
- `runtime.tools.sketchUploader.path` gets the value of the last one processed

with this PR

`runtime.tools.sketchUploader.path.Intel.arc32` and `runtime.tools.sketchUploader.path.Intel.i586` get created

when resolving `{runtime.tools.sketchUploader}`, the routine searches for a key `runtime.tools.sketchUploader.Vendor.Architecture`

If found, the value is obtained by `{runtime.tools.sketchUploader.Vendor.Architecture}.getKey()`, which always contains the required value.
If no value is found, the old method is applied