### PR TITLE
Fix move constructor and operator= in String.

### DIFF
--- a/hardware/arduino/avr/cores/arduino/WString.cpp
+++ b/hardware/arduino/avr/cores/arduino/WString.cpp
@@ -43,16 +43,15 @@ String::String(const __FlashStringHelper *pstr)
 	*this = pstr;
 }
 
-#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
+#if STRING_HAS_MOVE
 String::String(String &&rval)
+	: buffer(rval.buffer)
+	, capacity(rval.capacity)
+	, len(rval.len)
 {
-	init();
-	move(rval);
-}
-String::String(StringSumHelper &&rval)
-{
-	init();
-	move(rval);
+	rval.buffer = NULL;
+	rval.capacity = 0;
+	rval.len = 0;
 }
 #endif
 
@@ -189,25 +188,22 @@ String & String::copy(const __FlashStringHelper *pstr, unsigned int length)
 	return *this;
 }
 
-#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
+#if STRING_HAS_MOVE
 void String::move(String &rhs)
 {
-	if (buffer) {
-		if (rhs && capacity >= rhs.len) {
-			strcpy(buffer, rhs.buffer);
-			len = rhs.len;
-			rhs.len = 0;
-			return;
-		} else {
+	if (this != &rhs)
+	{
+		if (buffer != NULL)
 			free(buffer);
-		}
+
+		buffer = rhs.buffer;
+		len = rhs.len;
+		capacity = rhs.capacity;
+
+		rhs.buffer = NULL;
+		rhs.len = 0;
+		rhs.capacity = 0;
 	}
-	buffer = rhs.buffer;
-	capacity = rhs.capacity;
-	len = rhs.len;
-	rhs.buffer = NULL;
-	rhs.capacity = 0;
-	rhs.len = 0;
 }
 #endif
 
@@ -221,16 +217,10 @@ String & String::operator = (const String &rhs)
 	return *this;
 }
 
-#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
+#if STRING_HAS_MOVE
 String & String::operator = (String &&rval)
 {
-	if (this != &rval) move(rval);
-	return *this;
-}
-
-String & String::operator = (StringSumHelper &&rval)
-{
-	if (this != &rval) move(rval);
+	move(rval);
 	return *this;
 }
 #endif

--- a/hardware/arduino/avr/cores/arduino/WString.cpp
+++ b/hardware/arduino/avr/cores/arduino/WString.cpp
@@ -136,7 +136,7 @@ inline void String::init(void)
 
 void String::invalidate(void)
 {
-	if (buffer) free(buffer);
+	free(buffer);
 	buffer = NULL;
 	capacity = len = 0;
 }
@@ -193,8 +193,7 @@ void String::move(String &rhs)
 {
 	if (this != &rhs)
 	{
-		if (buffer != NULL)
-			free(buffer);
+		free(buffer);
 
 		buffer = rhs.buffer;
 		len = rhs.len;

--- a/hardware/arduino/avr/cores/arduino/WString.h
+++ b/hardware/arduino/avr/cores/arduino/WString.h
@@ -41,6 +41,10 @@ class __FlashStringHelper;
 // result objects are assumed to be writable by subsequent concatenations.
 class StringSumHelper;
 
+#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
+#define STRING_HAS_MOVE 1
+#endif
+
 // The string class
 class String
 {
@@ -59,9 +63,8 @@ public:
 	String(const char *cstr = "");
 	String(const String &str);
 	String(const __FlashStringHelper *str);
-       #if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
+	#if STRING_HAS_MOVE
 	String(String &&rval);
-	String(StringSumHelper &&rval);
 	#endif
 	explicit String(char c);
 	explicit String(unsigned char, unsigned char base=10);
@@ -86,9 +89,8 @@ public:
 	String & operator = (const String &rhs);
 	String & operator = (const char *cstr);
 	String & operator = (const __FlashStringHelper *str);
-       #if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
+	#if STRING_HAS_MOVE
 	String & operator = (String &&rval);
-	String & operator = (StringSumHelper &&rval);
 	#endif
 
 	// concatenate (works w/ built-in types)
@@ -205,7 +207,7 @@ protected:
 	// copy and move
 	String & copy(const char *cstr, unsigned int length);
 	String & copy(const __FlashStringHelper *pstr, unsigned int length);
-       #if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
+	#if STRING_HAS_MOVE
 	void move(String &rhs);
 	#endif
 };


### PR DESCRIPTION
The move constructor String::String(String&&) and String::operator=(String&&) now perform move instead of copy.
This fixes #6260.