### PR TITLE
Add support for alternative IPv4 formats

### DIFF
--- a/hardware/arduino/avr/cores/arduino/IPAddress.cpp
+++ b/hardware/arduino/avr/cores/arduino/IPAddress.cpp
@@ -45,8 +45,6 @@ IPAddress::IPAddress(const uint8_t *address)
 
 bool IPAddress::fromString(const char *address)
 {
-    // TODO: add support for "a", "a.b", "a.b.c" formats
-
     uint16_t acc = 0; // Accumulator
     uint8_t dots = 0;
 
@@ -76,12 +74,15 @@ bool IPAddress::fromString(const char *address)
             return false;
         }
     }
+    
+    _address.bytes[dots++] = acc;
 
-    if (dots != 3) {
-        // Too few dots (there must be 3 dots)
-        return false;
+    // Fill remaining bytes with zeroes (needed to support a, a.b, a.b.c addresses)
+    while (dots <= 3)
+    {
+       _address.bytes[dots++] = 0; 
     }
-    _address.bytes[3] = acc;
+    
     return true;
 }
 

--- a/hardware/arduino/sam/cores/arduino/IPAddress.cpp
+++ b/hardware/arduino/sam/cores/arduino/IPAddress.cpp
@@ -45,8 +45,6 @@ IPAddress::IPAddress(const uint8_t *address)
 
 bool IPAddress::fromString(const char *address)
 {
-    // TODO: add support for "a", "a.b", "a.b.c" formats
-
     uint16_t acc = 0; // Accumulator
     uint8_t dots = 0;
 
@@ -76,12 +74,15 @@ bool IPAddress::fromString(const char *address)
             return false;
         }
     }
+    
+    _address.bytes[dots++] = acc;
 
-    if (dots != 3) {
-        // Too few dots (there must be 3 dots)
-        return false;
+    // Fill remaining bytes with zeroes (needed to support a, a.b, a.b.c addresses)
+    while (dots <= 3)
+    {
+       _address.bytes[dots++] = 0; 
     }
-    _address.bytes[3] = acc;
+    
     return true;
 }
 

--- a/libraries/Ethernet/src/Dns.cpp
+++ b/libraries/Ethernet/src/Dns.cpp
@@ -57,8 +57,6 @@ void DNSClient::begin(const IPAddress& aDNSServer)
 
 int DNSClient::inet_aton(const char* address, IPAddress& result)
 {
-    // TODO: add support for "a", "a.b", "a.b.c" formats
-
     uint16_t acc = 0; // Accumulator
     uint8_t dots = 0;
 
@@ -88,12 +86,15 @@ int DNSClient::inet_aton(const char* address, IPAddress& result)
             return 0;
         }
     }
+    
+    result[dots++] = acc;
 
-    if (dots != 3) {
-        // Too few dots (there must be 3 dots)
-        return 0;
+    // Fill remaining bytes with zeroes (needed to support a, a.b, a.b.c addresses)
+    while (dots <= 3)
+    {
+       result[dots++] = 0; 
     }
-    result[3] = acc;
+    
     return 1;
 }
 


### PR DESCRIPTION
This patch satisfies the TODO that was present in the modified sources,
which requested support for "a", "a.b" and "a.b.c" shortened ipv4 addresses.

This patch zero-fills the remaining bytes of the address, if they are left
untouched by the string-to-number conversion routine (the main while loop of
the method).

Signed-off-by: Patrick Roncagliolo <ronca.pat@gmail.com>