### PR TITLE
Add infinite loop after wdt_enable call

### DIFF
--- a/hardware/arduino/avr/cores/arduino/CDC.cpp
+++ b/hardware/arduino/avr/cores/arduino/CDC.cpp
@@ -128,6 +128,8 @@ bool CDC_Setup(USBSetup& setup)
 				// Store boot key
 				*(uint16_t *)magic_key_pos = MAGIC_KEY;
 				wdt_enable(WDTO_120MS);
+				// Go into infinite loop to avoid any watchdog resets or disable calls
+				while(1);
 			}
 			else
 			{


### PR DESCRIPTION
Currently when using Leonardo and derivatives reseting the watchdog in the main sketch code will interfere with the bootloader reset.  This solution was proposed [by pjanco in the arduino.cc forums](http://forum.arduino.cc/index.php?topic=401628.msg2782592#msg2782592).