### PR TITLE
Do not show splash screen when options are present

### DIFF
--- a/build/linux/dist/arduino
+++ b/build/linux/dist/arduino
@@ -27,7 +27,8 @@ fi
 # Collect options to java in an array, to properly handle whitespace in options
 JAVA_OPTIONS=("-DAPP_DIR=$APPDIR" "-Dswing.defaultlaf=com.sun.java.swing.plaf.gtk.GTKLookAndFeel")
 
-if [[ "$@" != *"--upload"* && "$@" != *"--verify"* && "$@" != *"--get-pref"* && "$@" != *"--install-board"* && "$@" != *"--install-library"* ]] ; then
+# Only show the splash screen when no options are present
+if [[ "$@" != *"--"* ]] ; then
 	JAVA_OPTIONS+=("-splash:$APPDIR/lib/splash.png")
 fi
 


### PR DESCRIPTION
This ensures now splash-screen is shown when preferences are changed or CLI-mode is used.

More information in #5131.

However this does NOT fix #5131, since the Arduino IDE in CLI-mode still requires X11 (according to #1981).