### PR TITLE
Fix path to preferences.txt on Windows

### DIFF
--- a/build/shared/manpage.adoc
+++ b/build/shared/manpage.adoc
@@ -212,7 +212,8 @@ EXIT STATUS
 
 FILES
 -----
-*~/.arduino15/preferences.txt*::
+*~/AppData/Local/Arduino15/preferences.txt (Windows)::
+*~/.arduino15/preferences.txt* (Mac OS X and Linux)::
 	This file stores the preferences used for the IDE, building and
 	uploading sketches.
 


### PR DESCRIPTION
The documentation was wrong for Windows, for locating the preferences file. This update matches modern Windows (7..10), but is probably not right for XP.