### PR TITLE
Fix signature and definition of utoa to match name

### DIFF
--- a/hardware/arduino/sam/cores/arduino/itoa.c
+++ b/hardware/arduino/sam/cores/arduino/itoa.c
@@ -121,7 +121,7 @@ extern char* ltoa( long value, char *string, int radix )
   return string;
 }
 
-extern char* utoa( unsigned long value, char *string, int radix )
+extern char* utoa( unsigned int value, char *string, int radix )
 {
   return ultoa( value, string, radix ) ;
 }

--- a/hardware/arduino/sam/cores/arduino/itoa.h
+++ b/hardware/arduino/sam/cores/arduino/itoa.h
@@ -31,7 +31,7 @@ extern void itoa( int n, char s[] ) ;
 
 extern char* itoa( int value, char *string, int radix ) ;
 extern char* ltoa( long value, char *string, int radix ) ;
-extern char* utoa( unsigned long value, char *string, int radix ) ;
+extern char* utoa( unsigned int value, char *string, int radix ) ;
 extern char* ultoa( unsigned long value, char *string, int radix ) ;
 #endif /* 0 */
 
@@ -40,3 +40,4 @@ extern char* ultoa( unsigned long value, char *string, int radix ) ;
 #endif // __cplusplus
 
 #endif // _ITOA_
+


### PR DESCRIPTION
Currently causes issues at the very least when compiled w/ newer versions of Newlib/arm-none-eabi-gcc. 