### PR TITLE
Fix font anti-alias on windows

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -120,8 +120,16 @@ public class Base {
   private final List<JMenuItem> recentSketchesMenuItems = new LinkedList<>();
 
   static public void main(String args[]) throws Exception {
-    System.setProperty("awt.useSystemAAFontSettings", "on");
-    System.setProperty("swing.aatext", "true");
+    if (!OSUtils.isWindows()) {
+      // Those properties helps enabling anti-aliasing on Linux
+      // (but not on Windows where they made things worse actually
+      // and the font rendering becomes ugly).
+
+      // Those properties must be set before initializing any
+      // graphic object, otherwise they don't have any effect.
+      System.setProperty("awt.useSystemAAFontSettings", "on");
+      System.setProperty("swing.aatext", "true");
+    }
     System.setProperty("java.net.useSystemProxies", "true");
 
     if (OSUtils.isMacOS()) {

--- a/build/shared/revisions.txt
+++ b/build/shared/revisions.txt
@@ -1,5 +1,7 @@
 ARDUINO 1.8.1
 
+[ide]
+* Fixed font rendering not anti-aliased on Windows (regression)
 
 ARDUINO 1.8.0 - 2016.12.20
 


### PR DESCRIPTION
The properties:

      System.setProperty("awt.useSystemAAFontSettings", "on");
      System.setProperty("swing.aatext", "true");

actually works on Linux (where the hint helps X11 to enable antialiased rendering) but makes things worse on Windows where the outcome is exactly the opposite (anti-alias is disabled).

Previously those settings had no effect because they were executed *after* the initialization of the graphics. This is no more true after the merge of #5578, that moved the graphics initialization after commmand line parsing and consequently revealed the weird behaviour on windows.

Fix #5750