### PR TITLE
Subtract one from USB_EP_SIZE in USB_SendSpace

### DIFF
--- a/hardware/arduino/avr/cores/arduino/USBCore.cpp
+++ b/hardware/arduino/avr/cores/arduino/USBCore.cpp
@@ -255,7 +255,9 @@ u8 USB_SendSpace(u8 ep)
 	LockEP lock(ep);
 	if (!ReadWriteAllowed())
 		return 0;
-	return USB_EP_SIZE - FifoByteCount();
+	// subtract 1 from the EP size to never send a full packet,
+	// this avoids dealing with ZLP's in USB_Send
+	return USB_EP_SIZE - 1 - FifoByteCount();
 }
 
 //	Blocking Send of data to an endpoint


### PR DESCRIPTION
This avoids dealing with ZLP’s in ```USB_Send```, because the max packet size will be EP size - 1.

Alternative to #4138 to resolve #3946.

cc/ @NicoHood @embmicro @BlackBrix.