### PR TITLE
use IAD Descriptor for device descriptor  to follow the specification

### DIFF
--- a/hardware/arduino/avr/cores/arduino/USBCore.cpp
+++ b/hardware/arduino/avr/cores/arduino/USBCore.cpp
@@ -34,8 +34,7 @@ volatile u8 RxLEDPulse; /**< Milliseconds remaining for data Rx LED pulse */
 extern const u16 STRING_LANGUAGE[] PROGMEM;
 extern const u8 STRING_PRODUCT[] PROGMEM;
 extern const u8 STRING_MANUFACTURER[] PROGMEM;
-extern const DeviceDescriptor USB_DeviceDescriptor PROGMEM;
-extern const DeviceDescriptor USB_DeviceDescriptorB PROGMEM;
+extern const DeviceDescriptor USB_DeviceDescriptorIAD PROGMEM;
 extern bool _updatedLUFAbootloader;
 
 const u16 STRING_LANGUAGE[2] = {
@@ -71,10 +70,7 @@ const u8 STRING_MANUFACTURER[] PROGMEM = USB_MANUFACTURER;
 #define DEVICE_CLASS 0x02
 
 //	DEVICE DESCRIPTOR
-const DeviceDescriptor USB_DeviceDescriptor =
-	D_DEVICE(0x00,0x00,0x00,64,USB_VID,USB_PID,0x100,IMANUFACTURER,IPRODUCT,ISERIAL,1);
-
-const DeviceDescriptor USB_DeviceDescriptorB =
+const DeviceDescriptor USB_DeviceDescriptorIAD =
 	D_DEVICE(0xEF,0x02,0x01,64,USB_VID,USB_PID,0x100,IMANUFACTURER,IPRODUCT,ISERIAL,1);
 
 //==================================================================
@@ -507,9 +503,7 @@ bool SendDescriptor(USBSetup& setup)
 	const u8* desc_addr = 0;
 	if (USB_DEVICE_DESCRIPTOR_TYPE == t)
 	{
-		if (setup.wLength == 8)
-			_cdcComposite = 1;
-		desc_addr = _cdcComposite ?  (const u8*)&USB_DeviceDescriptorB : (const u8*)&USB_DeviceDescriptor;
+		desc_addr = (const u8*)&USB_DeviceDescriptorIAD;
 	}
 	else if (USB_STRING_DESCRIPTOR_TYPE == t)
 	{


### PR DESCRIPTION
## issue description

My host device based on Nucleus usb stack failed to enumerate Arduino in below step:
1. Nucleus send GetDescritpor(device) request with specified 8 byte length to see if _bcdUSB_ and _bMaxPacketSize0_ used by the device is acceptable. But Arduino send out the DeviceDescriptor with class type 0, subclass type 0, protocol type 0. Nucleus only write down these information at this step.
2. since Arudino's usb version and packet size is acceptable by Nucleus, Nucleus then send full GetDescritpor(device) request to get full device descriptor. this time Arduino will send out DeviceDescriptorB with class type **0xEF**, subclass type **0x02**, protocol type **0x01**.
3. then Nucleus send subsequent GetDescriptor(configuration)
4. Nucleus send subsequent GetDescriptor(interface). Arduino send out interface configuration with IAD. Then Nucleus think this is a wrong behavior because in step 1, the device type doesn't follow IAD specification.
## specification

per "USB 2.0 ECN Interface Association Descriptor" and "USB Interface Association Descriptor Device Class Code and Use Model", if one device use IAD, then it must use class type 0xEF, subclass type 0x02, protocol type 0x01
## conclusion

Currently Arduino doesn't follow the specification strictly. I guess it might had been implemented before the specification was published, at that time, the host may have own different behavior for IAD. But now, as the specification has been accepted and published, Arduino should update this.

I have tested in Win7 system, and Nucleus, this update works.
