### PR TITLE
Add a --get-build command line option

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -479,6 +479,8 @@ public class Base {
       System.exit(0);
     } else if (parser.isGetPrefMode()) {
       BaseNoGui.dumpPrefs(parser);
+    } else if (parser.isGetBuildMode()) {
+      BaseNoGui.dumpBuild(parser);
     }
   }
 

--- a/arduino-core/src/cc/arduino/Compiler.java
+++ b/arduino-core/src/cc/arduino/Compiler.java
@@ -161,6 +161,21 @@ public class Compiler implements MessageConsumer {
     return sketch.getPrimaryFile().getFileName();
   }
 
+  public PreferencesMap getBuildPreferences() throws RunnerException, IOException {
+    this.buildPath = sketch.getBuildPath().getAbsolutePath();
+
+    TargetBoard board = BaseNoGui.getTargetBoard();
+    if (board == null) {
+      throw new RunnerException("Board is not selected");
+    }
+
+    TargetPlatform platform = board.getContainerPlatform();
+    TargetPackage aPackage = platform.getContainerPackage();
+    String vidpid = VIDPID();
+
+    return loadPreferences(board, platform, aPackage, vidpid);
+  }
+
   private String VIDPID() {
     BoardPort boardPort = BaseNoGui.getDiscoveryManager().find(PreferencesData.get("serial.port"));
     if (boardPort == null) {

--- a/arduino-core/src/processing/app/BaseNoGui.java
+++ b/arduino-core/src/processing/app/BaseNoGui.java
@@ -464,8 +464,8 @@ public class BaseNoGui {
         }
       }
 
-      if (!parser.isVerifyOrUploadMode() && !parser.isGetPrefMode())
-        showError(tr("Mode not supported"), tr("Only --verify, --upload or --get-pref are supported"), null);
+      if (!parser.isVerifyOrUploadMode() && !parser.isGetPrefMode() && !parser.isGetBuildMode())
+        showError(tr("Mode not supported"), tr("Only --verify, --upload, --get-pref or --get-build are supported"), null);
 
       if (!parser.isForceSavePrefs())
         PreferencesData.setDoSave(false);
@@ -577,6 +577,8 @@ public class BaseNoGui {
     }
     else if (parser.isGetPrefMode()) {
       dumpPrefs(parser);
+    } else if (parser.isGetBuildMode()) {
+      dumpBuild(parser);
     }
   }
 
@@ -597,6 +599,27 @@ public class BaseNoGui {
       }
       System.exit(0);
     }
+  }
+
+  protected static void dumpBuild(CommandlineParser parser) {
+    System.out.println("#BUILDDUMP#");
+    try {
+      File minimal = new File(getContentFile("examples"), "01.Basics" + File.separator + "BareMinimum" + File.separator + "BareMinimum.ino");
+      Sketch data = new Sketch(minimal);
+      Compiler compiler	= new Compiler(data);
+      PreferencesMap prefs = compiler.getBuildPreferences();
+
+      for (Map.Entry<String, String> entry : prefs.entrySet()) {
+	if (!entry.getKey().isEmpty()) {
+	  System.out.println(entry.getKey() + "=" + entry.getValue());
+	}
+      }
+    } catch (Exception e) {
+      showError(tr("Error while getting build information"),
+		tr("An error occurred while retrieving build platform information"),
+		e);
+    }
+    System.exit(0);
   }
 
   static public void initLogger() {

--- a/arduino-core/src/processing/app/helpers/CommandlineParser.java
+++ b/arduino-core/src/processing/app/helpers/CommandlineParser.java
@@ -16,7 +16,7 @@ import static processing.app.I18n.tr;
 public class CommandlineParser {
 
   private enum ACTION {
-    GUI, NOOP, VERIFY("--verify"), UPLOAD("--upload"), GET_PREF("--get-pref"), INSTALL_BOARD("--install-boards"), INSTALL_LIBRARY("--install-library");
+    GUI, NOOP, VERIFY("--verify"), UPLOAD("--upload"), GET_PREF("--get-pref"), GET_BUILD("--get-build"), INSTALL_BOARD("--install-boards"), INSTALL_LIBRARY("--install-library");
 
     private final String value;
 
@@ -50,6 +50,7 @@ public class CommandlineParser {
     actions.put("--verify", ACTION.VERIFY);
     actions.put("--upload", ACTION.UPLOAD);
     actions.put("--get-pref", ACTION.GET_PREF);
+    actions.put("--get-build", ACTION.GET_BUILD);
     actions.put("--install-boards", ACTION.INSTALL_BOARD);
     actions.put("--install-library", ACTION.INSTALL_LIBRARY);
   }
@@ -212,7 +213,7 @@ public class CommandlineParser {
     if ((action == ACTION.UPLOAD || action == ACTION.VERIFY) && filenames.size() != 1)
       BaseNoGui.showError(null, tr("Must specify exactly one sketch file"), 3);
 
-    if ((action == ACTION.NOOP || action == ACTION.GET_PREF) && filenames.size() != 0)
+    if ((action == ACTION.NOOP || action == ACTION.GET_PREF || action == ACTION.GET_BUILD) && filenames.size() != 0)
       BaseNoGui.showError(null, tr("Cannot specify any sketch files"), 3);
 
     if ((action != ACTION.UPLOAD && action != ACTION.VERIFY) && (doVerboseBuild || doVerboseUpload))
@@ -302,6 +303,10 @@ public class CommandlineParser {
 
   public boolean isGetPrefMode() {
     return action == ACTION.GET_PREF;
+  }
+
+  public boolean isGetBuildMode() {
+    return action == ACTION.GET_BUILD;
   }
 
   public boolean isGuiMode() {

--- a/build/shared/manpage.adoc
+++ b/build/shared/manpage.adoc
@@ -29,6 +29,8 @@ SYNOPSIS
 
 *arduino* [*--get-pref* [__preference__]]
 
+*arduino* [*--get-build*]
+
 *arduino* [*--install-boards* __package name__:__platform architecture__[:__version__]]
 
 *arduino* [*--install-library* __library name__[:__version__][,__library name__[:__version__],__library name__[:__version__]]
@@ -75,6 +77,10 @@ ACTIONS
 	stream. When the value does not exist, nothing is printed and
 	the exit status is set (see EXIT STATUS below).
 	If no preference is given as parameter, it prints all preferences.
+
+*--get-build*::
+	Prints all architecture/platform and board properties for the
+	selected board.
 
 *--install-boards* __package name__:__platform architecture__[:__version__]::
 	Fetches available board support (platform) list and install the specified one, along with its related tools. If __version__ is omitted, the latest is installed. If a platform with the same version is already installed, nothing is installed and program exits with exit code 1. If a platform with a different version is already installed, it's replaced.


### PR DESCRIPTION
Allow build systems external to the Arduino IDE to retrieve build
definitions for a given platform and board. The --get-build option dumps
properties (whose definitions are found in the 3rd Party Hardware
Specification) that an alternative build system can interpret and use to
construct build commands and tool invocations.
