### PR TITLE
Contributed tools may not be platform-compatible -- this situation cu…

### DIFF
--- a/arduino-core/src/processing/app/BaseNoGui.java
+++ b/arduino-core/src/processing/app/BaseNoGui.java
@@ -3,6 +3,7 @@ package processing.app;
 import cc.arduino.Compiler;
 import cc.arduino.Constants;
 import cc.arduino.UploaderUtils;
+import cc.arduino.contributions.DownloadableContribution;
 import cc.arduino.contributions.GPGDetachedSignatureVerifier;
 import cc.arduino.contributions.SignatureVerificationFailedException;
 import cc.arduino.contributions.libraries.LibrariesIndexer;
@@ -853,15 +854,18 @@ public class BaseNoGui {
     }
 
     for (ContributedTool tool : installedTools) {
-      File installedFolder = tool.getDownloadableContribution(getPlatform()).getInstalledFolder();
-      String absolutePath;
-      if (installedFolder != null) {
-        absolutePath = installedFolder.getAbsolutePath();
-      } else {
-        absolutePath = Constants.PREF_REMOVE_PLACEHOLDER;
+      DownloadableContribution dlContrib = tool.getDownloadableContribution(getPlatform());
+      if (dlContrib != null) {
+        File installedFolder = dlContrib.getInstalledFolder();
+        String absolutePath;
+        if (installedFolder != null) {
+          absolutePath = installedFolder.getAbsolutePath();
+        } else {
+          absolutePath = Constants.PREF_REMOVE_PLACEHOLDER;
+        }
+        PreferencesData.set(prefix + tool.getName() + ".path", absolutePath);
+        PreferencesData.set(prefix + tool.getName() + "-" + tool.getVersion() + ".path", absolutePath);
       }
-      PreferencesData.set(prefix + tool.getName() + ".path", absolutePath);
-      PreferencesData.set(prefix + tool.getName() + "-" + tool.getVersion() + ".path", absolutePath);
     }
   }
 


### PR DESCRIPTION
…rrently fails terribly. This may not be the ideal situation, but it would be nice if it didn't crash and burn the IDE if it happens. =)

With this change and manually replacing libastylej/liblistSerialsj, the IDE comes up relatively cleanly and I can move onto some other platform-related issues before going back and addressing the build issues.