### PR TITLE
Make metainfo and .desktop files spec compliant

### DIFF
--- a/build/linux/dist/appdata.xml
+++ b/build/linux/dist/appdata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- See https://wiki.gnome.org/GnomeGoals/AppDataGnomeSoftware -->
-<application>
-  <id type="desktop">arduino.desktop</id>
-  <licence>CC-BY-SA</licence>
+<!-- See https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html -->
+<component type="desktop-application">
+  <id>cc.arduino.arduinoide.desktop</id>
+  <metadata_license>CC-BY-SA-3.0</metadata_license>
+
+  <name>Arduino IDE</name>
+  <summary>Open-source electronics prototyping platform</summary>
+
   <description>
     <p>
       Arduino is an open-source electronics prototyping platform based
@@ -15,10 +19,13 @@
       to develop and upload code to compatible microcontrollers.
     </p>
   </description>
+
   <screenshots>
     <screenshot type="default" width="624" height="351">http://mavit.fedorapeople.org/appdata/arduino-screenshot.png</screenshot>
     <screenshot width="704" height="396">http://mavit.fedorapeople.org/appdata/arduino-photo.jpg</screenshot>
   </screenshots>
+
   <url type="homepage">http://www.arduino.cc/</url>
-  <updatecontact>arduino.appdata.xml@mavit.org.uk</updatecontact>
-</application>
+
+  <update_contact>arduino.appdata.xml@mavit.org.uk</update_contact>
+</component>

--- a/build/linux/dist/appdata.xml
+++ b/build/linux/dist/appdata.xml
@@ -3,6 +3,7 @@
 <component type="desktop-application">
   <id>cc.arduino.arduinoide.desktop</id>
   <metadata_license>CC-BY-SA-3.0</metadata_license>
+  <developer_name>Arduino LLC</developer_name>
 
   <name>Arduino IDE</name>
   <summary>Open-source electronics prototyping platform</summary>
@@ -21,11 +22,21 @@
   </description>
 
   <screenshots>
-    <screenshot type="default" width="624" height="351">http://mavit.fedorapeople.org/appdata/arduino-screenshot.png</screenshot>
-    <screenshot width="704" height="396">http://mavit.fedorapeople.org/appdata/arduino-photo.jpg</screenshot>
+    <screenshot type="default">
+      <image>https://mavit.fedorapeople.org/appdata/arduino-screenshot.png</image>
+      <caption>The Arduino IDE showing a simple example program</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://mavit.fedorapeople.org/appdata/arduino-photo.jpg</image>
+      <caption>Arduino hardware being connected to a breadboard</caption>
+    </screenshot>
   </screenshots>
 
   <url type="homepage">http://www.arduino.cc/</url>
+  <url type="help">https://www.arduino.cc/en/Guide/HomePage</url>
+  <url type="bugtracker">https://github.com/arduino/Arduino/issues</url>
+  <url type="translate">https://github.com/arduino/Arduino/tree/master/arduino-core/src/processing/app/i18n</url>
+  <url type="donation">https://www.arduino.cc/en/Main/Contribute</url>
 
   <update_contact>arduino.appdata.xml@mavit.org.uk</update_contact>
 </component>

--- a/build/linux/dist/install.sh
+++ b/build/linux/dist/install.sh
@@ -6,7 +6,7 @@
 # If called with the "-u" option, it will undo the changes.
 
 # Resource name to use (including vendor prefix)
-RESOURCE_NAME=arduino-arduinoide
+RESOURCE_NAME=cc.arduino.arduinoide
 
 # Get absolute path from which this script file was executed
 # (Could be changed to "pwd -P" to resolve symlinks to their target)
@@ -85,6 +85,9 @@ simple_install_f() {
   mkdir -p "${HOME}/.local/share/applications"
   cp "${TMP_DIR}/${RESOURCE_NAME}.desktop" "${HOME}/.local/share/applications/"
 
+  mkdir -p "${HOME}/.local/share/metainfo"
+  cp "${SCRIPT_PATH}/lib/appdata.xml" "${HOME}/.local/share/metainfo/${RESOURCE_NAME}.appdata.xml"
+
   # Copy desktop icon if desktop dir exists (was found)
   if [ -d "${XDG_DESKTOP_DIR}" ]; then
    cp "${TMP_DIR}/${RESOURCE_NAME}.desktop" "${XDG_DESKTOP_DIR}/"
@@ -137,12 +140,22 @@ xdg_uninstall_f() {
 # Uninstall by simply removing desktop files (fallback), incl. old one
 simple_uninstall_f() {
 
+  # delete legacy cruft .desktop file
   if [ -f "${HOME}/.local/share/applications/arduino.desktop" ]; then
     rm "${HOME}/.local/share/applications/arduino.desktop"
   fi
 
+  # delete another legacy .desktop file
+  if [ -f "${HOME}/.local/share/applications/arduino-arduinoide.desktop" ]; then
+    rm "${HOME}/.local/share/applications/arduino-arduinoide.desktop"
+  fi
+
   if [ -f "${HOME}/.local/share/applications/${RESOURCE_NAME}.desktop" ]; then
     rm "${HOME}/.local/share/applications/${RESOURCE_NAME}.desktop"
+  fi
+
+  if [ -f "${HOME}/.local/share/metainfo/${RESOURCE_NAME}.appdata.xml" ]; then
+    rm "${HOME}/.local/share/metainfo/${RESOURCE_NAME}.appdata.xml"
   fi
 
   if [ -f "${XDG_DESKTOP_DIR}/arduino.desktop" ]; then


### PR DESCRIPTION
This resolves bug #5890 

The AppStream/Metainfo spec has changed a bit, and the file shipped with Arduino doesn't work at all currently, since it was apparently written against a draft version of the initial spec which was never fully supported (congrats, looks like you were one of the earliest adopters!).
This patch updates the metainfo file to match the current version of the specification as found at https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Application.html

Additionally, I also updated the .desktop file to follow the reverse-DNS scheme. This is a new requirement of the desktop-entry specification for modern applications to be D-Bus activatable and work well on Wayland.
The AppStream spec highly recommends using that scheme too, so I adapted it to be used in the .desktop and metainfo files.
You can read more about this at https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s02.html

If you have any questions, let me know!
You can validate the current metadata using `appstreamcli validate <metainfofile>`.

NOTE: I haven't tested if the script works yet (but it should).
If the .desktop filename change is not wanted, we can also go without it - just let me know and I'll adapt the patch.