### PR TITLE
Set default values for Arduino AVR Boards upload.verify and program.verify

### DIFF
--- a/hardware/arduino/avr/platform.txt
+++ b/hardware/arduino/avr/platform.txt
@@ -97,11 +97,15 @@ tools.avrdude.config.path={path}/etc/avrdude.conf
 
 tools.avrdude.upload.params.verbose=-v
 tools.avrdude.upload.params.quiet=-q -q
+# tools.avrdude.upload.verify is needed for backwards compatibility with IDE 1.6.8 or older, IDE 1.6.9 or newer overrides this value
+tools.avrdude.upload.verify=
 tools.avrdude.upload.params.noverify=-V
 tools.avrdude.upload.pattern="{cmd.path}" "-C{config.path}" {upload.verbose} {upload.verify} -p{build.mcu} -c{upload.protocol} -P{serial.port} -b{upload.speed} -D "-Uflash:w:{build.path}/{build.project_name}.hex:i"
 
 tools.avrdude.program.params.verbose=-v
 tools.avrdude.program.params.quiet=-q -q
+# tools.avrdude.program.verify is needed for backwards compatibility with IDE 1.6.8 or older, IDE 1.6.9 or newer overrides this value
+tools.avrdude.program.verify=
 tools.avrdude.program.params.noverify=-V
 tools.avrdude.program.pattern="{cmd.path}" "-C{config.path}" {program.verbose} {program.verify} -p{build.mcu} -c{protocol} {program.extra_params} "-Uflash:w:{build.path}/{build.project_name}.hex:i"
 


### PR DESCRIPTION
The purpose of this pull request is to provide backwards compatibility of Arduino AVR Boards with Arduino IDE 1.6.8 and previous.

Arduino AVR Boards 1.6.11 added the `{upload.verify}` property to the `tools.avrdude.upload` recipe and `{program.verify}` to the `tools.avrdude.program` recipe to support the **File > Preferences > Verify code after upload** setting. In Arduino IDE versions 1.6.8 and previous `upload.verify` is set to true or false depending on the preferences setting which causes **Upload** to an AVR board with Arduino IDE 1.6.8 or older and Arduino AVR Boards 1.6.11 or newer to generate AVRDUDE commands like:
```
avrdude -CC:\Users\per\AppData\Local\Arduino15\packages\arduino\tools\avrdude\6.3.0-arduino2/etc/avrdude.conf -v true -patmega328p -carduino -PCOM21 -b115200 -D -Uflash:w:C:\Users\per\AppData\Local\Temp\buildece560c1024a4a94b7c3b05be61aa2fc.tmp/sketch_sep28a.ino.hex:i
```
`program.verify` is unset, which causes **Upload Using Programmer** to an AVR board with Arduino IDE 1.6.8 or older and Arduino AVR Boards 1.6.11 or newer to generate AVRDUDE commands like:
```
avrdude -CC:\Users\per\AppData\Local\Arduino15\packages\arduino\tools\avrdude\6.3.0-arduino6/etc/avrdude.conf -v {program.verify} -patmega328p -cusbasp -Pusb -Uflash:w:C:\Users\per\AppData\Local\Temp\build77ff2e21c5523c5895e8d065447461cb.tmp/sketch_sep28a.ino.hex:i 
```
AVRDUDE 6.0.1 is able to ignore the spurious item in the command and successfully upload but when used with AVRDUDE 6.3.0 this causes upload to fail:
```
avrdude: no programmer has been specified on the command line or the config file
         Specify a programmer using the -c option and try again
```
This means that Arduino AVR Boards 1.6.12 and 1.6.14 are not backwards compatible with Arduino IDE 1.6.8 and previous.

Setting a default empty value for the `upload.verify` and `program.verify` properties in platform.txt causes Arduino IDE 1.6.8 and older to generate an AVRDUDE command identical to that generated with Arduino AVR Boards 1.6.10 or older(meaning that, as previously, the preferences setting has no effect):
```
avrdude -CC:\Users\per\AppData\Local\Arduino15\packages\arduino\tools\avrdude\6.3.0-arduino2/etc/avrdude.conf -v -patmega328p -carduino -PCOM21 -b115200 -D -Uflash:w:C:\Users\per\AppData\Local\Temp\buildece560c1024a4a94b7c3b05be61aa2fc.tmp/sketch_sep28a.ino.hex:i
```
Arduino IDE 1.6.9 and newer overrides the default values of `upload.verify` and `program.verify`, therefore this change has no effect on the AVRDUDE command generated and verification is controlled by the preferences setting as usual.

Tested back to Arduino IDE 1.6.2, the oldest IDE version that supports Boards Manager updates.