### PR TITLE
Disable serial monitor for non-SSH network ports

### DIFF
--- a/app/src/cc/arduino/packages/MonitorFactory.java
+++ b/app/src/cc/arduino/packages/MonitorFactory.java
@@ -37,7 +37,13 @@ public class MonitorFactory {
 
   public AbstractMonitor newMonitor(BoardPort port) {
     if ("network".equals(port.getProtocol())) {
-      return new NetworkMonitor(port);
+      if ("yes".equals(port.getPrefs().get("ssh_upload"))) {
+        // the board is SSH capable
+        return new NetworkMonitor(port); 
+      } else {
+        // SSH not supported, no monitor support
+        return null;
+      }
     }
 
     return new SerialMonitor(port);

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -2318,6 +2318,14 @@ public class Editor extends JFrame implements RunnerListener {
     }
 
     serialMonitor = new MonitorFactory().newMonitor(port);
+    
+    if (serialMonitor == null) {
+      String board = port.getPrefs().get("board");
+      String boardName = BaseNoGui.getPlatform().resolveDeviceByBoardID(BaseNoGui.packages, board);
+      statusError(I18n.format(tr("Serial monitor is not supported on network ports such as {0} for the {1} in this release"), PreferencesData.get("serial.port"), boardName));
+      return;
+    }
+    
     Base.setIcon(serialMonitor);
 
     // If currently uploading, disable the monitor (it will be later


### PR DESCRIPTION
This avoids displaying the password prompt for network ports that don't support SSH.