### PR TITLE
Make init() run before C++ static initializers

### DIFF
--- a/hardware/arduino/avr/cores/arduino/wiring.c
+++ b/hardware/arduino/avr/cores/arduino/wiring.c
@@ -238,7 +238,10 @@ void delayMicroseconds(unsigned int us)
 	// return = 4 cycles
 }
 
-void init()
+//http://www.atmel.com/webdoc/AVRLibcReferenceManual/mem_sections_1sec_dot_init.html
+// init5 is after .data, but before C++ initialization - perfect for hardware setup
+void _do_setup(void) __attribute__ ((naked, used, section (".init5")));
+void _do_setup()
 {
 	// this needs to be called before setup() or some functions won't
 	// work there
@@ -390,3 +393,6 @@ void init()
 	UCSR0B = 0;
 #endif
 }
+
+// for backwards compatibility
+void init() {}


### PR DESCRIPTION
Before this change, the contents of `init()` run after [`.init6`](http://www.nongnu.org/avr-libc/user-manual/mem_sections.html) which is when static initializers run.

However, this is not desirable:
* init() does not need any C++ classes to be active
* C++ static initialization sometimes _does_ require that the hardware be pre-configured!

This makes it possible to make calls like `Serial.begin()` inside constructors of global variables.