### PR TITLE
Make avr and sam files more similar to aid #5771

### DIFF
--- a/hardware/arduino/avr/cores/arduino/Print.cpp
+++ b/hardware/arduino/avr/cores/arduino/Print.cpp
@@ -41,19 +41,6 @@ size_t Print::write(const uint8_t *buffer, size_t size)
   return n;
 }
 
-size_t Print::print(const __FlashStringHelper *ifsh)
-{
-  PGM_P p = reinterpret_cast<PGM_P>(ifsh);
-  size_t n = 0;
-  while (1) {
-    unsigned char c = pgm_read_byte(p++);
-    if (c == 0) break;
-    if (write(c)) n++;
-    else break;
-  }
-  return n;
-}
-
 size_t Print::print(const String &s)
 {
   return write(s.c_str(), s.length());
@@ -257,7 +244,7 @@ size_t Print::printFloat(double number, uint8_t digits)
   while (digits-- > 0)
   {
     remainder *= 10.0;
-    unsigned int toPrint = (unsigned int)(remainder);
+    unsigned int toPrint = (unsigned int)remainder;
     n += print(toPrint);
     remainder -= toPrint; 
   } 

--- a/hardware/arduino/avr/cores/arduino/PrintFlashString.cpp
+++ b/hardware/arduino/avr/cores/arduino/PrintFlashString.cpp
@@ -1,0 +1,40 @@
+/*
+ PrintFlashString.cpp - Provides the platform-specific print for flash strings
+ Copyright (c) 2008 David A. Mellis.  All right reserved.
+ 
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+ 
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ 
+ Modified 23 November 2006 by David A. Mellis
+ Modified 03 August 2015 by Chuck Todd
+ */
+
+#include "Arduino.h"
+
+#include "Print.h"
+
+// Public Methods //////////////////////////////////////////////////////////////
+
+size_t Print::print(const __FlashStringHelper *ifsh)
+{
+  PGM_P p = reinterpret_cast<PGM_P>(ifsh);
+  size_t n = 0;
+  while (1) {
+    unsigned char c = pgm_read_byte(p++);
+    if (c == 0) break;
+    if (write(c)) n++;
+    else break;
+  }
+  return n;
+}

--- a/hardware/arduino/avr/cores/arduino/Stream.h
+++ b/hardware/arduino/avr/cores/arduino/Stream.h
@@ -67,7 +67,7 @@ class Stream : public Print
 
   void setTimeout(unsigned long timeout);  // sets maximum milliseconds to wait for stream data, default is 1 second
   unsigned long getTimeout(void) { return _timeout; }
-  
+
   bool find(char *target);   // reads data from the stream until the target string is found
   bool find(uint8_t *target) { return find ((char *)target); }
   // returns true if target string is found, false if timed out (see setTimeout)

--- a/hardware/arduino/sam/cores/arduino/Print.cpp
+++ b/hardware/arduino/sam/cores/arduino/Print.cpp
@@ -41,11 +41,6 @@ size_t Print::write(const uint8_t *buffer, size_t size)
   return n;
 }
 
-size_t Print::print(const __FlashStringHelper *ifsh)
-{
-  return print(reinterpret_cast<const char *>(ifsh));
-}
-
 size_t Print::print(const String &s)
 {
   return write(s.c_str(), s.length());

--- a/hardware/arduino/sam/cores/arduino/PrintFlashString.cpp
+++ b/hardware/arduino/sam/cores/arduino/PrintFlashString.cpp
@@ -1,0 +1,32 @@
+/*
+ PrintFlashString.cpp - Provides the platform-specific print for flash strings
+ Copyright (c) 2008 David A. Mellis.  All right reserved.
+ 
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+ 
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ 
+ Modified 23 November 2006 by David A. Mellis
+ Modified 03 August 2015 by Chuck Todd
+ */
+
+#include "Arduino.h"
+
+#include "Print.h"
+
+// Public Methods //////////////////////////////////////////////////////////////
+
+size_t Print::print(const __FlashStringHelper *ifsh)
+{
+  return print(reinterpret_cast<const char *>(ifsh));
+}

--- a/hardware/arduino/sam/cores/arduino/Stream.cpp
+++ b/hardware/arduino/sam/cores/arduino/Stream.cpp
@@ -53,7 +53,7 @@ int Stream::timedPeek()
 
 // returns peek of the next digit in the stream or -1 if timeout
 // discards non-numeric characters
-int Stream::peekNextDigit(LookaheadMode lookahead, bool detectDecimal )
+int Stream::peekNextDigit(LookaheadMode lookahead, bool detectDecimal)
 {
   int c;
   while (1) {


### PR DESCRIPTION
Pulls the per-platform code in `Print.cpp` into its own file, so that both `Print.cpp`s are now identical.

Also corrects style divergence between otherwise-identical files. Hopefully this helps with #5771 