### PR TITLE
During compilation, scroll the console to the first error

### DIFF
--- a/app/src/cc/arduino/ConsoleOutputStream.java
+++ b/app/src/cc/arduino/ConsoleOutputStream.java
@@ -95,7 +95,7 @@ public class ConsoleOutputStream extends ByteArrayOutputStream {
     if (editorConsole != null) {
       SwingUtilities.invokeLater(() -> {
         try {
-          editorConsole.insertString(text, attributes);
+          editorConsole.insertString(this, text, attributes);
         } catch (BadLocationException ble) {
           //ignore
         }

--- a/app/src/processing/app/EditorConsole.java
+++ b/app/src/processing/app/EditorConsole.java
@@ -57,6 +57,7 @@ public class EditorConsole extends JScrollPane {
 
   private final DefaultStyledDocument document;
   private final JTextPane consoleTextPane;
+  private int firstErrorOffset = -1;
 
   public EditorConsole() {
     document = new DefaultStyledDocument();
@@ -117,21 +118,42 @@ public class EditorConsole extends JScrollPane {
       // ignore the error otherwise this will cause an infinite loop
       // maybe not a good idea in the long run?
     }
+    firstErrorOffset = -1;
   }
 
   public void scrollDown() {
-    getHorizontalScrollBar().setValue(0);
-    getVerticalScrollBar().setValue(getVerticalScrollBar().getMaximum());
+    if (firstErrorOffset >= 0) {
+      try {
+        // Scroll to the first error, making sure that the line above the error
+        // is the first one shown.
+        int offset = Utilities.getPositionAbove(consoleTextPane,
+                                                firstErrorOffset, 0);
+        if (offset < 0)
+          offset = firstErrorOffset;
+        Rectangle rect = consoleTextPane.modelToView(offset);
+        this.getViewport().setViewPosition(new Point(0, rect.y));
+      } catch (BadLocationException e) {
+        // Ignore
+      }
+    } else {
+      getHorizontalScrollBar().setValue(0);
+      getVerticalScrollBar().setValue(getVerticalScrollBar().getMaximum());
+    }
   }
 
   public boolean isEmpty() {
     return document.getLength() == 0;
   }
 
-  public void insertString(String line, SimpleAttributeSet attributes) throws BadLocationException {
+  public void insertString(ConsoleOutputStream from, String line,
+                           SimpleAttributeSet attributes)
+                               throws BadLocationException {
     line = line.replace("\r\n", "\n").replace("\r", "\n");
     int offset = document.getLength();
     document.insertString(offset, line, attributes);
+    if (from == err && firstErrorOffset < 0) {
+      firstErrorOffset = offset;
+    }
   }
 
   public String getText() {


### PR DESCRIPTION
While adding messages to the console, this keeps track of the position
of the first bit of stderr output. Then, whenever
`EditorConsole.scrollDown()` is called, the scroll position is changed
so that the line above the first error line is the first one in the
console. If no errors are printed yet, the console scrolls down as
before.

To know what messages are coming from stderr, the ConsoleOutputStream
that generated the message is passed to `EditorConsole.insertString()`,
though this might not be the best solution for this.


This PR is still a bit of proof-of-concept, especially the extra argument to `insertString()` doesn't sound like the perfect solution yet. Perhaps the console code should be refactored to be a bit simpler in the first place. But I needed this myself (it will be saving me a lot of time in my current work), so might as well put it up for discussion :-)