### PR TITLE
Make String::move of an invalidated String result in an invalidated String

### DIFF
--- a/hardware/arduino/avr/cores/arduino/WString.cpp
+++ b/hardware/arduino/avr/cores/arduino/WString.cpp
@@ -193,7 +193,7 @@ String & String::copy(const __FlashStringHelper *pstr, unsigned int length)
 void String::move(String &rhs)
 {
 	if (buffer) {
-		if (capacity >= rhs.len) {
+		if (rhs && capacity >= rhs.len) {
 			strcpy(buffer, rhs.buffer);
 			len = rhs.len;
 			rhs.len = 0;

--- a/hardware/arduino/sam/cores/arduino/WString.cpp
+++ b/hardware/arduino/sam/cores/arduino/WString.cpp
@@ -195,7 +195,7 @@ String & String::copy(const __FlashStringHelper *pstr, unsigned int length)
 void String::move(String &rhs)
 {
 	if (buffer) {
-		if (capacity >= rhs.len) {
+		if (rhs && capacity >= rhs.len) {
 			strcpy(buffer, rhs.buffer);
 			len = rhs.len;
 			rhs.len = 0;


### PR DESCRIPTION
Currently the sketch below prints out:

```
b is false
s is true
```

However, I expect the output to be:

```
b is false
s is false
```

because the `blah()` function returns an invalidated String (NULL buffer, zero length). However, since the `String s;` is equivalent to `String s("")`, `s`'s buffer is `realloc(NULL, 0)` resulting in a valid buffer.

```arduino
String s;

void setup() {
  Serial.begin(9600);
  while(!Serial);

  s = blah();

  if (s) {
    Serial.println("s is true");
  } else {
    Serial.println("s is false");
  }
}

String blah() {
  String b((const char*)NULL);

  if (b) {
    Serial.println("b is true");
  } else {
    Serial.println("b is false");
  }

  return b;
}

void loop() {
}
```