### PR TITLE
Implement Do-Not-Verify-After-Upload preference for Serial Uploads

### DIFF
--- a/arduino-core/src/cc/arduino/packages/Uploader.java
+++ b/arduino-core/src/cc/arduino/packages/Uploader.java
@@ -70,6 +70,7 @@ public abstract class Uploader implements MessageConsumer {
   }
 
   protected final boolean verbose;
+  protected final boolean verifyUpload;
 
   private String error;
   protected boolean notFoundError;
@@ -77,11 +78,13 @@ public abstract class Uploader implements MessageConsumer {
 
   protected Uploader() {
     this.verbose = PreferencesData.getBoolean("upload.verbose");
+    this.verifyUpload = PreferencesData.getBoolean("upload.verify");
     init(false);
   }
 
   protected Uploader(boolean nup) {
     this.verbose = PreferencesData.getBoolean("upload.verbose");
+    this.verifyUpload = PreferencesData.getBoolean("upload.verify");
     init(nup);
   }
 

--- a/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
+++ b/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
@@ -102,6 +102,11 @@ public class SerialUploader extends Uploader {
       else
         prefs.put("upload.verbose", prefs.getOrExcept("upload.params.quiet"));
 
+      if (verifyUpload)
+        prefs.put("upload.verify", prefs.get("upload.params.verify", ""));
+      else
+        prefs.put("upload.verify", prefs.get("upload.params.noverify", ""));
+
       boolean uploadResult;
       try {
         String pattern = prefs.getOrExcept("upload.pattern");
@@ -191,6 +196,11 @@ public class SerialUploader extends Uploader {
     } else {
       prefs.put("upload.verbose", prefs.getOrExcept("upload.params.quiet"));
     }
+
+    if (verifyUpload)
+      prefs.put("upload.verify", prefs.get("upload.params.verify", ""));
+    else
+      prefs.put("upload.verify", prefs.get("upload.params.noverify", ""));
 
     boolean uploadResult;
     try {
@@ -317,6 +327,11 @@ public class SerialUploader extends Uploader {
       prefs.put("program.verbose", prefs.getOrExcept("program.params.verbose"));
     else
       prefs.put("program.verbose", prefs.getOrExcept("program.params.quiet"));
+
+    if (verifyUpload)
+      prefs.put("program.verify", prefs.get("program.params.verify", ""));
+    else
+      prefs.put("program.verify", prefs.get("program.params.noverify", ""));
 
     try {
       // if (prefs.get("program.disable_flushing") == null

--- a/hardware/arduino/avr/platform.txt
+++ b/hardware/arduino/avr/platform.txt
@@ -97,11 +97,13 @@ tools.avrdude.config.path={path}/etc/avrdude.conf
 
 tools.avrdude.upload.params.verbose=-v
 tools.avrdude.upload.params.quiet=-q -q
-tools.avrdude.upload.pattern="{cmd.path}" "-C{config.path}" {upload.verbose} -p{build.mcu} -c{upload.protocol} -P{serial.port} -b{upload.speed} -D "-Uflash:w:{build.path}/{build.project_name}.hex:i"
+tools.avrdude.upload.params.noverify=-V
+tools.avrdude.upload.pattern="{cmd.path}" "-C{config.path}" {upload.verbose} {upload.verify} -p{build.mcu} -c{upload.protocol} -P{serial.port} -b{upload.speed} -D "-Uflash:w:{build.path}/{build.project_name}.hex:i"
 
 tools.avrdude.program.params.verbose=-v
 tools.avrdude.program.params.quiet=-q -q
-tools.avrdude.program.pattern="{cmd.path}" "-C{config.path}" {program.verbose} -p{build.mcu} -c{protocol} {program.extra_params} "-Uflash:w:{build.path}/{build.project_name}.hex:i"
+tools.avrdude.program.params.noverify=-V
+tools.avrdude.program.pattern="{cmd.path}" "-C{config.path}" {program.verbose} {program.verify} -p{build.mcu} -c{protocol} {program.extra_params} "-Uflash:w:{build.path}/{build.project_name}.hex:i"
 
 tools.avrdude.erase.params.verbose=-v
 tools.avrdude.erase.params.quiet=-q -q


### PR DESCRIPTION
This change picks up the existing upload.verify preference from the preferences dialog/preferences.txt and allows you to use this with your USB/Serial upload tool of choice. Configuration is already added for avrdude. This option stopped working somewhere around the update to 1.5.

It uses PreferencesMap.get to avoid an exception if the config is not found in platforms.txt - this should avoid problems with other cores and allow backwards compatibility.

The SAM and SAMD cores can be updated later if required. They won't benefit much from the change as the upload speed is so much better.

