### PR TITLE
[AVR][USB] Configurable USB_VERSION value via define

### DIFF
--- a/hardware/arduino/avr/cores/arduino/USBCore.h
+++ b/hardware/arduino/avr/cores/arduino/USBCore.h
@@ -126,11 +126,15 @@
 #define MSC_SUBCLASS_SCSI						0x06 
 #define MSC_PROTOCOL_BULK_ONLY					0x50 
 
+#ifndef USB_VERSION
+#define USB_VERSION 0x200
+#endif
+
 //	Device
 typedef struct {
 	u8 len;				// 18
 	u8 dtype;			// 1 USB_DEVICE_DESCRIPTOR_TYPE
-	u16 usbVersion;		// 0x200
+	u16 usbVersion;		// 0x200 or 0x210
 	u8	deviceClass;
 	u8	deviceSubClass;
 	u8	deviceProtocol;
@@ -260,7 +264,7 @@ typedef struct
 
 
 #define D_DEVICE(_class,_subClass,_proto,_packetSize0,_vid,_pid,_version,_im,_ip,_is,_configs) \
-	{ 18, 1, 0x200, _class,_subClass,_proto,_packetSize0,_vid,_pid,_version,_im,_ip,_is,_configs }
+	{ 18, 1, USB_VERSION, _class,_subClass,_proto,_packetSize0,_vid,_pid,_version,_im,_ip,_is,_configs }
 
 #define D_CONFIG(_totalLength,_interfaces) \
 	{ 9, 2, _totalLength,_interfaces, 1, 0, USB_CONFIG_BUS_POWERED | USB_CONFIG_REMOTE_WAKEUP, USB_CONFIG_POWER_MA(500) }


### PR DESCRIPTION
To allow WebUSB development on atmega32u4 boards, provide a way to change the reported USB compliance version using an external define (contained in an additional core)

This (webUSB) core will survive IDE and AVR core updates, making it easier to test https://github.com/WICG/webusb and https://github.com/webusb/arduino/

replaces #4627 and #4793