### PR TITLE
Do not save build_properties_custom.* preferences to disk

### DIFF
--- a/arduino-core/src/processing/app/PreferencesData.java
+++ b/arduino-core/src/processing/app/PreferencesData.java
@@ -120,7 +120,7 @@ public class PreferencesData {
       String[] keys = prefs.keySet().toArray(new String[0]);
       Arrays.sort(keys);
       for (String key : keys) {
-        if (key.startsWith("runtime."))
+        if (key.startsWith("runtime.") || key.startsWith("build_properties_custom."))
           continue;
         writer.println(key + "=" + prefs.get(key));
       }


### PR DESCRIPTION
Related to #4702.

If a ```--pref``` option is passed into the IDE as a command line arg, then it is also saved in the ```preferences.txt file``` with a ```build_properties_custom.``` prefix.

For example: ```arduino --pref "boardsmanager.additional.urls=http://arduino.esp8266.com/stable/package_esp8266com_index.json" --install-boards esp8266:esp8266```

will add the following line:

```
build_properties_custom.boardsmanager.additional.urls=http://arduino.esp8266.com/stable/package_esp8266com_index.json
```

The main purpose of the ```build_properties_custom.*``` properties is to pass in custom build properties to the Compiler. See [Compiler.java](https://github.com/arduino/Arduino/blob/8385aedc642d6cd76b50ac5167307121007e5045/arduino-core/src/cc/arduino/Compiler.java#L230-L234). I think these parameters are not mean't to be persistent.