### PR TITLE
Add FreeBSD Platform Tag -- supports x86_64-freebsd, arm*-freebsd, an…

### DIFF
--- a/arduino-core/src/cc/arduino/contributions/packages/HostDependentDownloadableContribution.java
+++ b/arduino-core/src/cc/arduino/contributions/packages/HostDependentDownloadableContribution.java
@@ -79,6 +79,16 @@ public abstract class HostDependentDownloadableContribution extends Downloadable
       }
     }
 
+    if (osName.contains("FreeBSD")) {
+      if (osArch.contains("amd64")) {
+        return host.matches("x86_64-freebsd[0-9]*");
+      } else if (osArch.contains("arm")) {
+        return host.matches("arm.*-freebsd[0-9]*");
+      } else {
+        return host.matches("i386-freebsd[0-9]*");
+      }
+    }
+
     return false;
   }
 }

--- a/arduino-core/src/cc/arduino/contributions/packages/HostDependentDownloadableContribution.java
+++ b/arduino-core/src/cc/arduino/contributions/packages/HostDependentDownloadableContribution.java
@@ -80,12 +80,10 @@ public abstract class HostDependentDownloadableContribution extends Downloadable
     }
 
     if (osName.contains("FreeBSD")) {
-      if (osArch.contains("amd64")) {
-        return host.matches("x86_64-freebsd[0-9]*");
-      } else if (osArch.contains("arm")) {
+      if (osArch.contains("arm")) {
         return host.matches("arm.*-freebsd[0-9]*");
       } else {
-        return host.matches("i386-freebsd[0-9]*");
+        return host.matches(osArch + "-freebsd[0-9]*");
       }
     }
 


### PR DESCRIPTION
…d i386-freebsd with optional extension for tagging a specific release (e.g. freebsd11) if it's decided to do so later.

This should give us the widest range of flexibility/compatibility, I believe.
