### PR TITLE
Filter examples based on contributed libraries by architecture

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -82,6 +82,7 @@ public class Base {
 
   public static final Predicate<UserLibrary> CONTRIBUTED = library -> library.getTypes() == null || library.getTypes().isEmpty() || library.getTypes().contains("Contributed");
   public static final Predicate<UserLibrary> RETIRED = library -> library.getTypes() != null && library.getTypes().contains("Retired");
+  public static final Predicate<UserLibrary> COMPATIBLE = library -> library.getArchitectures() != null && (library.getArchitectures().contains("*") || library.getArchitectures().contains(BaseNoGui.getTargetPlatform().getId()));
 
   private static final int RECENT_SKETCHES_MAX_SIZE = 10;
 
@@ -1104,6 +1105,7 @@ public class Base {
     List<UserLibrary> libs = installedLibraries.stream()
       .filter(CONTRIBUTED.negate())
       .filter(RETIRED.negate())
+      .filter(COMPATIBLE)
       .collect(Collectors.toList());
     return new LibraryList(libs);
   }

--- a/arduino-core/src/cc/arduino/contributions/libraries/LibrariesIndexer.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/LibrariesIndexer.java
@@ -187,11 +187,11 @@ public class LibrariesIndexer {
     if (headers.length == 0) {
       throw new IOException(lib.getSrcFolder().getAbsolutePath());
     }
-    installedLibraries.addOrReplace(lib);
+    installedLibraries.addOrReplaceArchAware(lib);
     if (isSketchbook) {
       installedLibrariesWithDuplicates.add(lib);
     } else {
-      installedLibrariesWithDuplicates.addOrReplace(lib);
+      installedLibrariesWithDuplicates.addOrReplaceArchAware(lib);
     }
 
     // Check if we can find the same library in the index

--- a/arduino-core/src/processing/app/packages/LibraryList.java
+++ b/arduino-core/src/processing/app/packages/LibraryList.java
@@ -57,15 +57,25 @@ public class LibraryList extends LinkedList<UserLibrary> {
     return null;
   }
 
+  public synchronized void addOrReplaceArchAware(UserLibrary lib) {
+    addOrReplace(lib, true);
+  }
+
   public synchronized void addOrReplace(UserLibrary lib) {
-    remove(lib);
+    addOrReplace(lib, false);
+  }
+
+  public synchronized void addOrReplace(UserLibrary lib, boolean archAware) {
+    remove(lib, archAware);
     add(lib);
   }
-  
-  public synchronized void remove(UserLibrary lib) {
+
+  public synchronized void remove(UserLibrary lib, boolean archAware) {
     UserLibrary l = getByName(lib.getName());
-    if (l != null)
-      super.remove(l);
+    if (l != null) {
+      if (!archAware || lib.getArchitectures().contains("*") || lib.getArchitectures().containsAll(l.getArchitectures()))
+        super.remove(l);
+    }
   }
 
   public synchronized void sort() {


### PR DESCRIPTION
Adds "COMPATIBLE" filter for Contributed libraries, this is not enough to ensure that the correct examples get displayed because the `addOrReplace` routine overrides the previous results.
Adding an architecture-aware routine to handle this (overrides old library only if the the architecture field is compatible)

Solves #4762, to be tested with nightly (`arduino-builder` >= 1.3.15)