### PR TITLE
Send an USB remote wakeup if data need to be written

### DIFF
--- a/hardware/arduino/avr/cores/arduino/USBCore.cpp
+++ b/hardware/arduino/avr/cores/arduino/USBCore.cpp
@@ -1,6 +1,7 @@
 
 
-/* Copyright (c) 2010, Peter Barrett  
+/* Copyright (c) 2010, Peter Barrett
+** Sleep/Wakeup support added by Michael Dreher
 **  
 ** Permission to use, copy, modify, and/or distribute this software for  
 ** any purpose with or without fee is hereby granted, provided that the  
@@ -265,6 +266,11 @@ int USB_Send(u8 ep, const void* d, int len)
 {
 	if (!_usbConfiguration)
 		return -1;
+
+	if (_usbSuspendState & (1<<SUSPI)) {
+		//send a remote wakeup
+		UDCON |= (1 << RMWKUP);
+	}
 
 	int r = len;
 	const u8* data = (const u8*)d;


### PR DESCRIPTION
On Linux, setting autosuspend_delay_ms to N and control to auto allows the host pc to suspend the peripheral. Some Linux distro (Ubuntu, Mint) apply this behaviour by default.
If the sketch's prints where less frequent than N milliseconds the sketch prints would never arrive.
This patch allows sending a remote wakeup event to unsuspend the peripheral and allow the serial prints to be received.