### PR TITLE
type qualifiers ignored on function return type

### DIFF
--- a/hardware/arduino/avr/libraries/EEPROM/src/EEPROM.h
+++ b/hardware/arduino/avr/libraries/EEPROM/src/EEPROM.h
@@ -40,7 +40,7 @@ struct EERef{
     
     //Access/read members.
     uint8_t operator*() const            { return eeprom_read_byte( (uint8_t*) index ); }
-    operator const uint8_t() const       { return **this; }
+    operator uint8_t()                   { return **this; }
     
     //Assignment/write members.
     EERef &operator=( const EERef &ref ) { return *this = *ref; }
@@ -89,7 +89,7 @@ struct EEPtr{
     EEPtr( const int index )
         : index( index )                {}
         
-    operator const int() const          { return index; }
+    operator int()                      { return index; }
     EEPtr &operator=( int in )          { return index = in, *this; }
     
     //Iterator functionality.


### PR DESCRIPTION
`/home/kelly/.arduino15/packages/arduino/hardware/avr/1.6.17/libraries/EEPROM/src/EEPROM.h:43:30: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
     operator const uint8_t() const       { return **this; }
                              ^
/home/kelly/.arduino15/packages/arduino/hardware/avr/1.6.17/libraries/EEPROM/src/EEPROM.h:92:26: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
     operator const int() const          { return index; }
                          ^
`