### PR TITLE
Move Caterina_BL related defines into generic USBCore.h

### DIFF
--- a/hardware/arduino/avr/cores/arduino/USBCore.h
+++ b/hardware/arduino/avr/cores/arduino/USBCore.h
@@ -277,5 +277,22 @@ typedef struct
 #define D_CDCCS(_subtype,_d0,_d1)	{ 5, 0x24, _subtype, _d0, _d1 }
 #define D_CDCCS4(_subtype,_d0)		{ 4, 0x24, _subtype, _d0 }
 
+// Bootloader related fields
+// Old Caterina bootloader places the MAGIC key into unsafe RAM locations (it can be rewritten
+// by the running sketch before to actual reboot).
+// Newer bootloaders, recognizable by the LUFA "signature" at the end of the flash, can handle both
+// the usafe and the safe location. Check once (in USBCore.cpp) if the bootloader in new, then set the global
+// _updatedLUFAbootloader variable to true/false and place the magic key consequently
+#ifndef MAGIC_KEY
+#define MAGIC_KEY 0x7777
+#endif
+
+#ifndef MAGIC_KEY_POS
+#define MAGIC_KEY_POS 0x0800
+#endif
+
+#ifndef NEW_LUFA_SIGNATURE
+#define NEW_LUFA_SIGNATURE 0xDCFB
+#endif
 
 #endif

--- a/hardware/arduino/avr/variants/leonardo/pins_arduino.h
+++ b/hardware/arduino/avr/variants/leonardo/pins_arduino.h
@@ -366,22 +366,4 @@ const uint8_t PROGMEM analog_pin_to_channel_PGM[] = {
 // Alias SerialUSB to Serial
 #define SerialUSB SERIAL_PORT_USBVIRTUAL
 
-// Bootloader related fields
-// Old Caterina bootloader places the MAGIC key into unsafe RAM locations (it can be rewritten
-// by the running sketch before to actual reboot).
-// Newer bootloaders, recognizable by the LUFA "signature" at the end of the flash, can handle both
-// the usafe and the safe location. Check once (in USBCore.cpp) if the bootloader in new, then set the global
-// _updatedLUFAbootloader variable to true/false and place the magic key consequently
-#ifndef MAGIC_KEY
-#define MAGIC_KEY 0x7777
-#endif
-
-#ifndef MAGIC_KEY_POS
-#define MAGIC_KEY_POS 0x0800
-#endif
-
-#ifndef NEW_LUFA_SIGNATURE
-#define NEW_LUFA_SIGNATURE 0xDCFB
-#endif
-
 #endif /* Pins_Arduino_h */


### PR DESCRIPTION
In an excess of confidence, these defines were added to Leonardo's variant.h
3rd party boards sometimes avoid inheriting this variant but they still define `USBCON`, thus breaking the build

@NicoHood 