### PR TITLE
Updated Steper Motors Circuits URL

### DIFF
--- a/libraries/Stepper/src/Stepper.cpp
+++ b/libraries/Stepper/src/Stepper.cpp
@@ -72,7 +72,7 @@
  *
  * The circuits can be found at
  *
- * http://www.arduino.cc/en/Tutorial/Stepper
+ * http://www.arduino.cc/en/Reference/Stepper
  */
 
 #include "Arduino.h"

--- a/libraries/Stepper/src/Stepper.h
+++ b/libraries/Stepper/src/Stepper.h
@@ -72,7 +72,7 @@
  *
  * The circuits can be found at
  *
- * http://www.arduino.cc/en/Tutorial/Stepper
+ * http://www.arduino.cc/en/Reference/Stepper
  */
 
 // ensure this library description is only included once


### PR DESCRIPTION
A quick update. The URL http://www.arduino.cc/en/Tutorial/Stepper doesn't exist anymore.

The new URL where a user can get the circuits is http://www.arduino.cc/en/Reference/Stepper