### PR TITLE
Change the CTRL+DELETE behaviour to delete the next word

### DIFF
--- a/app/src/processing/app/syntax/SketchTextArea.java
+++ b/app/src/processing/app/syntax/SketchTextArea.java
@@ -30,6 +30,8 @@
 
 package processing.app.syntax;
 
+import java.awt.event.KeyEvent;
+import javax.swing.KeyStroke;
 import org.apache.commons.compress.utils.IOUtils;
 import org.fife.ui.rsyntaxtextarea.*;
 import org.fife.ui.rsyntaxtextarea.Token;
@@ -72,6 +74,7 @@ public class SketchTextArea extends RSyntaxTextArea {
   public SketchTextArea(PdeKeywords pdeKeywords) throws IOException {
     this.pdeKeywords = pdeKeywords;
     installFeatures();
+    fixCtrlDeleteBehavior();
   }
 
   public void setKeywords(PdeKeywords keywords) {
@@ -388,5 +391,11 @@ public class SketchTextArea extends RSyntaxTextArea {
   @Override
   protected RTextAreaUI createRTextAreaUI() {
     return new SketchTextAreaUI(this);
+  }
+
+  private void fixCtrlDeleteBehavior() {
+    KeyStroke keyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_DELETE,
+      Toolkit.getDefaultToolkit().getMenuShortcutKeyMask());
+    getInputMap().put(keyStroke, SketchTextAreaEditorKit.rtaDeleteNextWordAction);
   }
 }

--- a/app/src/processing/app/syntax/SketchTextArea.java
+++ b/app/src/processing/app/syntax/SketchTextArea.java
@@ -30,6 +30,7 @@
 
 package processing.app.syntax;
 
+import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import javax.swing.KeyStroke;
 import org.apache.commons.compress.utils.IOUtils;
@@ -58,6 +59,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
 import java.util.logging.Logger;
+import processing.app.helpers.OSUtils;
 
 /**
  * Arduino Sketch code editor based on RSyntaxTextArea (http://fifesoft.com/rsyntaxtextarea)
@@ -394,8 +396,8 @@ public class SketchTextArea extends RSyntaxTextArea {
   }
 
   private void fixCtrlDeleteBehavior() {
-    KeyStroke keyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_DELETE,
-      Toolkit.getDefaultToolkit().getMenuShortcutKeyMask());
+    int modifier = OSUtils.isMacOS()? InputEvent.ALT_MASK : InputEvent.CTRL_MASK;
+    KeyStroke keyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, modifier);
     getInputMap().put(keyStroke, SketchTextAreaEditorKit.rtaDeleteNextWordAction);
   }
 }


### PR DESCRIPTION
According to https://github.com/arduino/Arduino/issues/4778 , this restores the "normal" behaviour for the KeyStroke (CTRL | Command) + DELETE to delete only one word in front of cursor instead of the rest of the line.