### PR TITLE
SD: File open with O_WRITE would always append, even when O_APPEND is…

### DIFF
--- a/libraries/SD/src/SD.cpp
+++ b/libraries/SD/src/SD.cpp
@@ -465,7 +465,7 @@ File SDClass::open(const char *filepath, uint8_t mode) {
     parentdir.close();
   }
 
-  if (mode & (O_APPEND | O_WRITE)) 
+  if ((mode & (O_APPEND | O_WRITE)) == (O_APPEND | O_WRITE))
     file.seekSet(file.fileSize());
   return File(file, filepath);
 }


### PR DESCRIPTION
… off

Without this fix it is not possible to open an existing file and truncate
the contents.