### PR TITLE
adding arduino-linux-setup.sh script

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -629,6 +629,7 @@
 
     <copy todir="linux/work" file="linux/dist/arduino" />
     <copy todir="linux/work" file="linux/dist/install.sh" />
+    <copy todir="linux/work" file="linux/dist/arduino-linux-setup.sh" />
     <copy todir="linux/work" file="linux/dist/uninstall.sh" />
 
     <chmod perm="ugo+x">

--- a/build/linux/dist/arduino-linux-setup.sh
+++ b/build/linux/dist/arduino-linux-setup.sh
@@ -1,0 +1,194 @@
+# arduino-linux-setup.sh : A simple Arduino setup script for Linux systems
+# Copyright (C) 2015 Arduino Srl
+#
+# Author : Arturo Rinaldi
+# E-mail : arturo@arduino.org
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+# Release v6 changelog :
+#
+#	+ removing sudocheck function and control
+#
+# Release v5 changelog :
+#
+#	+ adding UDEV rule for stm32 DFU mode
+#
+# Release v4 changelog :
+#
+#	+ The rules are generated in a temporary folder
+#
+#	+ the user should run it without sudo while having its permissions
+#
+# Release v3 changelog :
+#
+#	+ The most common linux distros are now fully supported
+#
+#	+ now the script checks for SUDO permissions
+#
+
+#! /bin/bash
+
+# if [[ $EUID != 0 ]] ; then
+#   echo This must be run as root!
+#   exit 1
+# fi
+
+refreshudev () {
+
+	echo ""
+    echo "Restarting udev"
+	echo ""
+
+    sudo service udev restart
+    sudo udevadm control --reload-rules
+    sudo udevadm trigger
+
+}
+
+groupsfunc () {
+
+    echo ""
+    echo "******* Add User to dialout,tty, uucp, plugdev groups *******"
+    echo ""
+
+    sudo usermod -a -G tty $1
+    sudo usermod -a -G dialout $1
+    sudo usermod -a -G uucp $1
+    sudo groupadd plugdev
+    sudo usermod -a -G plugdev $1
+
+}
+
+acmrules () {
+
+    echo ""
+    echo "Setting serial port rules"
+    echo ""
+
+cat <<EOF
+"KERNEL="ttyUSB[0-9]*", TAG+="udev-acl", TAG+="uaccess", OWNER="$1"
+"KERNEL="ttyACM[0-9]*", TAG+="udev-acl", TAG+="uaccess", OWNER="$1"
+EOF
+
+}
+
+openocdrules () {
+
+    echo ""
+	echo "Adding Arduino M0/M0 Pro Rules"
+    echo ""
+
+cat <<EOF
+ACTION!="add|change", GOTO="openocd_rules_end"
+SUBSYSTEM!="usb|tty|hidraw", GOTO="openocd_rules_end"
+
+#Please keep this list sorted by VID:PID
+
+#CMSIS-DAP compatible adapters
+ATTRS{product}=="*CMSIS-DAP*", MODE="664", GROUP="plugdev"
+
+LABEL="openocd_rules_end"
+EOF
+
+}
+
+avrisprules () {
+
+cat <<EOF
+SUBSYSTEM!="usb_device", ACTION!="add", GOTO="avrisp_end"
+# Atmel Corp. JTAG ICE mkII
+ATTR{idVendor}=="03eb", ATTRS{idProduct}=="2103", MODE="660", GROUP="dialout"
+# Atmel Corp. AVRISP mkII
+ATTR{idVendor}=="03eb", ATTRS{idProduct}=="2104", MODE="660", GROUP="dialout"
+# Atmel Corp. Dragon
+ATTR{idVendor}=="03eb", ATTRS{idProduct}=="2107", MODE="660", GROUP="dialout"
+
+LABEL="avrisp_end"
+EOF
+
+}
+
+dfustm32rules () {
+
+cat <<EOF
+# Example udev rules (usually placed in /etc/udev/rules.d)
+# Makes STM32 DfuSe device writeable for the "plugdev" group
+
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE="664", GROUP="plugdev", TAG+="uaccess"
+EOF
+
+}
+
+removemm () {
+
+    echo ""
+    echo "******* Removing modem manager *******"
+    echo ""
+
+    if [ -f /etc/lsb-release -a ! -f /etc/SuSE-release ] || [ -f /etc/debian_version ] || [ -f /etc/linuxmint/info ]
+    then
+        #Only for Ubuntu/Mint/Debian
+        sudo apt-get remove modemmanager
+    elif [ -f /etc/SuSE-release ]
+    then
+        #Only for Suse
+        sudo zypper remove modemmanager
+    elif [ -f /etc/fedora-release ] || [ -f /etc/redhat-release ]
+    then
+        #Only for Red Hat/Fedora/CentOS
+        sudo yum remove modemmanager
+	else
+		echo ""
+		echo "Your system is not supported, please take care of it with your package manager"
+		echo ""
+    fi
+
+}
+
+
+if [ "$1" = "" ]
+then
+    echo ""
+    echo "Run the script with command ./arduino-linux-setup.sh \$USER"
+    echo ""
+else
+
+    [ `whoami` != $1 ] && echo "" && echo "The user name is not the right one, please double-check it !" && echo "" && exit 1
+
+    groupsfunc $1
+
+    removemm
+
+    mkdir -p $PWD/rulesgen
+
+    acmrules $1 > $PWD/rulesgen/90-extraacl.rules
+
+    openocdrules > $PWD/rulesgen/98-openocd.rules
+
+    avrisprules > $PWD/rulesgen/avrisp.rules
+
+    dfustm32rules > $PWD/rulesgen/40-dfuse.rules
+
+    sudo mv $PWD/rulesgen/*.rules /etc/udev/rules.d/
+
+    rm -rf $PWD/rulesgen
+
+    refreshudev
+
+    echo ""
+    echo "*********** Please Reboot your system ************"
+    echo ""
+fi


### PR DESCRIPTION
The shell script helps the linux user to quickly configure the OS environment to work with the Arduino IDE. It mainly performs these tasks :

* writes **UDEV** rules for accessing the serial ports
* uninstalls **modemmanager** from the system if installed (preventing the use of the serial ports)
* add the user to the **tty** and **dialout** groups