### PR TITLE
Add all analog references supported by the ATtinyX5 series

### DIFF
--- a/hardware/arduino/avr/cores/arduino/Arduino.h
+++ b/hardware/arduino/avr/cores/arduino/Arduino.h
@@ -61,10 +61,18 @@ void yield(void);
 #define FALLING 2
 #define RISING 3
 
-#if defined(__AVR_ATtiny24__) || defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__) || defined(__AVR_ATtiny25__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__)
-#define DEFAULT 0
-#define EXTERNAL 1
-#define INTERNAL 2
+#if defined(__AVR_ATtiny24__) || defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__)
+  #define DEFAULT 0
+  #define EXTERNAL 1
+  #define INTERNAL1V1 2
+  #define INTERNAL INTERNAL1V1
+#elif defined(__AVR_ATtiny25__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__)
+  #define DEFAULT 0
+  #define EXTERNAL 1
+  #define INTERNAL1V1 2
+  #define INTERNAL INTERNAL1V1
+  #define INTERNAL2V56 6
+  #define INTERNAL2V56_EXTCAP 7
 #else  
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega644__) || defined(__AVR_ATmega644A__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644PA__)
 #define INTERNAL1V1 2

--- a/hardware/arduino/avr/cores/arduino/Arduino.h
+++ b/hardware/arduino/avr/cores/arduino/Arduino.h
@@ -68,11 +68,11 @@ void yield(void);
   #define INTERNAL INTERNAL1V1
 #elif defined(__AVR_ATtiny25__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__)
   #define DEFAULT 0
-  #define EXTERNAL 1
-  #define INTERNAL1V1 2
+  #define EXTERNAL 4
+  #define INTERNAL1V1 8
   #define INTERNAL INTERNAL1V1
-  #define INTERNAL2V56 6
-  #define INTERNAL2V56_EXTCAP 7
+  #define INTERNAL2V56 9
+  #define INTERNAL2V56_EXTCAP 13
 #else  
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega644__) || defined(__AVR_ATmega644A__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644PA__)
 #define INTERNAL1V1 2

--- a/hardware/arduino/avr/cores/arduino/wiring_analog.c
+++ b/hardware/arduino/avr/cores/arduino/wiring_analog.c
@@ -64,7 +64,11 @@ int analogRead(uint8_t pin)
 	// channel (low 4 bits).  this also sets ADLAR (left-adjust result)
 	// to 0 (the default).
 #if defined(ADMUX)
-	ADMUX = ((analog_reference & 0x3) << 6) | ((analog_reference & 0x4) ? 0x10 : 0) | (pin & 0x07);
+#if defined(__AVR_ATtiny25__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__)
+	ADMUX = (analog_reference << 4) | (pin & 0x07);
+#else
+	ADMUX = (analog_reference << 6) | (pin & 0x07);
+#endif
 #endif
 
 	// without a delay, we seem to read from the wrong channel

--- a/hardware/arduino/avr/cores/arduino/wiring_analog.c
+++ b/hardware/arduino/avr/cores/arduino/wiring_analog.c
@@ -64,7 +64,7 @@ int analogRead(uint8_t pin)
 	// channel (low 4 bits).  this also sets ADLAR (left-adjust result)
 	// to 0 (the default).
 #if defined(ADMUX)
-	ADMUX = (analog_reference << 6) | (pin & 0x07);
+	ADMUX = ((analog_reference & 0x3) << 6) | ((analog_reference & 0x4) ? 0x10 : 0) | (pin & 0x07);
 #endif
 
 	// without a delay, we seem to read from the wrong channel


### PR DESCRIPTION
Now it should possible to use the 2.56V voltage reference on the ATtinyX5's.

Should resolve #1739 , where the formula is derived from.