### PR TITLE
Update Mega2560 maximum sketch size

### DIFF
--- a/hardware/arduino/avr/boards.txt
+++ b/hardware/arduino/avr/boards.txt
@@ -204,7 +204,7 @@ mega.build.board=AVR_MEGA2560
 mega.menu.cpu.atmega2560=ATmega2560 (Mega 2560)
 
 mega.menu.cpu.atmega2560.upload.protocol=wiring
-mega.menu.cpu.atmega2560.upload.maximum_size=253952
+mega.menu.cpu.atmega2560.upload.maximum_size=245762
 mega.menu.cpu.atmega2560.upload.speed=115200
 
 mega.menu.cpu.atmega2560.bootloader.high_fuses=0xD8
@@ -244,7 +244,7 @@ megaADK.pid.3=0x0044
 
 megaADK.upload.tool=avrdude
 megaADK.upload.protocol=wiring
-megaADK.upload.maximum_size=253952
+megaADK.upload.maximum_size=245762
 megaADK.upload.maximum_data_size=8192
 megaADK.upload.speed=115200
 


### PR DESCRIPTION
Changed atmega2560 boards maximum program size.
I've tested this size with the stk500boot_v2_mega2560.hex bootloader on a Mega Adk with this sketch https://github.com/bigjohnson/Test-Arduino-Boards-max-prog-mem 