### PR TITLE
Add function "printf" to AVR core class "print"

### DIFF
--- a/hardware/arduino/avr/cores/arduino/Print.cpp
+++ b/hardware/arduino/avr/cores/arduino/Print.cpp
@@ -264,3 +264,56 @@ size_t Print::printFloat(double number, uint8_t digits)
   
   return n;
 }
+
+//----------------------------------------
+//printf begin
+
+#include <stdarg.h>
+#include <stdio.h>
+                            
+//non class function for callback from stdio.FILE steam.
+//in field FILE.udata  passed class->this
+static int dummy_putchar(char c, FILE *stream  ) 
+{
+    Print* pPrint = (Print*)(stream->udata); 
+    if(c=='\n') pPrint->print('\r');
+    pPrint->print(c);
+    return 1;
+}
+
+size_t Print::printf(const char *fmt, ...)
+{
+   FILE oStream; //size 12 bytes on Stack 
+   oStream.put   = dummy_putchar;
+   oStream.flags |= __SWR;
+   oStream.udata = (void*) this;
+   //----  
+   oStream.flags &= ~__SPGM;
+   //
+   va_list ap;
+   va_start( (ap), (fmt) );     
+   size_t i = vfprintf(&oStream, fmt, ap);
+   va_end(ap); 
+   return i; 
+}
+
+size_t Print::printf(const __FlashStringHelper  *fmt_P, ...)
+{ 
+   PGM_P fmt = reinterpret_cast<PGM_P>(fmt_P);  
+
+   FILE oStream; //size 12 bytes on Stack 
+   oStream.put   = dummy_putchar;
+   oStream.flags |= __SWR;
+   oStream.udata = (void*)this;
+   //----
+   oStream.flags |=  __SPGM;    
+   //
+   va_list ap;
+   va_start( (ap), (fmt_P) ); 
+   size_t i = vfprintf(&oStream, fmt, ap);
+   va_end(ap); 
+   return i; 
+}
+
+//printf end
+//----------------------------------------

--- a/hardware/arduino/avr/cores/arduino/Print.h
+++ b/hardware/arduino/avr/cores/arduino/Print.h
@@ -79,6 +79,9 @@ class Print
     size_t println(double, int = 2);
     size_t println(const Printable&);
     size_t println(void);
+  
+    size_t printf (const char *szFormat, ...);
+    size_t printf (const __FlashStringHelper  *szFormat, ...);  
 };
 
 #endif


### PR DESCRIPTION
Add  to AVR core class "print":
    size_t printf (const char *szFormat, ...);
    size_t printf (const __FlashStringHelper  *szFormat, ...);

This is does not use the "sprintf" and buffers in RAM.
If it is not used, the compiler does not add any extra code.
For AVR Excellent.

You can write more readable code:
Serial.printf (F ("Var = 5%"), Var);
Serial.printf ("Var = 5%", Var);
LCD.printf (F ("Var2 = 3% Var3=0x%04X"), Var2, VAR2);

On large projects, the overall code size is significantly reduced when using printf.

Note:
For ARM this is code not working. 
For ARM need to use GNU  extension "fopencookie" or a  "retarget putsch" way.
