### PR TITLE
Add '--useprogrammer' option to the man page

### DIFF
--- a/build/shared/manpage.adoc
+++ b/build/shared/manpage.adoc
@@ -133,6 +133,10 @@ OPTIONS
 	This option is only valid together with *--verify* or
 	*--upload*.
 
+*--useprogrammer*::
+	Upload using a programmer. Set if you're using an external programmer, or
+	using the Arduino as ISP.
+
 *--verbose-upload*::
 	Enable verbose mode during upload. If this option is not given,
 	verbose mode during upload is *disabled* regardless of the current


### PR DESCRIPTION
It took me quite a while to hunt down how to upload using a programmer from the command line, and then discovering there is a simple switch for it. I hope documenting it prevents other people from having to dig in the source code.