### PR TITLE
Amended .gitignore to ignore liblistSerials dev dependency.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ build/windows/*.zip
 build/windows/*.tgz
 build/windows/*.tar.bz2
 build/windows/libastylej*
+build/windows/liblistSerials*
 build/windows/arduino-*.zip
 build/windows/dist/*.tar.gz
 build/windows/dist/*.tar.bz2


### PR DESCRIPTION
This .gitignore entry was left out of the windows exclusions, it is present for linux.
This will stop git from displaying the pesky untracked files.