### PR TITLE
declare timer0_fract non static and volatile to make it available for linking

### DIFF
--- a/hardware/arduino/avr/cores/arduino/wiring.c
+++ b/hardware/arduino/avr/cores/arduino/wiring.c
@@ -37,7 +37,7 @@
 
 volatile unsigned long timer0_overflow_count = 0;
 volatile unsigned long timer0_millis = 0;
-static unsigned char timer0_fract = 0;
+volatile unsigned char timer0_fract = 0;
 
 #if defined(__AVR_ATtiny24__) || defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__)
 ISR(TIM0_OVF_vect)


### PR DESCRIPTION
using timer0_fract and Timer0s count register it's possible to write more
precise millis function that include all milliseconds or return some extra
accuracy (eg 1/4 on 1/8 millisecond) with less overhead than micros.


    unsigned long millisx()
    {
        //this includes all milliseconds (e.g. 42)
        extern unsigned long timer0_millis;
        extern uint8_t timer0_fract;
        unsigned long m;
        uint8_t oldSREG = SREG;
        uint8_t t;

        #if defined(TCNT0)
            t = TCNT0;
        #elif defined(TCNT0L)
            t = TCNT0L;
        #else
            #error TIMER 0 not defined
        #endif
        // disable interrupts while we read timer0_millis or we might get an
        // inconsistent value (e.g. in the middle of a write to timer0_millis)


        cli();
        m = timer0_millis;
        SREG = oldSREG;

        if( (timer0_fract >> 1) + (t >> 2) > 63) ++m;
        return m;
    }
