### PR TITLE
Enabling "external editor" now requires to save all sketches.

### DIFF
--- a/app/src/cc/arduino/view/preferences/Preferences.java
+++ b/app/src/cc/arduino/view/preferences/Preferences.java
@@ -34,6 +34,7 @@ import cc.arduino.i18n.Language;
 import cc.arduino.i18n.Languages;
 import processing.app.Base;
 import processing.app.BaseNoGui;
+import processing.app.Editor;
 import processing.app.I18n;
 import processing.app.PreferencesData;
 import processing.app.Theme;
@@ -42,6 +43,7 @@ import processing.app.legacy.PApplet;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.ItemEvent;
 import java.awt.event.WindowEvent;
 import java.io.File;
 import java.util.LinkedList;
@@ -243,6 +245,20 @@ public class Preferences extends javax.swing.JDialog {
     checkboxesContainer.add(verifyUploadBox);
 
     externalEditorBox.setText(tr("Use external editor"));
+    externalEditorBox.addItemListener(ev -> {
+      if (ev.getStateChange() == ItemEvent.SELECTED) {
+        for (Editor e : base.getEditors()) {
+          if (e.getSketch().isModified()) {
+            String msg = tr("You have unsaved changes!\nYou must save all your sketches to enable this option.");
+            JOptionPane.showMessageDialog(null, msg,
+                                          tr("Can't enable external editor"),
+                                          JOptionPane.INFORMATION_MESSAGE);
+            externalEditorBox.setSelected(false);
+          }
+        }
+      }
+    });
+
     checkboxesContainer.add(externalEditorBox);
 
     cacheCompiledCore.setText(tr("Aggressively cache compiled core"));

--- a/app/src/cc/arduino/view/preferences/Preferences.java
+++ b/app/src/cc/arduino/view/preferences/Preferences.java
@@ -254,6 +254,7 @@ public class Preferences extends javax.swing.JDialog {
                                           tr("Can't enable external editor"),
                                           JOptionPane.INFORMATION_MESSAGE);
             externalEditorBox.setSelected(false);
+            return;
           }
         }
       }

--- a/arduino-core/src/processing/app/i18n/Resources_en.po
+++ b/arduino-core/src/processing/app/i18n/Resources_en.po
@@ -427,6 +427,10 @@ msgstr "CRC doesn't match, file is corrupted. It may be a temporary problem, ple
 msgid "Can only pass one of: {0}"
 msgstr "Can only pass one of: {0}"
 
+#: ../../../../../app/src/cc/arduino/view/preferences/Preferences.java:254
+msgid "Can't enable external editor"
+msgstr ""
+
 #: ../../../processing/app/BaseNoGui.java:504
 #: ../../../processing/app/BaseNoGui.java:549
 msgid "Can't find the sketch in the specified path"
@@ -468,6 +472,10 @@ msgstr "Chinese (Taiwan)"
 #: ../../../processing/app/Preferences.java:143
 msgid "Chinese (Taiwan) (Big5)"
 msgstr "Chinese (Taiwan) (Big5)"
+
+#: ../../../../../app/src/processing/app/AbstractTextMonitor.java:80
+msgid "Clear output"
+msgstr ""
 
 #: ../../../../../app/src/cc/arduino/view/preferences/AdditionalBoardsManagerURLTextArea.java:98
 msgid "Click for a list of unofficial boards support URLs"
@@ -2454,6 +2462,12 @@ msgstr "You cannot save the sketch into a folder\ninside itself. This would go o
 #: Base.java:1888
 msgid "You forgot your sketchbook"
 msgstr "You forgot your sketchbook"
+
+#: ../../../../../app/src/cc/arduino/view/preferences/Preferences.java:252
+msgid ""
+"You have unsaved changes!\n"
+"You must save all your sketches to enable this option."
+msgstr ""
 
 #: ../../../processing/app/AbstractMonitor.java:92
 msgid ""

--- a/arduino-core/src/processing/app/i18n/Resources_en.properties
+++ b/arduino-core/src/processing/app/i18n/Resources_en.properties
@@ -298,6 +298,9 @@ CRC\ doesn't\ match,\ file\ is\ corrupted.\ It\ may\ be\ a\ temporary\ problem,\
 #, java-format
 Can\ only\ pass\ one\ of\:\ {0}=Can only pass one of\: {0}
 
+#: ../../../../../app/src/cc/arduino/view/preferences/Preferences.java:254
+!Can't\ enable\ external\ editor=
+
 #: ../../../processing/app/BaseNoGui.java:504
 #: ../../../processing/app/BaseNoGui.java:549
 Can't\ find\ the\ sketch\ in\ the\ specified\ path=Can't find the sketch in the specified path
@@ -329,6 +332,9 @@ Chinese\ (Taiwan)=Chinese (Taiwan)
 
 #: ../../../processing/app/Preferences.java:143
 Chinese\ (Taiwan)\ (Big5)=Chinese (Taiwan) (Big5)
+
+#: ../../../../../app/src/processing/app/AbstractTextMonitor.java:80
+!Clear\ output=
 
 #: ../../../../../app/src/cc/arduino/view/preferences/AdditionalBoardsManagerURLTextArea.java:98
 Click\ for\ a\ list\ of\ unofficial\ boards\ support\ URLs=Click for a list of unofficial boards support URLs
@@ -1770,6 +1776,9 @@ You\ cannot\ save\ the\ sketch\ into\ a\ folder\ninside\ itself.\ This\ would\ g
 
 #: Base.java:1888
 You\ forgot\ your\ sketchbook=You forgot your sketchbook
+
+#: ../../../../../app/src/cc/arduino/view/preferences/Preferences.java:252
+!You\ have\ unsaved\ changes\!\nYou\ must\ save\ all\ your\ sketches\ to\ enable\ this\ option.=
 
 #: ../../../processing/app/AbstractMonitor.java:92
 You've\ pressed\ {0}\ but\ nothing\ was\ sent.\ Should\ you\ select\ a\ line\ ending?=You've pressed {0} but nothing was sent. Should you select a line ending?

--- a/build/shared/revisions.txt
+++ b/build/shared/revisions.txt
@@ -3,6 +3,7 @@ ARDUINO 1.8.3
 [ide]
 * Serial Monitor: added "Clear output" button. Thanks @MichaelSy
 * added option in preferences.txt for: custom title, comment/uncomment shortcut, always show file extensions. Thanks @MichaelSy
+* Enabling "Use external editor" option now requires to save all sketches.
 
 ARDUINO 1.8.2 2017.03.22
 


### PR DESCRIPTION
Fix #6196

![image](https://cloud.githubusercontent.com/assets/423515/25432770/11c5ccfe-2a86-11e7-9cc5-b691147656b8.png)
