### PR TITLE
Add Print::availableForWrite

### DIFF
--- a/hardware/arduino/avr/cores/arduino/HardwareSerial.h
+++ b/hardware/arduino/avr/cores/arduino/HardwareSerial.h
@@ -124,7 +124,7 @@ class HardwareSerial : public Stream
     virtual int available(void);
     virtual int peek(void);
     virtual int read(void);
-    int availableForWrite(void);
+    virtual int availableForWrite(void);
     virtual void flush(void);
     virtual size_t write(uint8_t);
     inline size_t write(unsigned long n) { return write((uint8_t)n); }

--- a/hardware/arduino/avr/cores/arduino/Print.h
+++ b/hardware/arduino/avr/cores/arduino/Print.h
@@ -22,6 +22,7 @@
 
 #include <inttypes.h>
 #include <stdio.h> // for size_t
+#include <limits.h> // for INT_MAX
 
 #include "WString.h"
 #include "Printable.h"
@@ -57,7 +58,11 @@ class Print
     size_t write(const char *buffer, size_t size) {
       return write((const uint8_t *)buffer, size);
     }
-    
+
+    // default to zero, meaning "a single write may block"
+    // should be overriden by subclasses with buffering
+    virtual int availableForWrite() { return 0; }
+
     size_t print(const __FlashStringHelper *);
     size_t print(const String &);
     size_t print(const char[]);

--- a/hardware/arduino/avr/cores/arduino/USBAPI.h
+++ b/hardware/arduino/avr/cores/arduino/USBAPI.h
@@ -98,7 +98,7 @@ public:
 	virtual int available(void);
 	virtual int peek(void);
 	virtual int read(void);
-	int availableForWrite(void);
+	virtual int availableForWrite(void);
 	virtual void flush(void);
 	virtual size_t write(uint8_t);
 	virtual size_t write(const uint8_t*, size_t);


### PR DESCRIPTION
If `available()` is in the base `Stream` class, then `availableForWrite()` should be in the base Print class

For backwards compatibility, this can't be pure virtual. So we return INT_MAX, indicating no limit.

Ideally, we'd use `size_t` and `SIZE_MAX`, but that's probably not a backwards-compatible change