### PR TITLE
Correct path to preferences file for Windows

### DIFF
--- a/build/shared/manpage.adoc
+++ b/build/shared/manpage.adoc
@@ -212,7 +212,9 @@ EXIT STATUS
 
 FILES
 -----
-*~/.arduino15/preferences.txt*::
+
+*~/AppData/Local/Arduino15/preferences.txt* (Windows)::
+*~/.arduino15/preferences.txt* (Mac OS X and Linux)::
 	This file stores the preferences used for the IDE, building and
 	uploading sketches.
 


### PR DESCRIPTION
The path to `preferences.txt` was incorrect for Windows. I did not update the HISTORY for this change, as this is just correcting a typo. 

The path as given is right for Windows 7 and later; I think it is right for Vista, wrong for XP, but do not have systems for testing.