### PR TITLE
Set default color of text for descriptions shown in library manager.

### DIFF
--- a/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryTableCellJPanel.java
+++ b/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryTableCellJPanel.java
@@ -221,6 +221,7 @@ public class ContributedLibraryTableCellJPanel extends JPanel {
       StyleSheet s = html.getStyleSheet();
       s.addRule("body { margin: 0; padding: 0;"
                 + "font-family: Verdana, Geneva, Arial, Helvetica, sans-serif;"
+                + "color: black;"
                 + "font-size: " + 10 * Theme.getScale() / 100 + "; }");
     }
     description.setOpaque(false);


### PR DESCRIPTION
Should fix #5353 
