### PR TITLE
[AVR] Send USB ZLP if required

### DIFF
--- a/hardware/arduino/avr/cores/arduino/USBCore.cpp
+++ b/hardware/arduino/avr/cores/arduino/USBCore.cpp
@@ -256,9 +256,7 @@ u8 USB_SendSpace(u8 ep)
 	LockEP lock(ep);
 	if (!ReadWriteAllowed())
 		return 0;
-	// subtract 1 from the EP size to never send a full packet,
-	// this avoids dealing with ZLP's in USB_Send
-	return USB_EP_SIZE - 1 - FifoByteCount();
+	return USB_EP_SIZE - FifoByteCount();
 }
 
 //	Blocking Send of data to an endpoint


### PR DESCRIPTION
Fixes #5732 , "reverts" #4864

Tested with all the following problematic code on Linux, WinXp and Win10

https://github.com/NicoHood/HID/blob/master/examples/RawHID/RawHID/RawHID.ino (only on Linux)

```arduino
void setup() {
  // put your setup code here, to run once:

}

void loop() {
  if (Serial) {
    if (Serial.available() > 0) {
      Serial.read();
      char buff[65] = "D_ENDPOINT(USB_ENDPOINT_IN (CDC_ENDPOINT_IN ),USB_ENDPOINT_TYPE";
      Serial.write(buff,64);
      Serial.flush();
    }
  }
}
```

```arduino
void setup() {
  // put your setup code here, to run once:

}

void loop() {
  if (Serial) {
    if (Serial.available() > 0) {
      Serial.read();
      char buff[129] = "D_ENDPOINT(USB_ENDPOINT_IN (CDC_ENDPOINT_IN ),USB_ENDPOINT_TYPED_ENDPOINT(USB_ENDPOINT_IN (CDC_ENDPOINT_IN ),USB_ENDPOINT_TYPE";
      Serial.write(buff,128);
      Serial.flush();
    }
  }
}
```

```arduino
void setup() {
  // put your setup code here, to run once:

}

void loop() {
  if (Serial) {
    if (Serial.read() == 'h'){
      Serial.write("Hello ");
      Serial.flush();
      Serial.write("World!\r\n");
      Serial.flush();
    }
  }
}
```

Comments are really appreciated (as the USB core is still really convoluted, I'm probably missing something important)

@NicoHood @sandeepmistry @matthijskooijman @embmicro 