### PR TITLE
Improve serial plotter graph colors

### DIFF
--- a/build/shared/lib/theme/theme.txt
+++ b/build/shared/lib/theme/theme.txt
@@ -37,16 +37,19 @@ buttons.status.font = SansSerif,plain,12
 buttons.status.color = #ffffff
 
 # GUI - PLOTTING
-# color cycle created via colorbrewer2.org
 plotting.bgcolor = #ffffff
 plotting.color = #ffffff
 plotting.gridcolor = #f0f0f0
 plotting.boundscolor = #000000
-plotting.graphcolor.size = 4
-plotting.graphcolor.00 = #2c7bb6
-plotting.graphcolor.01 = #fdae61
-plotting.graphcolor.02 = #d7191c
-plotting.graphcolor.03 = #abd9e9
+plotting.graphcolor.size = 8
+plotting.graphcolor.00 = #0000FF
+plotting.graphcolor.01 = #FF0000
+plotting.graphcolor.02 = #009900
+plotting.graphcolor.03 = #FF9900
+plotting.graphcolor.04 = #CC00CC
+plotting.graphcolor.05 = #666666
+plotting.graphcolor.06 = #00CCFF
+plotting.graphcolor.07 = #000000
 
 # GUI - LINESTATUS   
 linestatus.color = #ffffff


### PR DESCRIPTION
I've noticed that the multi-plot feature of the serial plotter has too few colors; it starts cycling after 4 colors.  (Also I personally don't quite like the current colors.)
This patch increases the number of colors to 8 and uses a brighter, more saturated palette so that the colors are easy to distinguish even by people with reduced color perception (blue, red, green, amber, purple, gray, aqua, black).

I made this palette a while back for plots used on technical reports because I didn't like the default one on Excel/Gnumeric, and I think it looks rather nice for line plots.  I thought it could be useful for Arduino too.

Example with **4 colors:**
![plot_4colors](https://cloud.githubusercontent.com/assets/6584870/20763480/7c8682ba-b72a-11e6-88ba-389deeb39ea0.png)

Example with **8 colors:**
![plot_8colors](https://cloud.githubusercontent.com/assets/6584870/20763493/880990fa-b72a-11e6-878d-427fa498608a.png)

Code used to generate the example (in case you want to try this):
```arduino
static byte randomize(byte &data, byte factor) {
  data += (random(256) - data) / factor;
  return data;
}

void setup() {
  Serial.begin(115200);
}

#define PLOTS 8
#define FACTOR 16
static byte plots[PLOTS] = {0};
void loop() {
  for (int i=0; i<PLOTS; i++) {
    Serial.print(randomize(plots[i], FACTOR));
    Serial.print(",");
  }
  Serial.println();
  delay(10);
}
```