### PR TITLE
Fix tools discovery by strictly following json data when available

### DIFF
--- a/arduino-core/src/cc/arduino/Compiler.java
+++ b/arduino-core/src/cc/arduino/Compiler.java
@@ -51,6 +51,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -234,6 +235,12 @@ public class Compiler implements MessageConsumer {
       .forEach(kv -> commandLine.addArgument("-prefs=\"" + kv.getKey() + "=" + kv.getValue() + "\"", false));
 
     commandLine.addArgument("-prefs=build.warn_data_percentage=" + PreferencesData.get("build.warn_data_percentage"));
+
+    for (Map.Entry<String, String> entry : BaseNoGui.getBoardPreferences().entrySet()) {
+        if (entry.getKey().startsWith("runtime.tools")) {
+          commandLine.addArgument("-prefs=" + entry.getKey() + "=" + entry.getValue());
+        }
+    }
 
     //commandLine.addArgument("-debug-level=10", false);
 

--- a/arduino-core/src/cc/arduino/contributions/packages/ContributedTool.java
+++ b/arduino-core/src/cc/arduino/contributions/packages/ContributedTool.java
@@ -42,6 +42,20 @@ public abstract class ContributedTool {
 
   public abstract List<HostDependentDownloadableContribution> getSystems();
 
+  private ContributedPackage contributedPackage;
+
+  public ContributedPackage getPackage() {
+    return contributedPackage;
+  }
+
+  public void setPackage(ContributedPackage pack) {
+    contributedPackage = pack;
+  }
+
+  public String getPackager() {
+    return contributedPackage.getName();
+  }
+
   public DownloadableContribution getDownloadableContribution(Platform platform) {
     for (HostDependentDownloadableContribution c : getSystems()) {
       if (c.isCompatible(platform))

--- a/arduino-core/src/cc/arduino/contributions/packages/ContributionsIndexer.java
+++ b/arduino-core/src/cc/arduino/contributions/packages/ContributionsIndexer.java
@@ -104,6 +104,11 @@ public class ContributionsIndexer {
       .collect(Collectors.toList());
 
     for (ContributedPackage pack : packages) {
+      // Fill references to package in tools
+      for (ContributedTool tool : pack.getTools()) {
+        tool.setPackage(pack);
+      }
+
       for (ContributedPlatform platform : pack.getPlatforms()) {
         // Set a reference to parent packages
         platform.setParentPackage(pack);

--- a/arduino-core/src/cc/arduino/contributions/packages/ContributionsIndexer.java
+++ b/arduino-core/src/cc/arduino/contributions/packages/ContributionsIndexer.java
@@ -439,4 +439,12 @@ public class ContributionsIndexer {
 
     return platformOptional.orElse(null);
   }
+
+  public ContributedPlatform getContributedPlaform(TargetPlatform targetPlatform) {
+    for (ContributedPlatform plat : getInstalledPlatforms()) {
+      if (plat.getInstalledFolder().equals(targetPlatform.getFolder()))
+        return plat;
+    }
+    return null;
+  }
 }

--- a/arduino-core/src/processing/app/BaseNoGui.java
+++ b/arduino-core/src/processing/app/BaseNoGui.java
@@ -171,6 +171,16 @@ public class BaseNoGui {
     if (platform != null)
       requiredTools.addAll(platform.getResolvedTools());
 
+    // Add all tools dependencies from the (possibily) referenced core
+    String core = prefs.get("build.core");
+    if (core.contains(":")) {
+      String split[] = core.split(":");
+      TargetPlatform referenced = BaseNoGui.getCurrentTargetPlatformFromPackage(split[0]);
+      ContributedPlatform referencedPlatform = indexer.getContributedPlaform(referenced);
+      if (referencedPlatform != null)
+        requiredTools.addAll(referencedPlatform.getResolvedTools());
+    }
+
     String prefix = "runtime.tools.";
     for (ContributedTool tool : requiredTools) {
       File folder = tool.getDownloadableContribution(getPlatform()).getInstalledFolder();

--- a/arduino-core/src/processing/app/BaseNoGui.java
+++ b/arduino-core/src/processing/app/BaseNoGui.java
@@ -164,16 +164,20 @@ public class BaseNoGui {
     prefs.put("name", extendedName);
 
     // Resolve tools needed for this board
+    List<ContributedTool> requiredTools = new ArrayList<>();
+
+    // Add all tools dependencies specified in package index
     ContributedPlatform platform = indexer.getContributedPlaform(getTargetPlatform());
-    if (platform != null) {
-      String prefix = "runtime.tools.";
-      for (ContributedTool tool : platform.getResolvedTools()) {
-        File folder = tool.getDownloadableContribution(getPlatform()).getInstalledFolder();
-        String toolPath = folder.getAbsolutePath();
-        prefs.put(prefix + tool.getName() + ".path", toolPath);
-        PreferencesData.set(prefix + tool.getName() + ".path", toolPath);
-        PreferencesData.set(prefix + tool.getName() + "-" + tool.getVersion() + ".path", toolPath);
-      }
+    if (platform != null)
+      requiredTools.addAll(platform.getResolvedTools());
+
+    String prefix = "runtime.tools.";
+    for (ContributedTool tool : requiredTools) {
+      File folder = tool.getDownloadableContribution(getPlatform()).getInstalledFolder();
+      String toolPath = folder.getAbsolutePath();
+      prefs.put(prefix + tool.getName() + ".path", toolPath);
+      PreferencesData.set(prefix + tool.getName() + ".path", toolPath);
+      PreferencesData.set(prefix + tool.getName() + "-" + tool.getVersion() + ".path", toolPath);
     }
     return prefs;
   }

--- a/arduino-core/src/processing/app/BaseNoGui.java
+++ b/arduino-core/src/processing/app/BaseNoGui.java
@@ -169,6 +169,7 @@ public class BaseNoGui {
       for (ContributedTool tool : platform.getResolvedTools()) {
         File folder = tool.getDownloadableContribution(getPlatform()).getInstalledFolder();
         String toolPath = folder.getAbsolutePath();
+        prefs.put(prefix + tool.getName() + ".path", toolPath);
         PreferencesData.set(prefix + tool.getName() + ".path", toolPath);
         PreferencesData.set(prefix + tool.getName() + "-" + tool.getVersion() + ".path", toolPath);
       }

--- a/arduino-core/src/processing/app/BaseNoGui.java
+++ b/arduino-core/src/processing/app/BaseNoGui.java
@@ -5,6 +5,7 @@ import cc.arduino.Constants;
 import cc.arduino.UploaderUtils;
 import cc.arduino.contributions.GPGDetachedSignatureVerifier;
 import cc.arduino.contributions.SignatureVerificationFailedException;
+import cc.arduino.contributions.VersionComparator;
 import cc.arduino.contributions.libraries.LibrariesIndexer;
 import cc.arduino.contributions.packages.ContributedPlatform;
 import cc.arduino.contributions.packages.ContributedTool;
@@ -866,6 +867,8 @@ public class BaseNoGui {
       PreferencesData.removeAllKeysWithPrefix(prefix);
     }
 
+    Map<String, String> latestVersions = new HashMap<>();
+    VersionComparator comparator = new VersionComparator();
     for (ContributedTool tool : installedTools) {
       File installedFolder = tool.getDownloadableContribution(getPlatform()).getInstalledFolder();
       String toolPath;
@@ -874,10 +877,15 @@ public class BaseNoGui {
       } else {
         toolPath = Constants.PREF_REMOVE_PLACEHOLDER;
       }
-      PreferencesData.set(prefix + tool.getName() + ".path", toolPath);
-      PreferencesData.set(prefix + tool.getName() + "-" + tool.getVersion() + ".path", toolPath);
-      PreferencesData.set(prefix + tool.getPackager() + "-" + tool.getName() + "-" + tool.getVersion() + ".path",
-          toolPath);
+      String toolName = tool.getName();
+      String toolVersion = tool.getVersion();
+      PreferencesData.set(prefix + toolName + "-" + toolVersion + ".path", toolPath);
+      PreferencesData.set(prefix + tool.getPackager() + "-" + toolName + "-" + toolVersion + ".path", toolPath);
+      // In the generic tool property put the path of the latest version if more are available
+      if (!latestVersions.containsKey(toolName) || comparator.greaterThan(toolVersion, latestVersions.get(toolName))) {
+        latestVersions.put(toolName, toolVersion);
+        PreferencesData.set(prefix + toolName + ".path", toolPath);
+      }
     }
   }
 

--- a/arduino-core/src/processing/app/BaseNoGui.java
+++ b/arduino-core/src/processing/app/BaseNoGui.java
@@ -6,6 +6,7 @@ import cc.arduino.UploaderUtils;
 import cc.arduino.contributions.GPGDetachedSignatureVerifier;
 import cc.arduino.contributions.SignatureVerificationFailedException;
 import cc.arduino.contributions.libraries.LibrariesIndexer;
+import cc.arduino.contributions.packages.ContributedPlatform;
 import cc.arduino.contributions.packages.ContributedTool;
 import cc.arduino.contributions.packages.ContributionsIndexer;
 import cc.arduino.files.DeleteFilesOnShutdown;
@@ -160,6 +161,18 @@ public class BaseNoGui {
       }
     }
     prefs.put("name", extendedName);
+
+    // Resolve tools needed for this board
+    ContributedPlatform platform = indexer.getContributedPlaform(getTargetPlatform());
+    if (platform != null) {
+      String prefix = "runtime.tools.";
+      for (ContributedTool tool : platform.getResolvedTools()) {
+        File folder = tool.getDownloadableContribution(getPlatform()).getInstalledFolder();
+        String toolPath = folder.getAbsolutePath();
+        PreferencesData.set(prefix + tool.getName() + ".path", toolPath);
+        PreferencesData.set(prefix + tool.getName() + "-" + tool.getVersion() + ".path", toolPath);
+      }
+    }
     return prefs;
   }
 

--- a/arduino-core/src/processing/app/BaseNoGui.java
+++ b/arduino-core/src/processing/app/BaseNoGui.java
@@ -867,14 +867,16 @@ public class BaseNoGui {
 
     for (ContributedTool tool : installedTools) {
       File installedFolder = tool.getDownloadableContribution(getPlatform()).getInstalledFolder();
-      String absolutePath;
+      String toolPath;
       if (installedFolder != null) {
-        absolutePath = installedFolder.getAbsolutePath();
+        toolPath = installedFolder.getAbsolutePath();
       } else {
-        absolutePath = Constants.PREF_REMOVE_PLACEHOLDER;
+        toolPath = Constants.PREF_REMOVE_PLACEHOLDER;
       }
-      PreferencesData.set(prefix + tool.getName() + ".path", absolutePath);
-      PreferencesData.set(prefix + tool.getName() + "-" + tool.getVersion() + ".path", absolutePath);
+      PreferencesData.set(prefix + tool.getName() + ".path", toolPath);
+      PreferencesData.set(prefix + tool.getName() + "-" + tool.getVersion() + ".path", toolPath);
+      PreferencesData.set(prefix + tool.getPackager() + "-" + tool.getName() + "-" + tool.getVersion() + ".path",
+          toolPath);
     }
   }
 


### PR DESCRIPTION
Should fix #5042 and #5168.

(in particular #5168 would need more work to implement my proposal of `coreDependencies` field into package_index.json to be a complete solution, IMHO)

See also #5197.

/cc @facchinm @PaulStoffregen @matthijskooijman @per1234 @jantje 