### PR TITLE
Add possibility to change server tcp port in void setup. No more fixed port!

### DIFF
--- a/libraries/Ethernet/src/EthernetServer.cpp
+++ b/libraries/Ethernet/src/EthernetServer.cpp
@@ -24,9 +24,7 @@ void EthernetServer::begin(uint16_t port)
   }  
 }
 
-void EthernetServer::begin() {
-  begin(80);
-}
+void EthernetServer::begin() {}
 
 void EthernetServer::accept()
 {

--- a/libraries/Ethernet/src/EthernetServer.cpp
+++ b/libraries/Ethernet/src/EthernetServer.cpp
@@ -8,6 +8,11 @@ extern "C" {
 #include "EthernetClient.h"
 #include "EthernetServer.h"
 
+EthernetServer::EthernetServer(uint16_t port)
+{
+  _port = port;
+}
+
 EthernetServer::EthernetServer() {}
 
 void EthernetServer::begin(uint16_t port)

--- a/libraries/Ethernet/src/EthernetServer.cpp
+++ b/libraries/Ethernet/src/EthernetServer.cpp
@@ -24,7 +24,9 @@ void EthernetServer::begin(uint16_t port)
   }  
 }
 
-void EthernetServer::begin() {}
+void EthernetServer::begin() {
+   begin(_port);
+}
 
 void EthernetServer::accept()
 {

--- a/libraries/Ethernet/src/EthernetServer.cpp
+++ b/libraries/Ethernet/src/EthernetServer.cpp
@@ -8,13 +8,11 @@ extern "C" {
 #include "EthernetClient.h"
 #include "EthernetServer.h"
 
-EthernetServer::EthernetServer(uint16_t port)
-{
-  _port = port;
-}
+EthernetServer::EthernetServer() {}
 
-void EthernetServer::begin()
+void EthernetServer::begin(uint16_t port)
 {
+   _port = port;
   for (int sock = 0; sock < MAX_SOCK_NUM; sock++) {
     EthernetClient client(sock);
     if (client.status() == SnSR::CLOSED) {
@@ -24,6 +22,10 @@ void EthernetServer::begin()
       break;
     }
   }  
+}
+
+void EthernetServer::begin() {
+  begin(80);
 }
 
 void EthernetServer::accept()

--- a/libraries/Ethernet/src/EthernetServer.h
+++ b/libraries/Ethernet/src/EthernetServer.h
@@ -11,8 +11,9 @@ private:
   uint16_t _port;
   void accept();
 public:
-  EthernetServer(uint16_t);
+  EthernetServer();
   EthernetClient available();
+  virtual void begin(uint16_t);
   virtual void begin();
   virtual size_t write(uint8_t);
   virtual size_t write(const uint8_t *buf, size_t size);

--- a/libraries/Ethernet/src/EthernetServer.h
+++ b/libraries/Ethernet/src/EthernetServer.h
@@ -11,6 +11,7 @@ private:
   uint16_t _port;
   void accept();
 public:
+  EthernetServer(uint16_t);
   EthernetServer();
   EthernetClient available();
   virtual void begin(uint16_t);


### PR DESCRIPTION
Before this mofication:

EthernetServer server(80);
void setup() {
  //some stuff here
  server.begin(); //User can't change initial port value
  //other stuff here
}


Now:

EthernetServer server; //without port declaration but still working old declaration system...
void setup() {
  //some stuff here
  unsigned int tcp = EEPROM.read(x)
  server.begin(tcp); //User can now use a different port, maybe saved in eprom directly from the sketch in a configuration page that permise to choice a value for the tcp port...
  //other stuff here
}


Many thanks to Arduino's forum user: SukkoPera