### PR TITLE
Use usbasp-clone protocol for programmer "usbasp".

### DIFF
--- a/hardware/arduino/avr/programmers.txt
+++ b/hardware/arduino/avr/programmers.txt
@@ -29,8 +29,8 @@ arduinoisporg.program.extra_params=
 
 usbasp.name=USBasp
 usbasp.communication=usb
-usbasp.protocol=usbasp
-usbasp.program.protocol=usbasp
+usbasp.protocol=usbasp-clone
+usbasp.program.protocol=usbasp-clone
 usbasp.program.tool=avrdude
 usbasp.program.extra_params=-Pusb
 


### PR DESCRIPTION
Avrdude won't check for usb name and vendor of the programmer, so even non-original usbasp clones (but with correct usb IDs) can be used for uploading. "Real" usbasp programmers are not affected by this change.
All in all more programmers are supported and problems with usbasp-clones are prevented.