### PR TITLE
fast serialUSB read function readBlock

### DIFF
--- a/hardware/arduino/sam/cores/arduino/Stream.cpp
+++ b/hardware/arduino/sam/cores/arduino/Stream.cpp
@@ -211,6 +211,19 @@ size_t Stream::readBytes(char *buffer, size_t length)
   return count;
 }
 
+// the same as readBytes only super fast
+size_t Stream::readBlock(char *buffer, size_t length)
+{
+  size_t count = 0;
+  int n;
+  _startMillis = millis();
+  while (count < length && millis() - _startMillis < _timeout) {
+    n = SerialUSB.readb(buffer+count, length-count);
+    count += (size_t)n;
+    if (n) _startMillis = millis();
+  }
+  return count;
+}
 
 // as readBytes with terminator character
 // terminates if length characters have been read, timeout, or if the terminator character  detected

--- a/hardware/arduino/sam/cores/arduino/Stream.h
+++ b/hardware/arduino/sam/cores/arduino/Stream.h
@@ -103,6 +103,9 @@ class Stream : public Print
   // terminates if length characters have been read, timeout, or if the terminator character  detected
   // returns the number of characters placed in the buffer (0 means no valid data found)
 
+  size_t readBlock( char *buffer, size_t length); // read block of chars from stream into buffer
+  size_t readBlock( uint8_t *buffer, size_t length) { return readBlock((char *)buffer, length); }
+
   // Arduino String functions to be added here
   String readString();
   String readStringUntil(char terminator);

--- a/hardware/arduino/sam/cores/arduino/USB/CDC.cpp
+++ b/hardware/arduino/sam/cores/arduino/USB/CDC.cpp
@@ -191,7 +191,6 @@ void Serial_::accept(void)
 	// current location of the tail), we're about to overflow the buffer
 	// and so we don't write the character or advance the head.
 	while (i != buffer->tail) {
-		uint32_t c;
 		if (!USBD_Available(CDC_RX)) {
 			udd_ack_fifocon(CDC_RX);
 			break;

--- a/hardware/arduino/sam/cores/arduino/USB/CDC.cpp
+++ b/hardware/arduino/sam/cores/arduino/USB/CDC.cpp
@@ -196,12 +196,13 @@ void Serial_::accept(void)
 			udd_ack_fifocon(CDC_RX);
 			break;
 		}
-		c = USBD_Recv(CDC_RX);
-		// c = UDD_Recv8(CDC_RX & 0xF);
-		buffer->buffer[buffer->head] = c;
-		buffer->head = i;
-
-		i = (i + 1) % CDC_SERIAL_BUFFER_SIZE;
+		uint8_t c[CDC_SERIAL_BUFFER_SIZE];
+                uint32_t k = USBD_Recv(CDC_RX, &c, (buffer->tail - i) % CDC_SERIAL_BUFFER_SIZE);
+                uint32_t j;
+                for (j=0;j<k;j++) buffer->buffer[(buffer->head + j) % CDC_SERIAL_BUFFER_SIZE] = c[j];
+                buffer->head = (buffer->head + k) % CDC_SERIAL_BUFFER_SIZE;
+                
+                i = (i + k) % CDC_SERIAL_BUFFER_SIZE;
 	}
 
 	// release the guard
@@ -245,6 +246,28 @@ int Serial_::read(void)
 			accept();
 		return c;
 	}
+}
+
+int Serial_::readb(char *c, size_t length)
+{
+        ring_buffer *buffer = &cdc_rx_buffer;
+
+        // if the head isn't ahead of the tail, we don't have any characters
+        if (buffer->head == buffer->tail)
+        {
+                return 0;
+        }
+        else
+        {
+                unsigned int d = min((buffer->head - buffer->tail) % CDC_SERIAL_BUFFER_SIZE, length);
+                unsigned int i;
+                for (i = 0; i < d; i++) *c++ = buffer->buffer[(buffer->tail + i) % CDC_SERIAL_BUFFER_SIZE];
+                buffer->tail = (unsigned int)(buffer->tail + d) % CDC_SERIAL_BUFFER_SIZE;
+
+                if (USBD_Available(CDC_RX))
+                        accept();
+                return d;
+        }
 }
 
 void Serial_::flush(void)

--- a/hardware/arduino/sam/cores/arduino/USB/USBAPI.h
+++ b/hardware/arduino/sam/cores/arduino/USB/USBAPI.h
@@ -57,6 +57,7 @@ public:
 	virtual void accept(void);
 	virtual int peek(void);
 	virtual int read(void);
+	virtual int readb(char *c, size_t length);
 	virtual void flush(void);
 	virtual size_t write(uint8_t);
 	virtual size_t write(const uint8_t *buffer, size_t size);

--- a/hardware/arduino/sam/cores/arduino/USB/USBCore.cpp
+++ b/hardware/arduino/sam/cores/arduino/USB/USBCore.cpp
@@ -143,12 +143,9 @@ uint32_t USBD_Recv(uint32_t ep, void* d, uint32_t len)
 		return -1;
 
 	LockEP lock(ep);
-	uint32_t n = UDD_FifoByteCount(ep & 0xF);
-	len = min(n,len);
-	n = len;
-	uint8_t* dst = (uint8_t*)d;
-	while (n--)
-		*dst++ = UDD_Recv8(ep & 0xF);
+	len = min(UDD_FifoByteCount(ep & 0xF),len);
+        uint8_t* dst = (uint8_t*)d;
+        UDD_Recv(ep & 0xF, dst, len);
 	if (len && !UDD_FifoByteCount(ep & 0xF)) // release empty buffer
 		UDD_ReleaseRX(ep & 0xF);
 


### PR DESCRIPTION
The main idea is that bytes are written and read into/from CDC buffer not one by one but block of bytes.

Serial_::accept write into CDC buffer as maximum as possible (only to not overflow the buffer)
Serial_::readb (you can change just read, not use readb) get from CDC buffer as maximum as possible or nessasary length

and one more important thing: in USBD_Recv "while (n--) *dst++ = UDD_Recv8(ep & 0xF);" should be replaced into UDD_Recv(ep & 0xF, dst, len);

after that read speed is incredible increases !!!  Up to 12Mbit/s
