### PR TITLE
LiquidCrystal - Corrected wiring instructions in header comment

### DIFF
--- a/libraries/LiquidCrystal/examples/Autoscroll/Autoscroll.ino
+++ b/libraries/LiquidCrystal/examples/Autoscroll/Autoscroll.ino
@@ -17,9 +17,9 @@
  * LCD D6 pin to digital pin 3
  * LCD D7 pin to digital pin 2
  * LCD R/W pin to ground
- * 10K resistor:
- * ends to +5V and ground
- * wiper to LCD VO pin (pin 3)
+ * 10K or 100K potentiometer:
+   * ends to +5V and ground
+   * wiper to LCD VO pin (pin 3)
 
  Library originally added 18 Apr 2008
  by David A. Mellis
@@ -71,4 +71,3 @@ void loop() {
   // clear screen for the next loop:
   lcd.clear();
 }
-

--- a/libraries/LiquidCrystal/examples/Blink/Blink.ino
+++ b/libraries/LiquidCrystal/examples/Blink/Blink.ino
@@ -17,7 +17,7 @@
  * LCD D6 pin to digital pin 3
  * LCD D7 pin to digital pin 2
  * LCD R/W pin to ground
- * 10K resistor:
+ * 10K or 100K potentiometer:
    * ends to +5V and ground
    * wiper to LCD VO pin (pin 3)
 
@@ -57,5 +57,3 @@ void loop() {
   lcd.blink();
   delay(3000);
 }
-
-

--- a/libraries/LiquidCrystal/examples/Cursor/Cursor.ino
+++ b/libraries/LiquidCrystal/examples/Cursor/Cursor.ino
@@ -18,9 +18,9 @@
  * LCD D6 pin to digital pin 3
  * LCD D7 pin to digital pin 2
  * LCD R/W pin to ground
- * 10K resistor:
- * ends to +5V and ground
- * wiper to LCD VO pin (pin 3)
+ * 10K or 100K potentiometer:
+   * ends to +5V and ground
+   * wiper to LCD VO pin (pin 3)
 
  Library originally added 18 Apr 2008
  by David A. Mellis
@@ -58,4 +58,3 @@ void loop() {
   lcd.cursor();
   delay(500);
 }
-

--- a/libraries/LiquidCrystal/examples/CustomCharacter/CustomCharacter.ino
+++ b/libraries/LiquidCrystal/examples/CustomCharacter/CustomCharacter.ino
@@ -17,10 +17,10 @@
  * LCD D6 pin to digital pin 3
  * LCD D7 pin to digital pin 2
  * LCD R/W pin to ground
- * 10K potentiometer:
- * ends to +5V and ground
- * wiper to LCD VO pin (pin 3)
- * 10K poterntiometer on pin A0
+ * 10K or 100K potentiometer:
+   * ends to +5V and ground
+   * wiper to LCD VO pin (pin 3)
+ * 10K potentiometer on pin A0
 
  created 21 Mar 2011
  by Tom Igoe

--- a/libraries/LiquidCrystal/examples/Display/Display.ino
+++ b/libraries/LiquidCrystal/examples/Display/Display.ino
@@ -18,9 +18,9 @@
  * LCD D6 pin to digital pin 3
  * LCD D7 pin to digital pin 2
  * LCD R/W pin to ground
- * 10K resistor:
- * ends to +5V and ground
- * wiper to LCD VO pin (pin 3)
+ * 10K or 100K potentiometer:
+   * ends to +5V and ground
+   * wiper to LCD VO pin (pin 3)
 
  Library originally added 18 Apr 2008
  by David A. Mellis
@@ -58,4 +58,3 @@ void loop() {
   lcd.display();
   delay(500);
 }
-

--- a/libraries/LiquidCrystal/examples/HelloWorld/HelloWorld.ino
+++ b/libraries/LiquidCrystal/examples/HelloWorld/HelloWorld.ino
@@ -19,9 +19,9 @@
  * LCD R/W pin to ground
  * LCD VSS pin to ground
  * LCD VCC pin to 5V
- * 10K resistor:
- * ends to +5V and ground
- * wiper to LCD VO pin (pin 3)
+ * 10K or 100K potentiometer:
+   * ends to +5V and ground
+   * wiper to LCD VO pin (pin 3)
 
  Library originally added 18 Apr 2008
  by David A. Mellis
@@ -57,4 +57,3 @@ void loop() {
   // print the number of seconds since reset:
   lcd.print(millis() / 1000);
 }
-

--- a/libraries/LiquidCrystal/examples/Scroll/Scroll.ino
+++ b/libraries/LiquidCrystal/examples/Scroll/Scroll.ino
@@ -18,9 +18,9 @@
  * LCD D6 pin to digital pin 3
  * LCD D7 pin to digital pin 2
  * LCD R/W pin to ground
- * 10K resistor:
- * ends to +5V and ground
- * wiper to LCD VO pin (pin 3)
+ * 10K or 100K potentiometer:
+   * ends to +5V and ground
+   * wiper to LCD VO pin (pin 3)
 
  Library originally added 18 Apr 2008
  by David A. Mellis
@@ -83,4 +83,3 @@ void loop() {
   delay(1000);
 
 }
-

--- a/libraries/LiquidCrystal/examples/SerialDisplay/SerialDisplay.ino
+++ b/libraries/LiquidCrystal/examples/SerialDisplay/SerialDisplay.ino
@@ -17,9 +17,9 @@
  * LCD D6 pin to digital pin 3
  * LCD D7 pin to digital pin 2
  * LCD R/W pin to ground
- * 10K resistor:
- * ends to +5V and ground
- * wiper to LCD VO pin (pin 3)
+ * 10K or 100K potentiometer:
+   * ends to +5V and ground
+   * wiper to LCD VO pin (pin 3)
 
  Library originally added 18 Apr 2008
  by David A. Mellis
@@ -29,7 +29,7 @@
  by Tom Igoe
  modified 22 Nov 2010
  by Tom Igoe
-
+ 
  This example code is in the public domain.
 
  http://www.arduino.cc/en/Tutorial/LiquidCrystalSerial

--- a/libraries/LiquidCrystal/examples/TextDirection/TextDirection.ino
+++ b/libraries/LiquidCrystal/examples/TextDirection/TextDirection.ino
@@ -17,9 +17,9 @@ The circuit:
 * LCD D6 pin to digital pin 3
 * LCD D7 pin to digital pin 2
 * LCD R/W pin to ground
-* 10K resistor:
-* ends to +5V and ground
-* wiper to LCD VO pin (pin 3)
+* 10K or 100K potentiometer:
+  * ends to +5V and ground
+  * wiper to LCD VO pin (pin 3)
 
 Library originally added 18 Apr 2008
 by David A. Mellis
@@ -76,11 +76,3 @@ void loop() {
   // increment the letter:
   thisChar++;
 }
-
-
-
-
-
-
-
-

--- a/libraries/LiquidCrystal/examples/setCursor/setCursor.ino
+++ b/libraries/LiquidCrystal/examples/setCursor/setCursor.ino
@@ -17,9 +17,9 @@
  * LCD D6 pin to digital pin 3
  * LCD D7 pin to digital pin 2
  * LCD R/W pin to ground
- * 10K resistor:
- * ends to +5V and ground
- * wiper to LCD VO pin (pin 3)
+ * 10K or 100K potentiometer:
+   * ends to +5V and ground
+   * wiper to LCD VO pin (pin 3)
 
  Library originally added 18 Apr 2008
  by David A. Mellis
@@ -68,5 +68,3 @@ void loop() {
     }
   }
 }
-
-


### PR DESCRIPTION
Instructions mention a resistor, when in fact it clearly needs a potentiometer.