### PR TITLE
resolving issue 6132 (option to enable/disable auto-curly-brace, editor.autocomplete option)

### DIFF
--- a/app/src/processing/app/EditorTab.java
+++ b/app/src/processing/app/EditorTab.java
@@ -147,6 +147,8 @@ public class EditorTab extends JPanel implements SketchFile.TextStorage {
     textArea.setMarkOccurrences(PreferencesData.getBoolean("editor.advanced"));
     textArea.setMarginLineEnabled(false);
     textArea.setCodeFoldingEnabled(PreferencesData.getBoolean("editor.code_folding"));
+    textArea.setAutoIndentEnabled(PreferencesData.getBoolean("editor.indent"));
+    textArea.setCloseCurlyBraces(PreferencesData.getBoolean("editor.autocomplete"));
     textArea.setAntiAliasingEnabled(PreferencesData.getBoolean("editor.antialias"));
     textArea.setTabsEmulated(PreferencesData.getBoolean("editor.tabs.expand"));
     textArea.setTabSize(PreferencesData.getInteger("editor.tabs.size"));

--- a/build/shared/lib/preferences.txt
+++ b/build/shared/lib/preferences.txt
@@ -146,6 +146,10 @@ editor.tabs.size   = 2
 # automatically indent each line
 editor.indent = true
 
+# enable/disable any 'autocomplete' features
+# this currently includes 'auto curly brace'
+editor.autocomplete = true
+
 # size of divider between editing area and the console
 editor.divider.size = 0
 # the larger divider on windows is ugly with the little arrows


### PR DESCRIPTION
@facchinm
@matthijskooijman

this pull request resolves issue #6132 by adding a new element 'editor.autocomplete' with default value of 'true' to 'preferences.txt', implementing it in 'EditorTab.java'.  It also incorporates the change for #6129 in the merge.

Please review, including the naming of the 'edit.autocomplete' setting in preferences.txt, and incorporate (and document) this change in the next official revision.  Thank you.

(for some odd reason there is an edit on line 601/603 that wasn't intended, seems to get rid of some trailing white space on a curly brace, or similar, might have been inadvertently caused by pluma)
