### PR TITLE
Library manager: dependency resolver

### DIFF
--- a/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryTableCellJPanel.java
+++ b/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryTableCellJPanel.java
@@ -205,6 +205,7 @@ public class ContributedLibraryTableCellJPanel extends JPanel {
     }
   }
 
+  // TODO Make this a method of Theme
   private JTextPane makeNewDescription() {
     if (getComponentCount() > 0) {
       remove(0);

--- a/app/src/cc/arduino/contributions/libraries/ui/LibraryManagerUI.java
+++ b/app/src/cc/arduino/contributions/libraries/ui/LibraryManagerUI.java
@@ -38,6 +38,7 @@ import java.awt.event.ActionListener;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.function.Predicate;
 
 import javax.swing.Box;
@@ -220,11 +221,23 @@ public class LibraryManagerUI extends InstallerJDialog<ContributedLibrary> {
   }
 
   public void onInstallPressed(final ContributedLibrary lib) {
+    List<ContributedLibrary> deps = BaseNoGui.librariesIndexer.getIndex().resolveDependeciesOf(lib);
+    final boolean installDeps;
+    if (deps.size() > 1) {
+      System.out.println("The library requires dependencies!");
+      installDeps = true;
+    } else {
+      installDeps = false;
+    }
     clearErrorMessage();
     installerThread = new Thread(() -> {
       try {
         setProgressVisible(true, tr("Installing..."));
-        installer.install(lib, this::setProgress);
+        if (installDeps) {
+          installer.install(deps, this::setProgress);
+        } else {
+          installer.install(lib, this::setProgress);
+        }
         onIndexesUpdated(); // TODO: Do a better job in refreshing only the needed element
         //getContribModel().updateLibrary(lib);
       } catch (Exception e) {

--- a/app/src/cc/arduino/contributions/libraries/ui/LibraryManagerUI.java
+++ b/app/src/cc/arduino/contributions/libraries/ui/LibraryManagerUI.java
@@ -84,7 +84,7 @@ public class LibraryManagerUI extends InstallerJDialog<ContributedLibrary> {
         if (selectedLibrary.isReadOnly()) {
           onRemovePressed(installedLibrary);
         } else {
-          onInstallPressed(selectedLibrary, installedLibrary);
+          onInstallPressed(selectedLibrary);
         }
       }
 
@@ -219,12 +219,12 @@ public class LibraryManagerUI extends InstallerJDialog<ContributedLibrary> {
     installerThread.start();
   }
 
-  public void onInstallPressed(final ContributedLibrary lib, final ContributedLibrary replaced) {
+  public void onInstallPressed(final ContributedLibrary lib) {
     clearErrorMessage();
     installerThread = new Thread(() -> {
       try {
         setProgressVisible(true, tr("Installing..."));
-        installer.install(lib, replaced, this::setProgress);
+        installer.install(lib, this::setProgress);
         onIndexesUpdated(); // TODO: Do a better job in refreshing only the needed element
         //getContribModel().updateLibrary(lib);
       } catch (Exception e) {

--- a/app/src/cc/arduino/contributions/libraries/ui/MultiLibraryInstallDialog.java
+++ b/app/src/cc/arduino/contributions/libraries/ui/MultiLibraryInstallDialog.java
@@ -1,0 +1,177 @@
+/*
+ * This file is part of Arduino.
+ *
+ * Copyright 2017 Arduino LLC (http://www.arduino.cc/)
+ *
+ * Arduino is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As a special exception, you may use this file as part of a free software
+ * library without restriction.  Specifically, if other files instantiate
+ * templates or use macros or inline functions from this file, or you compile
+ * this file and link it with other files to produce an executable, this
+ * file does not by itself cause the resulting executable to be covered by
+ * the GNU General Public License.  This exception does not however
+ * invalidate any other reasons why the executable file might be covered by
+ * the GNU General Public License.
+ */
+
+package cc.arduino.contributions.libraries.ui;
+
+import static processing.app.I18n.format;
+import static processing.app.I18n.tr;
+
+import java.awt.BorderLayout;
+import java.awt.Container;
+import java.awt.Insets;
+import java.awt.Window;
+import java.awt.event.WindowEvent;
+import java.util.List;
+
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JPanel;
+import javax.swing.JTextPane;
+import javax.swing.WindowConstants;
+import javax.swing.border.EmptyBorder;
+import javax.swing.text.Document;
+import javax.swing.text.html.HTMLDocument;
+import javax.swing.text.html.StyleSheet;
+
+import cc.arduino.contributions.libraries.ContributedLibrary;
+import cc.arduino.contributions.libraries.UnavailableContributedLibrary;
+import processing.app.Base;
+import processing.app.Theme;
+
+public class MultiLibraryInstallDialog extends JDialog {
+
+  enum Result {
+    ALL, NONE, CANCEL
+  }
+
+  Result result = Result.CANCEL;
+
+  public MultiLibraryInstallDialog(Window parent, ContributedLibrary lib,
+                                   List<ContributedLibrary> dependencies) {
+    super(parent, format(tr("Dependencies for library {0}:{1}"), lib.getName(),
+                         lib.getParsedVersion()),
+        ModalityType.APPLICATION_MODAL);
+    Container pane = getContentPane();
+    pane.setLayout(new BorderLayout());
+
+    pane.add(Box.createHorizontalStrut(10), BorderLayout.WEST);
+    pane.add(Box.createHorizontalStrut(10), BorderLayout.EAST);
+
+    {
+      JButton cancel = new JButton(tr("Cancel"));
+      cancel.addActionListener(ev -> {
+        result = Result.CANCEL;
+        setVisible(false);
+      });
+
+      JButton all = new JButton(tr("Install all"));
+      all.addActionListener(ev -> {
+        result = Result.ALL;
+        setVisible(false);
+      });
+
+      JButton none = new JButton(format(tr("Install '{0}' only"), lib.getName()));
+      none.addActionListener(ev -> {
+        result = Result.NONE;
+        setVisible(false);
+      });
+
+      Box buttonsBox = Box.createHorizontalBox();
+      buttonsBox.add(all);
+      buttonsBox.add(Box.createHorizontalStrut(5));
+      buttonsBox.add(none);
+      buttonsBox.add(Box.createHorizontalStrut(5));
+      buttonsBox.add(cancel);
+
+      JPanel buttonsPanel = new JPanel();
+      buttonsPanel.setBorder(new EmptyBorder(7, 10, 7, 10));
+      buttonsPanel.setLayout(new BoxLayout(buttonsPanel, BoxLayout.Y_AXIS));
+      buttonsPanel.add(buttonsBox);
+
+      pane.add(buttonsPanel, BorderLayout.SOUTH);
+    }
+
+    {
+      String libName = format("<b>{0}:{1}</b>", lib.getName(),
+                              lib.getParsedVersion());
+      String desc = format(tr("The library {0} needs some other library<br />dependencies currently not installed:"),
+                           libName);
+      desc += "<br/><br/>";
+      for (ContributedLibrary l : dependencies) {
+        if (l.getName().equals(lib.getName()))
+          continue;
+        if (l.isInstalled())
+          continue;
+        if (l instanceof UnavailableContributedLibrary)
+          continue;
+        desc += format("- <b>{0}</b><br/>", l.getName());
+      }
+      desc += "<br/>";
+      desc += tr("Would you like to install also all the missing dependencies?");
+
+      JTextPane textArea = makeNewDescription();
+      textArea.setContentType("text/html");
+      textArea.setText(desc);
+
+      JPanel libsList = new JPanel();
+      libsList.setLayout(new BoxLayout(libsList, BoxLayout.Y_AXIS));
+      libsList.add(textArea);
+      libsList.setBorder(new EmptyBorder(7, 7, 7, 7));
+      pane.add(libsList, BorderLayout.NORTH);
+    }
+
+    pack();
+    setResizable(false);
+    setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+
+    WindowEvent closing = new WindowEvent(this, WindowEvent.WINDOW_CLOSING);
+    Base.registerWindowCloseKeys(getRootPane(), e -> dispatchEvent(closing));
+  }
+
+  // TODO Make this a method of Theme
+  private JTextPane makeNewDescription() {
+    JTextPane description = new JTextPane();
+    description.setInheritsPopupMenu(true);
+    Insets margin = description.getMargin();
+    margin.bottom = 0;
+    description.setMargin(margin);
+    description.setContentType("text/html");
+    Document doc = description.getDocument();
+    if (doc instanceof HTMLDocument) {
+      HTMLDocument html = (HTMLDocument) doc;
+      StyleSheet s = html.getStyleSheet();
+      s.addRule("body { margin: 0; padding: 0;"
+                + "font-family: Verdana, Geneva, Arial, Helvetica, sans-serif;"
+                + "color: black;" + "font-size: " + 15 * Theme.getScale() / 100
+                + "; }");
+    }
+    description.setOpaque(false);
+    description.setBorder(new EmptyBorder(4, 7, 7, 7));
+    description.setHighlighter(null);
+    description.setEditable(false);
+    add(description, 0);
+    return description;
+  }
+
+  public Result getInstallDepsResult() {
+    return result;
+  }
+}

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -352,7 +352,7 @@ public class Base {
         if (selected.isReadOnly()) {
           libraryInstaller.remove(installed, progressListener);
         } else {
-          libraryInstaller.install(selected, installed, progressListener);
+          libraryInstaller.install(selected, progressListener);
         }
       }
 

--- a/arduino-core/src/cc/arduino/contributions/VersionHelper.java
+++ b/arduino-core/src/cc/arduino/contributions/VersionHelper.java
@@ -64,4 +64,7 @@ public class VersionHelper {
     }
   }
 
+  public static int compare(String a, String b) {
+    return valueOf(a).compareTo(valueOf(b));
+  }
 }

--- a/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibrary.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibrary.java
@@ -61,7 +61,7 @@ public abstract class ContributedLibrary extends DownloadableContribution {
 
   public abstract List<String> getTypes();
 
-  public abstract List<ContributedLibraryReference> getRequires();
+  public abstract List<ContributedLibraryDependency> getRequires();
 
   public static final Comparator<ContributedLibrary> CASE_INSENSITIVE_ORDER = (o1, o2) -> o1.getName().compareToIgnoreCase(o2.getName());
 
@@ -117,7 +117,7 @@ public abstract class ContributedLibrary extends DownloadableContribution {
     res += "\n";
     res += "            requires :\n";
     if (getRequires() != null)
-      for (ContributedLibraryReference r : getRequires()) {
+      for (ContributedLibraryDependency r : getRequires()) {
         res += "                       " + r;
       }
     res += "\n";

--- a/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibrary.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibrary.java
@@ -29,13 +29,14 @@
 
 package cc.arduino.contributions.libraries;
 
-import cc.arduino.contributions.DownloadableContribution;
-import processing.app.I18n;
+import static processing.app.I18n.tr;
 
 import java.util.Comparator;
 import java.util.List;
 
-import static processing.app.I18n.tr;
+import cc.arduino.contributions.DownloadableContribution;
+import cc.arduino.contributions.VersionHelper;
+import processing.app.I18n;
 
 public abstract class ContributedLibrary extends DownloadableContribution {
 
@@ -150,6 +151,10 @@ public abstract class ContributedLibrary extends DownloadableContribution {
     boolean nameEquals = thisName != null && thisName.equals(otherName);
 
     return versionEquals && nameEquals;
+  }
+
+  public boolean isBefore(ContributedLibrary other) {
+    return VersionHelper.compare(getVersion(), other.getVersion()) < 0;
   }
 
   @Override

--- a/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibrary.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibrary.java
@@ -137,7 +137,7 @@ public abstract class ContributedLibrary extends DownloadableContribution {
     String thisVersion = getParsedVersion();
     String otherVersion = other.getParsedVersion();
 
-    boolean versionEquals = (thisVersion != null && otherVersion != null
+    boolean versionEquals = (thisVersion != null
                              && thisVersion.equals(otherVersion));
 
     // Important: for legacy libs, versions are null. Two legacy libs must
@@ -147,9 +147,14 @@ public abstract class ContributedLibrary extends DownloadableContribution {
 
     String thisName = getName();
     String otherName = other.getName();
-
-    boolean nameEquals = thisName == null || otherName == null || thisName.equals(otherName);
+    boolean nameEquals = thisName != null && thisName.equals(otherName);
 
     return versionEquals && nameEquals;
+  }
+
+  @Override
+  public int hashCode() {
+    String hashingData = "CONTRIBUTEDLIB" + getName() + getVersion();
+    return hashingData.hashCode();
   }
 }

--- a/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibraryDependency.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibraryDependency.java
@@ -29,16 +29,14 @@
 
 package cc.arduino.contributions.libraries;
 
-public abstract class ContributedLibraryReference {
+public abstract class ContributedLibraryDependency {
 
   public abstract String getName();
 
-  public abstract String getMaintainer();
-
-  public abstract String getVersion();
+  public abstract String getVersionRequired();
 
   @Override
   public String toString() {
-    return getName() + " " + getVersion() + " (" + getMaintainer() + ")";
+    return getName() + " " + getVersionRequired();
   }
 }

--- a/arduino-core/src/cc/arduino/contributions/libraries/LibrariesIndex.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/LibrariesIndex.java
@@ -29,12 +29,17 @@
 
 package cc.arduino.contributions.libraries;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import cc.arduino.contributions.DownloadableContributionBuiltInAtTheBottomComparator;
 import cc.arduino.contributions.filters.InstalledPredicate;
 import cc.arduino.contributions.libraries.filters.LibraryWithNamePredicate;
-
-import java.util.*;
-import java.util.stream.Collectors;
 
 public abstract class LibrariesIndex {
 
@@ -100,5 +105,75 @@ public abstract class LibrariesIndex {
     }
 
     return installedReleases.get(0);
+  }
+
+  public List<ContributedLibrary> resolveDependeciesOf(ContributedLibrary library) {
+    List<ContributedLibrary> solution = new ArrayList<>();
+    solution.add(library);
+    if (resolveDependeciesOf(solution, library)) {
+      return solution;
+    } else {
+      return null;
+    }
+  }
+
+  public boolean resolveDependeciesOf(List<ContributedLibrary> solution,
+                                      ContributedLibrary library) {
+    List<ContributedLibraryDependency> requirements = library.getRequires();
+    if (requirements == null) {
+      // No deps for this library, great!
+      return true;
+    }
+
+    for (ContributedLibraryDependency dep : requirements) {
+
+      // If the current solution already contains this dependency, skip over
+      boolean alreadyInSolution = false;
+      for (ContributedLibrary c : solution) {
+        if (c.getName().equals(dep.getName()))
+          alreadyInSolution = true;
+      }
+      if (alreadyInSolution)
+        continue;
+
+      // Generate possible matching dependencies
+      List<ContributedLibrary> possibleDeps = findMatchingDependencies(dep);
+
+      // If there are no dependencies available add as "missing" lib
+      if (possibleDeps.isEmpty()) {
+        solution.add(new UnavailableContributedLibrary(dep));
+        continue;
+      }
+
+      // Pick the latest version among possible deps
+      ContributedLibrary last = possibleDeps.stream()
+          .reduce((a, b) -> b.isBefore(a) ? a : b).get();
+
+      // Add dependecy to the solution and process recursively
+      solution.add(last);
+      if (!resolveDependeciesOf(solution, last)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private List<ContributedLibrary> findMatchingDependencies(ContributedLibraryDependency dep) {
+    List<ContributedLibrary> available = find(dep.getName());
+    if (dep.getVersionRequired() == null || dep.getVersionRequired().isEmpty())
+      return available;
+
+    // XXX: The following part is actually never reached. The use of version
+    // constraints requires a much complex backtracking algorithm, the following
+    // is just a draft placeholder.
+
+//    List<ContributedLibrary> match = available.stream()
+//        // TODO: add more complex version comparators (> >= < <= ~ 1.0.* 1.*...)
+//        .filter(candidate -> candidate.getParsedVersion()
+//            .equals(dep.getVersionRequired()))
+//        .collect(Collectors.toList());
+//    return match;
+
+    return available;
   }
 }

--- a/arduino-core/src/cc/arduino/contributions/libraries/LibrariesIndex.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/LibrariesIndex.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import cc.arduino.contributions.DownloadableContributionBuiltInAtTheBottomComparator;
@@ -145,13 +146,20 @@ public abstract class LibrariesIndex {
         continue;
       }
 
-      // Pick the latest version among possible deps
-      ContributedLibrary last = possibleDeps.stream()
-          .reduce((a, b) -> b.isBefore(a) ? a : b).get();
+      // Pick the installed version if available
+      ContributedLibrary selected;
+      Optional<ContributedLibrary> installed = possibleDeps.stream()
+          .filter(l -> l.isInstalled()).findAny();
+      if (installed.isPresent()) {
+        selected = installed.get();
+      } else {
+        // otherwise pick the latest version
+        selected = possibleDeps.stream().reduce((a, b) -> b.isBefore(a) ? a : b).get();
+      }
 
-      // Add dependecy to the solution and process recursively
-      solution.add(last);
-      if (!resolveDependeciesOf(solution, last)) {
+      // Add dependency to the solution and process recursively
+      solution.add(selected);
+      if (!resolveDependeciesOf(solution, selected)) {
         return false;
       }
     }

--- a/arduino-core/src/cc/arduino/contributions/libraries/LibrariesIndexer.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/LibrariesIndexer.java
@@ -68,7 +68,7 @@ public class LibrariesIndexer {
   private final List<String> badLibNotified = new ArrayList<>();
 
   public LibrariesIndexer(File preferencesFolder) {
-    indexFile = new File(preferencesFolder, "library_index.json");
+    indexFile = new File(preferencesFolder, "library_index_test.json");
     stagingFolder = new File(new File(preferencesFolder, "staging"), "libraries");
   }
 
@@ -99,6 +99,11 @@ public class LibrariesIndexer {
     } finally {
       IOUtils.closeQuietly(indexIn);
     }
+
+//    ContributedLibrary lib = index.find("ArduinoCloud","1.0.0");
+//    System.out.println(lib.info());
+//    System.out.println(index.resolveDependeciesOf(lib));
+//    System.exit(0);
   }
 
   public void setLibrariesFolders(List<File> _librariesFolders) {

--- a/arduino-core/src/cc/arduino/contributions/libraries/LibraryInstaller.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/LibraryInstaller.java
@@ -83,14 +83,22 @@ public class LibraryInstaller {
   }
 
   public synchronized void install(ContributedLibrary lib, ContributedLibrary replacedLib, ProgressListener progressListener) throws Exception {
+    final MultiStepProgress progress = new MultiStepProgress(4);
+
+    // Do install library (3 steps)
+    performInstall(lib, replacedLib, progressListener, progress);
+
+    // Rescan index (1 step)
+    rescanLibraryIndex(progress, progressListener);
+  }
+
+  private void performInstall(ContributedLibrary lib, ContributedLibrary replacedLib, ProgressListener progressListener, MultiStepProgress progress) throws Exception {
     if (lib.isInstalled()) {
       System.out.println(I18n.format(tr("Library is already installed: {0} version {1}"), lib.getName(), lib.getParsedVersion()));
       return;
     }
 
     DownloadableContributionsDownloader downloader = new DownloadableContributionsDownloader(BaseNoGui.librariesIndexer.getStagingFolder());
-
-    final MultiStepProgress progress = new MultiStepProgress(3);
 
     // Step 1: Download library
     try {
@@ -99,6 +107,7 @@ public class LibraryInstaller {
       // Download interrupted... just exit
       return;
     }
+    progress.stepDone();
 
     // TODO: Extract to temporary folders and move to the final destination only
     // once everything is successfully unpacked. If the operation fails remove
@@ -123,9 +132,6 @@ public class LibraryInstaller {
     File destFolder = new File(libsFolder, lib.getName().replaceAll(" ", "_"));
     tmpFolder.renameTo(destFolder);
     progress.stepDone();
-
-    // Step 4: Rescan index
-    rescanLibraryIndex(progress, progressListener);
   }
 
   public synchronized void remove(ContributedLibrary lib, ProgressListener progressListener) throws IOException {

--- a/arduino-core/src/cc/arduino/contributions/libraries/LibraryInstaller.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/LibraryInstaller.java
@@ -43,6 +43,8 @@ import processing.app.helpers.FileUtils;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 import static processing.app.I18n.tr;
 
@@ -82,11 +84,19 @@ public class LibraryInstaller {
     rescanLibraryIndex(progress, progressListener);
   }
 
-  public synchronized void install(ContributedLibrary lib, ProgressListener progressListener) throws Exception {
-    final MultiStepProgress progress = new MultiStepProgress(4);
+  public void install(ContributedLibrary lib, ProgressListener progressListener) throws Exception {
+    ArrayList<ContributedLibrary> libs = new ArrayList<>();
+    libs.add(lib);
+    install(libs, progressListener);
+  }
 
-    // Do install library (3 steps)
-    performInstall(lib, progressListener, progress);
+  public synchronized void install(List<ContributedLibrary> libs, ProgressListener progressListener) throws Exception {
+    MultiStepProgress progress = new MultiStepProgress(3 * libs.size() + 1);
+
+    for (ContributedLibrary lib : libs) {
+      // Do install library (3 steps)
+      performInstall(lib, progressListener, progress);
+    }
 
     // Rescan index (1 step)
     rescanLibraryIndex(progress, progressListener);

--- a/arduino-core/src/cc/arduino/contributions/libraries/LibraryInstaller.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/LibraryInstaller.java
@@ -57,6 +57,7 @@ public class LibraryInstaller {
   }
 
   public synchronized void updateIndex(ProgressListener progressListener) throws Exception {
+    if (true) return;
     final MultiStepProgress progress = new MultiStepProgress(2);
 
     DownloadableContributionsDownloader downloader = new DownloadableContributionsDownloader(BaseNoGui.librariesIndexer.getStagingFolder());

--- a/arduino-core/src/cc/arduino/contributions/libraries/UnavailableContributedLibrary.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/UnavailableContributedLibrary.java
@@ -1,0 +1,137 @@
+/*
+ * This file is part of Arduino.
+ *
+ * Copyright 2017 Arduino LLC (http://www.arduino.cc/)
+ *
+ * Arduino is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As a special exception, you may use this file as part of a free software
+ * library without restriction.  Specifically, if other files instantiate
+ * templates or use macros or inline functions from this file, or you compile
+ * this file and link it with other files to produce an executable, this
+ * file does not by itself cause the resulting executable to be covered by
+ * the GNU General Public License.  This exception does not however
+ * invalidate any other reasons why the executable file might be covered by
+ * the GNU General Public License.
+ */
+
+package cc.arduino.contributions.libraries;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class UnavailableContributedLibrary extends ContributedLibrary {
+
+  private String name;
+  private String version;
+
+  public UnavailableContributedLibrary(ContributedLibraryDependency dependency) {
+    this(dependency.getName(), dependency.getVersionRequired());
+  }
+
+  public UnavailableContributedLibrary(String _name, String _version) {
+    name = _name;
+    version = _version;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getMaintainer() {
+    return "Unknown";
+  }
+
+  @Override
+  public String getAuthor() {
+    return "Unknown";
+  }
+
+  @Override
+  public String getWebsite() {
+    return "Unknown";
+  }
+
+  @Override
+  public String getCategory() {
+    return "Uncategorized";
+  }
+
+  @Override
+  public void setCategory(String category) {
+  }
+
+  @Override
+  public String getLicense() {
+    return "Unknown";
+  }
+
+  @Override
+  public String getParagraph() {
+    return "";
+  }
+
+  @Override
+  public String getSentence() {
+    return "";
+  }
+
+  @Override
+  public List<String> getArchitectures() {
+    return new ArrayList<>();
+  }
+
+  @Override
+  public List<String> getTypes() {
+    return new ArrayList<>();
+  }
+
+  @Override
+  public List<ContributedLibraryDependency> getRequires() {
+    return new ArrayList<>();
+  }
+
+  @Override
+  public String getUrl() {
+    return "";
+  }
+
+  @Override
+  public String getVersion() {
+    return version;
+  }
+
+  @Override
+  public String getChecksum() {
+    return "";
+  }
+
+  @Override
+  public long getSize() {
+    return 0;
+  }
+
+  @Override
+  public String getArchiveFileName() {
+    return "";
+  }
+
+  @Override
+  public String toString() {
+    return "!" + super.toString();
+  }
+}

--- a/arduino-core/src/processing/app/BaseNoGui.java
+++ b/arduino-core/src/processing/app/BaseNoGui.java
@@ -487,6 +487,7 @@ public class BaseNoGui {
     try {
       librariesIndexer.parseIndex();
     } catch (JsonProcessingException e) {
+      e.printStackTrace();
       File librariesIndexFile = librariesIndexer.getIndexFile();
       FileUtils.deleteIfExists(librariesIndexFile);
     }

--- a/arduino-core/src/processing/app/packages/LibraryList.java
+++ b/arduino-core/src/processing/app/packages/LibraryList.java
@@ -30,8 +30,15 @@ package processing.app.packages;
 
 import java.io.File;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
 
 import processing.app.helpers.FileUtils;
 
@@ -97,5 +104,36 @@ public class LibraryList extends LinkedList<UserLibrary> {
       if (l == lib) return true;
     return false;
   }
-}
 
+  public static Collector<UserLibrary, LibraryList, LibraryList> collector() {
+    return new Collector<UserLibrary, LibraryList, LibraryList>() {
+      @Override
+      public Supplier<LibraryList> supplier() {
+        return () -> new LibraryList();
+      }
+
+      @Override
+      public BiConsumer<LibraryList, UserLibrary> accumulator() {
+        return (libs, lib) -> libs.add(lib);
+      }
+
+      @Override
+      public BinaryOperator<LibraryList> combiner() {
+        return (we, they) -> {
+          we.addAll(they);
+          return we;
+        };
+      }
+
+      @Override
+      public Function<LibraryList, LibraryList> finisher() {
+        return (libs) -> libs;
+      }
+
+      @Override
+      public Set<Collector.Characteristics> characteristics() {
+        return EnumSet.noneOf(Characteristics.class);
+      }
+    };
+  }
+}

--- a/arduino-core/src/processing/app/packages/UserLibrary.java
+++ b/arduino-core/src/processing/app/packages/UserLibrary.java
@@ -30,7 +30,7 @@ package processing.app.packages;
 
 import cc.arduino.Constants;
 import cc.arduino.contributions.libraries.ContributedLibrary;
-import cc.arduino.contributions.libraries.ContributedLibraryReference;
+import cc.arduino.contributions.libraries.ContributedLibraryDependency;
 import processing.app.helpers.PreferencesMap;
 
 import java.io.File;
@@ -244,7 +244,7 @@ public class UserLibrary extends ContributedLibrary {
   }
 
   @Override
-  public List<ContributedLibraryReference> getRequires() {
+  public List<ContributedLibraryDependency> getRequires() {
     return null;
   }
 


### PR DESCRIPTION
This is an attempt to solve #5795.

The dependency tree is read from the `library_index.json`, downloaded from `arduino.cc`, this json is build from the information contained in the `library.properties` of each library so, to complete this PR, we should add a field in the `library.properties` to explicitly specificy dependencies.
In this PR the dependent libraries are handled without versions constraints, this will be added in a future development.

The latest commit has been added for testing purposes and it will be removed before merging this PR: it disables the automatic download of `library_index.json` and reads the index from `library_index_test.json`, this way we can test this PR by providing a fake `library_index_test.json`.

This is the index that I used for testing: [library_index_test.zip](https://github.com/arduino/Arduino/files/787794/library_index_test.zip) that contains a modified fake entry:

```json
    {
      "name": "ArduinoCloud",
      "version": "1.0.0",
      "author": "Arduino",
      "maintainer": "Arduino \u003cinfo@arduino.cc\u003e",
      "sentence": "Easly connect your Arduino/Genuino board to the Arduino Cloud",
      "paragraph": "Easly connect your Arduino/Genuino board to the Arduino Cloud",
      "website": "https://github.com/arduino-libraries/ArduinoCloud",
      "category": "Communication",
      "architectures": [
        "*"
      ],
      "types": [
        "Arduino"
      ],
      "requires": [
        { "name": "WiFi101" },
        { "name": "ArduinoSound" }
      ],
      "url": "http://downloads.arduino.cc/libraries/github.com/arduino-libraries/ArduinoCloud-1.0.0.zip",
      "archiveFileName": "ArduinoCloud-1.0.0.zip",
      "size": 45097,
      "checksum": "SHA-256:679a73db1aa4825652882ff71d7a3fb4992f4f79b41cb4a0a6c5c912adbfa848"
    },
```

and this is the dialog that appears when we try to install "ArduinoCloud":

![image](https://cloud.githubusercontent.com/assets/423515/23130260/0b6e016a-f786-11e6-96f4-f07bb1e87117.png)

(of course ArduinoCloud doesn't need ArduinoSound, this is **just for testing multiple dependencies**)

This PR also lead me to think about a possible simplification of the `ContributedLibrary` object model, but this is something for another PR to build on top of this one.