### PR TITLE
Const correct eeprom

### DIFF
--- a/hardware/arduino/avr/libraries/EEPROM/src/EEPROM.h
+++ b/hardware/arduino/avr/libraries/EEPROM/src/EEPROM.h
@@ -93,8 +93,8 @@ struct EEPtr{
     EEPtr &operator=( int in )          { return index = in, *this; }
     
     //Iterator functionality.
-    bool operator!=( const EEPtr &ptr ) { return index != ptr.index; }
-    EERef operator*()                   { return index; }
+    bool operator!=( const EEPtr &ptr ) const { return index != ptr.index; }
+    EERef operator*()                         { return index; }
     
     /** Prefix & Postfix increment/decrement **/
     EEPtr& operator++()                 { return ++index, *this; }

--- a/hardware/arduino/avr/libraries/EEPROM/src/EEPROM.h
+++ b/hardware/arduino/avr/libraries/EEPROM/src/EEPROM.h
@@ -116,10 +116,11 @@ struct EEPtr{
 struct EEPROMClass{
 
     //Basic user access methods.
-    EERef operator[]( const int idx )    { return idx; }
-    uint8_t read( int idx )              { return EERef( idx ); }
-    void write( int idx, uint8_t val )   { (EERef( idx )) = val; }
-    void update( int idx, uint8_t val )  { EERef( idx ).update( val ); }
+    EERef operator[]( const int idx )             { return idx; }
+    const EERef operator[]( const int idx ) const { return idx; }
+    uint8_t read( int idx ) const                 { return EERef( idx ); }
+    void write( int idx, uint8_t val )            { (EERef( idx )) = val; }
+    void update( int idx, uint8_t val )           { EERef( idx ).update( val ); }
     
     //STL and C++11 iteration capability.
     EEPtr begin()                        { return 0x00; }
@@ -127,7 +128,7 @@ struct EEPROMClass{
     uint16_t length()                    { return E2END + 1; }
     
     //Functionality to 'get' and 'put' objects to and from EEPROM.
-    template< typename T > T &get( int idx, T &t ){
+    template< typename T > T &get( int idx, T &t ) const {
         EEPtr e = idx;
         uint8_t *ptr = (uint8_t*) &t;
         for( int count = sizeof(T) ; count ; --count, ++e )  *ptr++ = *e;


### PR DESCRIPTION
Add `const` keywords to methods where appropriate. This makes the following possible:

```c++

void do_readonly(const EEPROMClass& eeprom) {
    const EERef ref = eeprom[1]; // before this patch, this would error!
    T x = eeprom.get<T>(2); // before this patch, this would error!
    uint8_t val = eeprom.read(2);  // before this patch, this would error!

    //intentionally errors: ref++;

    bool empty = eeprom.begin() == eeprom.end();  // before this patch, this would error!
}
```

A minor but hopefully uncontentious change.

No changes to `EEPtr`, since that would require introducing a new type to mean "pointer to const" (`const EEPtr` just means "const pointer")