### PR TITLE
"Include library" now checks for `includes` property

### DIFF
--- a/app/src/processing/app/Sketch.java
+++ b/app/src/processing/app/Sketch.java
@@ -917,20 +917,20 @@ public class Sketch {
   }
 
 
-  public void importLibrary(UserLibrary lib) throws IOException {
-    importLibrary(lib.getSrcFolder());
-  }
-
   /**
-   * Add import statements to the current tab for all of packages inside
-   * the specified jar file.
+   * Add import statements to the current tab for the specified library
    */
-  private void importLibrary(File jarPath) throws IOException {
+  public void importLibrary(UserLibrary lib) throws IOException {
     // make sure the user didn't hide the sketch folder
     ensureExistence();
 
-    String list[] = Base.headerListFromIncludePath(jarPath);
-    if (list == null || list.length == 0) {
+    List<String> list = lib.getIncludes();
+    if (list == null) {
+      File srcFolder = lib.getSrcFolder();
+      String[] headers = Base.headerListFromIncludePath(srcFolder);
+      list = Arrays.asList(headers);
+    }
+    if (list.isEmpty()) {
       return;
     }
 

--- a/arduino-core/src/processing/app/packages/UserLibrary.java
+++ b/arduino-core/src/processing/app/packages/UserLibrary.java
@@ -56,6 +56,7 @@ public class UserLibrary extends ContributedLibrary {
   private List<String> types;
   private List<String> declaredTypes;
   private boolean onGoingDevelopment;
+  private List<String> includes;
 
   public static UserLibrary create(File libFolder) throws IOException {
     // Parse metadata
@@ -131,6 +132,13 @@ public class UserLibrary extends ContributedLibrary {
       typesList.add(type.trim());
     }
 
+    List<String> includes = null;
+    if (properties.containsKey("includes")) {
+      includes = new ArrayList<>();
+      for (String i : properties.get("includes").split(","))
+        includes.add(i.trim());
+    }
+
     UserLibrary res = new UserLibrary();
     res.setInstalledFolder(libFolder);
     res.setInstalled(true);
@@ -147,6 +155,7 @@ public class UserLibrary extends ContributedLibrary {
     res.layout = layout;
     res.declaredTypes = typesList;
     res.onGoingDevelopment = Files.exists(Paths.get(libFolder.getAbsolutePath(), Constants.LIBRARY_DEVELOPMENT_FLAG_FILE));
+    res.includes = includes;
     return res;
   }
 
@@ -247,6 +256,10 @@ public class UserLibrary extends ContributedLibrary {
     return onGoingDevelopment;
   }
 
+  public List<String> getIncludes() {
+    return includes;
+  }
+
   protected enum LibraryLayout {
     FLAT, RECURSIVE
   }
@@ -278,6 +291,8 @@ public class UserLibrary extends ContributedLibrary {
     res += "         (paragraph=" + paragraph + ")\n";
     res += "         (url=" + website + ")\n";
     res += "         (architectures=" + architectures + ")\n";
+    if (includes != null)
+      res += "         (includes=" + includes + ")\n";
     return res;
   }
 


### PR DESCRIPTION
A new property "includes" has been added to library.properties.
This property contains a comma-separated list of the files to be included when
the user selects the "Include library" command on the Arduino IDE.

If the property is missing the old behaviour is used.

Fixes #5044 

/cc @vshymanskyy @matteosuppo 
