### PR TITLE
Change double quotes to single quotes

### DIFF
--- a/hardware/arduino/avr/cores/arduino/Print.cpp
+++ b/hardware/arduino/avr/cores/arduino/Print.cpp
@@ -250,7 +250,7 @@ size_t Print::printFloat(double number, uint8_t digits)
 
   // Print the decimal point, but only if there are digits beyond
   if (digits > 0) {
-    n += print("."); 
+    n += print('.'); 
   }
 
   // Extract digits from the remainder one at a time

--- a/hardware/arduino/sam/cores/arduino/Print.cpp
+++ b/hardware/arduino/sam/cores/arduino/Print.cpp
@@ -242,7 +242,7 @@ size_t Print::printFloat(double number, uint8_t digits)
 
   // Print the decimal point, but only if there are digits beyond
   if (digits > 0) {
-    n += print("."); 
+    n += print('.'); 
   }
 
   // Extract digits from the remainder one at a time


### PR DESCRIPTION
Observe that "." is a string literal, and so is treated as the char '.' plus the null char '\0'. Single quotes reduces the necessary memory for this literal to only one char instead. 
A string literal as the one actually present may require the use of the method "write(const char *str)", so there could be also a performance overhead. 
Another reason to change quotes style is for consistency with line 235.

Signed-off-by: Patrick Roncagliolo <ronca.pat@gmail.com>