### PR TITLE
Update to USB v2.1

### DIFF
--- a/hardware/arduino/avr/cores/arduino/USBCore.h
+++ b/hardware/arduino/avr/cores/arduino/USBCore.h
@@ -127,7 +127,7 @@
 #define MSC_PROTOCOL_BULK_ONLY					0x50 
 
 #ifndef USB_VERSION
-#define USB_VERSION 0x200
+#define USB_VERSION 0x210
 #endif
 
 //	Device


### PR DESCRIPTION
In order to stay compatible with the upcoming WebUSB API, as specified at https://github.com/webusb/arduino/blob/gh-pages/README.md#getting-started