### PR TITLE
Improve Examples menu (take 2)

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -80,10 +80,6 @@ import static processing.app.I18n.tr;
  */
 public class Base {
 
-  public static final Predicate<UserLibrary> CONTRIBUTED = library -> library.getTypes() == null || library.getTypes().isEmpty() || library.getTypes().contains("Contributed");
-  public static final Predicate<UserLibrary> RETIRED = library -> library.getTypes() != null && library.getTypes().contains("Retired");
-  public static final Predicate<UserLibrary> COMPATIBLE = library -> library.getArchitectures() != null && (library.getArchitectures().contains("*") || library.getArchitectures().contains(BaseNoGui.getTargetPlatform().getId()));
-
   private static final int RECENT_SKETCHES_MAX_SIZE = 10;
 
   private static boolean commandLine;
@@ -1053,30 +1049,6 @@ public class Base {
     }
   }
 
-  public LibraryList getIDELibs() {
-    LibraryList installedLibraries = new LibraryList(BaseNoGui.librariesIndexer.getInstalledLibraries());
-    List<UserLibrary> libs = installedLibraries.stream()
-      .filter(CONTRIBUTED.negate())
-      .filter(RETIRED.negate())
-      .filter(COMPATIBLE)
-      .collect(Collectors.toList());
-    return new LibraryList(libs);
-  }
-
-  public LibraryList getIDERetiredLibs() {
-    LibraryList installedLibraries = new LibraryList(BaseNoGui.librariesIndexer.getInstalledLibraries());
-    List<UserLibrary> libs = installedLibraries.stream()
-      .filter(RETIRED)
-      .collect(Collectors.toList());
-    return new LibraryList(libs);
-  }
-
-  public LibraryList getUserLibs() {
-    LibraryList installedLibraries = new LibraryList(BaseNoGui.librariesIndexer.getInstalledLibraries());
-    List<UserLibrary> libs = installedLibraries.stream().filter(CONTRIBUTED).collect(Collectors.toList());
-    return new LibraryList(libs);
-  }
-
   private List<ContributedLibrary> getSortedLibraries() {
     List<ContributedLibrary> installedLibraries = new LinkedList<ContributedLibrary>(BaseNoGui.librariesIndexer.getInstalledLibraries());
     Collections.sort(installedLibraries, new LibraryByTypeComparator());
@@ -1159,11 +1131,92 @@ public class Base {
       menu.addSeparator();
     }
 
+    // Libraries can come from 4 locations: collect info about all four
+    File ideLibraryPath = BaseNoGui.getContentFile("libraries");
+    File sketchbookLibraryPath = BaseNoGui.getSketchbookLibrariesFolder();
+    File platformLibraryPath = null;
+    File referencedPlatformLibraryPath = null;
+    String platformName = null;
+    String referencedPlatformName = null;
+    String myArch = null;
+    TargetPlatform targetPlatform = BaseNoGui.getTargetPlatform();
+    if (targetPlatform != null) {
+      myArch = targetPlatform.getId();
+      platformName = targetPlatform.getPreferences().get("name");
+      platformLibraryPath = new File(targetPlatform.getFolder(), "libraries");
+      String core = BaseNoGui.getBoardPreferences().get("build.core", "arduino");
+      if (core.contains(":")) {
+        String refcore = core.split(":")[0];
+        TargetPlatform referencedPlatform = BaseNoGui.getTargetPlatform(refcore, myArch);
+        if (referencedPlatform != null) {
+          referencedPlatformName = referencedPlatform.getPreferences().get("name");
+          referencedPlatformLibraryPath = new File(referencedPlatform.getFolder(), "libraries");
+        }
+      }
+    }
+
+    // Divide the libraries into 7 lists, corresponding to the 4 locations
+    // with the retired IDE libs further divided into their own list, and
+    // any incompatible sketchbook libs further divided into their own list.
+    // The 7th list of "other" libraries should always be empty, but serves
+    // as a safety feature to prevent any library from vanishing.
+    LibraryList allLibraries = new LibraryList(BaseNoGui.librariesIndexer.getInstalledLibraries());
+    LibraryList ideLibs = new LibraryList();
+    LibraryList retiredIdeLibs = new LibraryList();
+    LibraryList platformLibs = new LibraryList();
+    LibraryList referencedPlatformLibs = new LibraryList();
+    LibraryList sketchbookLibs = new LibraryList();
+    LibraryList sketchbookIncompatibleLibs = new LibraryList();
+    LibraryList otherLibs = new LibraryList();
+    for (UserLibrary lib : allLibraries) {
+      // Get the library's location - used for sorting into categories
+      File libraryLocation = lib.getInstalledFolder().getParentFile();
+      // Is this library compatible?
+      List<String> arch = lib.getArchitectures();
+      boolean compatible;
+      if (myArch == null || arch == null || arch.contains("*")) {
+        compatible = true;
+      } else {
+        compatible = arch.contains(myArch);
+      }
+      // IDE Libaries (including retired)
+      if (libraryLocation.equals(ideLibraryPath)) {
+        if (compatible) {
+          // only compatible IDE libs are shown
+          boolean retired = false;
+          List<String> types = lib.getTypes();
+          if (types != null) retired = types.contains("Retired");
+          if (retired) {
+            retiredIdeLibs.add(lib);
+          } else {
+            ideLibs.add(lib);
+          }
+        }
+      // Platform Libraries
+      } else if (libraryLocation.equals(platformLibraryPath)) {
+        // all platform libs are assumed to be compatible
+        platformLibs.add(lib);
+      // Referenced Platform Libraries
+      } else if (libraryLocation.equals(referencedPlatformLibraryPath)) {
+        // all referenced platform libs are assumed to be compatible
+        referencedPlatformLibs.add(lib);
+      // Sketchbook Libraries (including incompatible)
+      } else if (libraryLocation.equals(sketchbookLibraryPath)) {
+        if (compatible) {
+          sketchbookLibs.add(lib);
+        } else {
+          sketchbookIncompatibleLibs.add(lib);
+        }
+      // Other libraries of unknown type (should never occur)
+      } else {
+        otherLibs.add(lib);
+      }
+    }
+
     // Add examples from libraries
-    LibraryList ideLibs = getIDELibs();
     ideLibs.sort();
     if (!ideLibs.isEmpty()) {
-      label = new JMenuItem(tr("Examples from Libraries"));
+      label = new JMenuItem(tr("Examples from Built-in Libraries"));
       label.setEnabled(false);
       menu.add(label);
     }
@@ -1171,9 +1224,8 @@ public class Base {
       addSketchesSubmenu(menu, lib);
     }
 
-    LibraryList retiredIdeLibs = getIDERetiredLibs();
-    retiredIdeLibs.sort();
     if (!retiredIdeLibs.isEmpty()) {
+      retiredIdeLibs.sort();
       JMenu retired = new JMenu(tr("RETIRED"));
       menu.add(retired);
       for (UserLibrary lib : retiredIdeLibs) {
@@ -1181,14 +1233,55 @@ public class Base {
       }
     }
 
-    LibraryList userLibs = getUserLibs();
-    if (userLibs.size() > 0) {
+    if (!platformLibs.isEmpty()) {
       menu.addSeparator();
-      userLibs.sort();
+      platformLibs.sort();
+      label = new JMenuItem(I18n.format(tr("Examples from {0} Libraries"), platformName));
+      label.setEnabled(false);
+      menu.add(label);
+      for (UserLibrary lib : platformLibs) {
+        addSketchesSubmenu(menu, lib);
+      }
+    }
+
+    if (!referencedPlatformLibs.isEmpty()) {
+      menu.addSeparator();
+      referencedPlatformLibs.sort();
+      label = new JMenuItem(I18n.format(tr("Examples from {0} Libraries"), referencedPlatformName));
+      label.setEnabled(false);
+      menu.add(label);
+      for (UserLibrary lib : referencedPlatformLibs) {
+        addSketchesSubmenu(menu, lib);
+      }
+    }
+
+    if (!sketchbookLibs.isEmpty()) {
+      menu.addSeparator();
+      sketchbookLibs.sort();
       label = new JMenuItem(tr("Examples from Custom Libraries"));
       label.setEnabled(false);
       menu.add(label);
-      for (UserLibrary lib : userLibs) {
+      for (UserLibrary lib : sketchbookLibs) {
+        addSketchesSubmenu(menu, lib);
+      }
+    }
+
+    if (!sketchbookIncompatibleLibs.isEmpty()) {
+      sketchbookIncompatibleLibs.sort();
+      JMenu incompatible = new JMenu(tr("INCOMPATIBLE"));
+      menu.add(incompatible);
+      for (UserLibrary lib : sketchbookIncompatibleLibs) {
+        addSketchesSubmenu(incompatible, lib);
+      }
+    }
+
+    if (!otherLibs.isEmpty()) {
+      menu.addSeparator();
+      otherLibs.sort();
+      label = new JMenuItem(tr("Examples from Other Libraries"));
+      label.setEnabled(false);
+      menu.add(label);
+      for (UserLibrary lib : otherLibs) {
         addSketchesSubmenu(menu, lib);
       }
     }

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1205,7 +1205,13 @@ public class Base {
       // Sketchbook Libraries (including incompatible)
       } else if (libraryLocation.equals(sketchbookLibraryPath)) {
         if (compatible) {
-          sketchbookLibs.add(lib);
+          // libraries promoted from sketchbook (behave as builtin)
+          if (lib.getTypes() != null && lib.getTypes().contains("Arduino")
+              && lib.getArchitectures().contains("*")) {
+            ideLibs.add(lib);
+          } else {
+            sketchbookLibs.add(lib);
+          }
         } else {
           sketchbookIncompatibleLibs.add(lib);
         }

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1214,8 +1214,8 @@ public class Base {
     }
 
     // Add examples from libraries
-    ideLibs.sort();
     if (!ideLibs.isEmpty()) {
+      ideLibs.sort();
       label = new JMenuItem(tr("Examples from Built-in Libraries"));
       label.setEnabled(false);
       menu.add(label);

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1137,11 +1137,13 @@ public class Base {
     File platformLibraryPath = null;
     File referencedPlatformLibraryPath = null;
     String platformName = null;
+    String boardId = null;
     String referencedPlatformName = null;
     String myArch = null;
     TargetPlatform targetPlatform = BaseNoGui.getTargetPlatform();
     if (targetPlatform != null) {
       myArch = targetPlatform.getId();
+      boardId = BaseNoGui.getTargetBoard().getName();
       platformName = targetPlatform.getPreferences().get("name");
       platformLibraryPath = new File(targetPlatform.getFolder(), "libraries");
       String core = BaseNoGui.getBoardPreferences().get("build.core", "arduino");
@@ -1216,7 +1218,7 @@ public class Base {
     // Add examples from libraries
     if (!ideLibs.isEmpty()) {
       ideLibs.sort();
-      label = new JMenuItem(tr("Examples from Built-in Libraries"));
+      label = new JMenuItem(tr("Examples for any board"));
       label.setEnabled(false);
       menu.add(label);
     }
@@ -1236,7 +1238,7 @@ public class Base {
     if (!platformLibs.isEmpty()) {
       menu.addSeparator();
       platformLibs.sort();
-      label = new JMenuItem(I18n.format(tr("Examples from {0} Libraries"), platformName));
+      label = new JMenuItem(I18n.format(tr("Examples for {0}"), boardId));
       label.setEnabled(false);
       menu.add(label);
       for (UserLibrary lib : platformLibs) {
@@ -1247,7 +1249,7 @@ public class Base {
     if (!referencedPlatformLibs.isEmpty()) {
       menu.addSeparator();
       referencedPlatformLibs.sort();
-      label = new JMenuItem(I18n.format(tr("Examples from {0} Libraries"), referencedPlatformName));
+      label = new JMenuItem(I18n.format(tr("Examples for {0}"), referencedPlatformName));
       label.setEnabled(false);
       menu.add(label);
       for (UserLibrary lib : referencedPlatformLibs) {


### PR DESCRIPTION
This is a follow up from @PaulStoffregen's #5178 with the following changes applied after internal discussion:

1) labels have been changed from:

From: `Examples from Built-in Libraries`
To: `Examples for any board`

From: `Examples from Arduino AVR Boards Libraries` (selected platform)
To: `Examples for Arduino/Genuino Micro` (selected board)

From: `Examples from Arduino AVR Boards Libraries` (referenced platform)
To: `Examples for Arduino AVR Boards` (referenced platform)

2) Examples of architecture independent libraries from Arduino appears inside `Examples for any board` and not in `Examples from Custom Libraries`

unless there are more concerns, IMHO this can be merged.

/cc @PaulStoffregen @00alis 
