### PR TITLE
Improve Examples menu

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1261,8 +1261,8 @@ public class Base {
     }
 
     // Add examples from libraries
-    ideLibs.sort();
     if (!ideLibs.isEmpty()) {
+      ideLibs.sort();
       label = new JMenuItem(tr("Examples from Built-in Libraries"));
       label.setEnabled(false);
       menu.add(label);

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -80,10 +80,6 @@ import static processing.app.I18n.tr;
  */
 public class Base {
 
-  public static final Predicate<UserLibrary> CONTRIBUTED = library -> library.getTypes() == null || library.getTypes().isEmpty() || library.getTypes().contains("Contributed");
-  public static final Predicate<UserLibrary> RETIRED = library -> library.getTypes() != null && library.getTypes().contains("Retired");
-  public static final Predicate<UserLibrary> COMPATIBLE = library -> library.getArchitectures() != null && (library.getArchitectures().contains("*") || library.getArchitectures().contains(BaseNoGui.getTargetPlatform().getId()));
-
   private static final int RECENT_SKETCHES_MAX_SIZE = 10;
 
   private static boolean commandLine;
@@ -1100,30 +1096,6 @@ public class Base {
     }
   }
 
-  public LibraryList getIDELibs() {
-    LibraryList installedLibraries = new LibraryList(BaseNoGui.librariesIndexer.getInstalledLibraries());
-    List<UserLibrary> libs = installedLibraries.stream()
-      .filter(CONTRIBUTED.negate())
-      .filter(RETIRED.negate())
-      .filter(COMPATIBLE)
-      .collect(Collectors.toList());
-    return new LibraryList(libs);
-  }
-
-  public LibraryList getIDERetiredLibs() {
-    LibraryList installedLibraries = new LibraryList(BaseNoGui.librariesIndexer.getInstalledLibraries());
-    List<UserLibrary> libs = installedLibraries.stream()
-      .filter(RETIRED)
-      .collect(Collectors.toList());
-    return new LibraryList(libs);
-  }
-
-  public LibraryList getUserLibs() {
-    LibraryList installedLibraries = new LibraryList(BaseNoGui.librariesIndexer.getInstalledLibraries());
-    List<UserLibrary> libs = installedLibraries.stream().filter(CONTRIBUTED).collect(Collectors.toList());
-    return new LibraryList(libs);
-  }
-
   private List<ContributedLibrary> getSortedLibraries() {
     List<ContributedLibrary> installedLibraries = new LinkedList<ContributedLibrary>(BaseNoGui.librariesIndexer.getInstalledLibraries());
     Collections.sort(installedLibraries, new LibraryByTypeComparator());
@@ -1206,11 +1178,92 @@ public class Base {
       menu.addSeparator();
     }
 
+    // Libraries can come from 4 locations: collect info about all four
+    File ideLibraryPath = BaseNoGui.getContentFile("libraries");
+    File sketchbookLibraryPath = BaseNoGui.getSketchbookLibrariesFolder();
+    File platformLibraryPath = null;
+    File referencedPlatformLibraryPath = null;
+    String platformName = null;
+    String referencedPlatformName = null;
+    String myArch = null;
+    TargetPlatform targetPlatform = BaseNoGui.getTargetPlatform();
+    if (targetPlatform != null) {
+      myArch = targetPlatform.getId();
+      platformName = targetPlatform.getPreferences().get("name");
+      platformLibraryPath = new File(targetPlatform.getFolder(), "libraries");
+      String core = BaseNoGui.getBoardPreferences().get("build.core", "arduino");
+      if (core.contains(":")) {
+        String refcore = core.split(":")[0];
+        TargetPlatform referencedPlatform = BaseNoGui.getTargetPlatform(refcore, myArch);
+        if (referencedPlatform != null) {
+          referencedPlatformName = referencedPlatform.getPreferences().get("name");
+          referencedPlatformLibraryPath = new File(referencedPlatform.getFolder(), "libraries");
+        }
+      }
+    }
+
+    // Divide the libraries into 7 lists, corresponding to the 4 locations
+    // with the retired IDE libs further divided into their own list, and
+    // any incompatible sketchbook libs further divided into their own list.
+    // The 7th list of "other" libraries should always be empty, but serves
+    // as a safety feature to prevent any library from vanishing.
+    LibraryList allLibraries = new LibraryList(BaseNoGui.librariesIndexer.getInstalledLibraries());
+    LibraryList ideLibs = new LibraryList();
+    LibraryList retiredIdeLibs = new LibraryList();
+    LibraryList platformLibs = new LibraryList();
+    LibraryList referencedPlatformLibs = new LibraryList();
+    LibraryList sketchbookLibs = new LibraryList();
+    LibraryList sketchbookIncompatibleLibs = new LibraryList();
+    LibraryList otherLibs = new LibraryList();
+    for (UserLibrary lib : allLibraries) {
+      // Get the library's location - used for sorting into categories
+      File libraryLocation = lib.getInstalledFolder().getParentFile();
+      // Is this library compatible?
+      List<String> arch = lib.getArchitectures();
+      boolean compatible;
+      if (myArch == null || arch == null || arch.contains("*")) {
+        compatible = true;
+      } else {
+        compatible = arch.contains(myArch);
+      }
+      // IDE Libaries (including retired)
+      if (libraryLocation.equals(ideLibraryPath)) {
+        if (compatible) {
+          // only compatible IDE libs are shown
+          boolean retired = false;
+          List<String> types = lib.getTypes();
+          if (types != null) retired = types.contains("Retired");
+          if (retired) {
+            retiredIdeLibs.add(lib);
+          } else {
+            ideLibs.add(lib);
+          }
+        }
+      // Platform Libraries
+      } else if (libraryLocation.equals(platformLibraryPath)) {
+        // all platform libs are assumed to be compatible
+        platformLibs.add(lib);
+      // Referenced Platform Libraries
+      } else if (libraryLocation.equals(referencedPlatformLibraryPath)) {
+        // all referenced platform libs are assumed to be compatible
+        referencedPlatformLibs.add(lib);
+      // Sketchbook Libraries (including incompatible)
+      } else if (libraryLocation.equals(sketchbookLibraryPath)) {
+        if (compatible) {
+          sketchbookLibs.add(lib);
+        } else {
+          sketchbookIncompatibleLibs.add(lib);
+        }
+      // Other libraries of unknown type (should never occur)
+      } else {
+        otherLibs.add(lib);
+      }
+    }
+
     // Add examples from libraries
-    LibraryList ideLibs = getIDELibs();
     ideLibs.sort();
     if (!ideLibs.isEmpty()) {
-      label = new JMenuItem(tr("Examples from Libraries"));
+      label = new JMenuItem(tr("Examples from Built-in Libraries"));
       label.setEnabled(false);
       menu.add(label);
     }
@@ -1218,9 +1271,8 @@ public class Base {
       addSketchesSubmenu(menu, lib);
     }
 
-    LibraryList retiredIdeLibs = getIDERetiredLibs();
-    retiredIdeLibs.sort();
     if (!retiredIdeLibs.isEmpty()) {
+      retiredIdeLibs.sort();
       JMenu retired = new JMenu(tr("RETIRED"));
       menu.add(retired);
       for (UserLibrary lib : retiredIdeLibs) {
@@ -1228,14 +1280,55 @@ public class Base {
       }
     }
 
-    LibraryList userLibs = getUserLibs();
-    if (userLibs.size() > 0) {
+    if (!platformLibs.isEmpty()) {
       menu.addSeparator();
-      userLibs.sort();
+      platformLibs.sort();
+      label = new JMenuItem(I18n.format(tr("Examples from {0} Libraries"), platformName));
+      label.setEnabled(false);
+      menu.add(label);
+      for (UserLibrary lib : platformLibs) {
+        addSketchesSubmenu(menu, lib);
+      }
+    }
+
+    if (!referencedPlatformLibs.isEmpty()) {
+      menu.addSeparator();
+      referencedPlatformLibs.sort();
+      label = new JMenuItem(I18n.format(tr("Examples from {0} Libraries"), referencedPlatformName));
+      label.setEnabled(false);
+      menu.add(label);
+      for (UserLibrary lib : referencedPlatformLibs) {
+        addSketchesSubmenu(menu, lib);
+      }
+    }
+
+    if (!sketchbookLibs.isEmpty()) {
+      menu.addSeparator();
+      sketchbookLibs.sort();
       label = new JMenuItem(tr("Examples from Custom Libraries"));
       label.setEnabled(false);
       menu.add(label);
-      for (UserLibrary lib : userLibs) {
+      for (UserLibrary lib : sketchbookLibs) {
+        addSketchesSubmenu(menu, lib);
+      }
+    }
+
+    if (!sketchbookIncompatibleLibs.isEmpty()) {
+      sketchbookIncompatibleLibs.sort();
+      JMenu incompatible = new JMenu(tr("INCOMPATIBLE"));
+      menu.add(incompatible);
+      for (UserLibrary lib : sketchbookIncompatibleLibs) {
+        addSketchesSubmenu(incompatible, lib);
+      }
+    }
+
+    if (!otherLibs.isEmpty()) {
+      menu.addSeparator();
+      otherLibs.sort();
+      label = new JMenuItem(tr("Examples from Other Libraries"));
+      label.setEnabled(false);
+      menu.add(label);
+      for (UserLibrary lib : otherLibs) {
         addSketchesSubmenu(menu, lib);
       }
     }


### PR DESCRIPTION
This patch changes the File > Examples menu to show libraries grouped by their type, either built in to the IDE, supplied by a platform, or custom installed.

Currently, libraries are grouped into "Examples from Libraries" and "Examples from Custom Libraries", with little rhyme or reason.  This patch attempts to give users a visual cue about the source of their many libraries, so they can understand which are from the IDE, which depend on their board's platform, and which libs are the ones they've chosen to install.

A few corner cases are automatically handled.  When the platform references another platform, both sets of their libraries are automatically shown.  In the custom libraries, any which are known to be incompatible are shown at the end using a sub-menu, similar to how the retired libs are shown.

![examplesmenu](https://cloud.githubusercontent.com/assets/965463/17233557/9c7b12f4-54e5-11e6-8da9-47c5cab29c9f.png)
