### PR TITLE
added support for missing LED_BUILTIN

### DIFF
--- a/build/shared/examples/01.Basics/Blink/Blink.ino
+++ b/build/shared/examples/01.Basics/Blink/Blink.ino
@@ -4,7 +4,8 @@
 
   Most Arduinos have an on-board LED you can control. On the UNO, MEGA and ZERO 
   it is attached to digital pin 13, on MKR1000 on pin 6. LED_BUILTIN takes care 
-  of use the correct LED pin whatever is the board used.
+  of use the correct LED pin whatever is the board used. Added exception when LED_BUILTIN 
+  isn't defined defaults to digital pin 13.
   If you want to know what pin the on-board LED is connected to on your Arduino model, check
   the Technical Specs of your board  at https://www.arduino.cc/en/Main/Products
   
@@ -15,8 +16,14 @@
   
   modified 2 Sep 2016
   by Arturo Guadalupi
+
+  modified 23 Sep 2016
+  by Joao Alves
 */
 
+#if !defined(LED_BUILTIN)
+#define LED_BUILTIN 13
+#endif
 
 // the setup function runs once when you press reset or power the board
 void setup() {


### PR DESCRIPTION
Some boards don't define (yet) the LED_BUILTIN define and it will prevent blink from compiling. The small fix only sets the LED_BUILDIN to the value 13 if it doesn't exist.