### PR TITLE
Fix "save as" operation for the data folder of a sketch

### DIFF
--- a/arduino-core/src/processing/app/Sketch.java
+++ b/arduino-core/src/processing/app/Sketch.java
@@ -351,13 +351,22 @@ public class Sketch {
         file.saveAs(new File(newFolder, file.getFileName()));
     }
 
-    folder = newFolder;
 
     // Copy the data folder (this may take a while.. add progress bar?)
     if (getDataFolder().exists()) {
       File newDataFolder = new File(newFolder, "data");
+      // Check if data folder exits, if not try to create the data folder
+      if (!newDataFolder.exists() && !newDataFolder.mkdirs()) {
+        String msg = I18n.format(tr("Could not create directory \"{0}\""), newFolder.getAbsolutePath());
+        throw new IOException(msg);
+      }
+      // Copy the data files into the new folder
       FileUtils.copy(getDataFolder(), newDataFolder);
     }
+    
+    // Change folder to the new folder
+    folder = newFolder;
+    
   }
 
   /**


### PR DESCRIPTION
This pull fixes #5998.

When performing a save as operation the data folder of the sketch was not copied to the new location.

What has changed:
- switching to the new folder is now the last operation in the save as method.
  - this caused not finding a data folder, since the folder was already changed to the new location
- If the data folder does not exists yet, it is created before the files are copied to the new location

I have tested this on my Windows machine and it solves the issue.