### PR TITLE
Changed ant build script to use http with launcher4j.

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -954,7 +954,7 @@
   <target name="download-launch4j-windows">
     <antcall target="unzip-with-ant-task">
       <param name="archive_file" value="windows/launch4j-3.9-win32.zip"/>
-      <param name="archive_url" value="https://downloads.sourceforge.net/project/launch4j/launch4j-3/3.9/launch4j-3.9-win32.zip"/>
+      <param name="archive_url" value="http://downloads.sourceforge.net/project/launch4j/launch4j-3/3.9/launch4j-3.9-win32.zip"/>
       <param name="final_folder" value="windows/launcher/launch4j"/>
       <param name="dest_folder" value="windows/launcher/"/>
     </antcall>
@@ -963,7 +963,7 @@
   <target name="download-launch4j-linux">
     <antcall target="untar">
       <param name="archive_file" value="windows/launch4j-3.9-linux.tgz"/>
-      <param name="archive_url" value="https://downloads.sourceforge.net/project/launch4j/launch4j-3/3.9/launch4j-3.9-linux.tgz"/>
+      <param name="archive_url" value="http://downloads.sourceforge.net/project/launch4j/launch4j-3/3.9/launch4j-3.9-linux.tgz"/>
       <param name="final_folder" value="windows/launcher/launch4j"/>
       <param name="dest_folder" value="windows/launcher/"/>
     </antcall>


### PR DESCRIPTION
Due to sourceforge using a 307 temporary redirect, the build script now fails to retrieve the launcher package (windows/linux).
This is because the build script uses the https protocol and the redirect uses http.

Error from ant script:
> [get] Redirection detected from https to http. Protocol switch unsafe, not allowed.

This is a simple fix as it now requests the download using http, so the redirect is allowed.