### PR TITLE
WString: add `toDouble`

### DIFF
--- a/hardware/arduino/avr/cores/arduino/WString.cpp
+++ b/hardware/arduino/avr/cores/arduino/WString.cpp
@@ -740,6 +740,11 @@ long String::toInt(void) const
 
 float String::toFloat(void) const
 {
-	if (buffer) return float(atof(buffer));
-	return 0;
+	return float(toDouble());
+}
+
+double String::toDouble(void) const
+{
+    if (buffer) return atof(buffer);
+    return 0;
 }

--- a/hardware/arduino/avr/cores/arduino/WString.cpp
+++ b/hardware/arduino/avr/cores/arduino/WString.cpp
@@ -745,6 +745,6 @@ float String::toFloat(void) const
 
 double String::toDouble(void) const
 {
-    if (buffer) return atof(buffer);
-    return 0;
+	if (buffer) return atof(buffer);
+	return 0;
 }

--- a/hardware/arduino/avr/cores/arduino/WString.h
+++ b/hardware/arduino/avr/cores/arduino/WString.h
@@ -190,6 +190,7 @@ public:
 	// parsing/conversion
 	long toInt(void) const;
 	float toFloat(void) const;
+    double toDouble(void) const;
 
 protected:
 	char *buffer;	        // the actual char array

--- a/hardware/arduino/avr/cores/arduino/WString.h
+++ b/hardware/arduino/avr/cores/arduino/WString.h
@@ -190,7 +190,7 @@ public:
 	// parsing/conversion
 	long toInt(void) const;
 	float toFloat(void) const;
-    double toDouble(void) const;
+	double toDouble(void) const;
 
 protected:
 	char *buffer;	        // the actual char array

--- a/hardware/arduino/sam/cores/arduino/WString.cpp
+++ b/hardware/arduino/sam/cores/arduino/WString.cpp
@@ -742,6 +742,11 @@ long String::toInt(void) const
 
 float String::toFloat(void) const
 {
-	if (buffer) return float(atof(buffer));
-	return 0;
+	return float(toDouble());
+}
+
+double String::toDouble(void) const
+{
+    if (buffer) return atof(buffer);
+    return 0;
 }

--- a/hardware/arduino/sam/cores/arduino/WString.cpp
+++ b/hardware/arduino/sam/cores/arduino/WString.cpp
@@ -747,6 +747,6 @@ float String::toFloat(void) const
 
 double String::toDouble(void) const
 {
-    if (buffer) return atof(buffer);
-    return 0;
+	if (buffer) return atof(buffer);
+	return 0;
 }

--- a/hardware/arduino/sam/cores/arduino/WString.h
+++ b/hardware/arduino/sam/cores/arduino/WString.h
@@ -190,6 +190,7 @@ public:
 	// parsing/conversion
 	long toInt(void) const;
 	float toFloat(void) const;
+    double toDouble(void) const;
 
 protected:
 	char *buffer;	        // the actual char array

--- a/hardware/arduino/sam/cores/arduino/WString.h
+++ b/hardware/arduino/sam/cores/arduino/WString.h
@@ -190,7 +190,7 @@ public:
 	// parsing/conversion
 	long toInt(void) const;
 	float toFloat(void) const;
-    double toDouble(void) const;
+	double toDouble(void) const;
 
 protected:
 	char *buffer;	        // the actual char array


### PR DESCRIPTION
`String::toFloat` internally converts the string into a double (using [`atof`](http://www.cplusplus.com/reference/cstdlib/atof/)) and then truncates into a
float, so why not to add a method to return the double?