### PR TITLE
Fixed serial port argument that may include spaces

### DIFF
--- a/hardware/arduino/avr/platform.txt
+++ b/hardware/arduino/avr/platform.txt
@@ -102,7 +102,7 @@ tools.avrdude.upload.params.quiet=-q -q
 # tools.avrdude.upload.verify is needed for backwards compatibility with IDE 1.6.8 or older, IDE 1.6.9 or newer overrides this value
 tools.avrdude.upload.verify=
 tools.avrdude.upload.params.noverify=-V
-tools.avrdude.upload.pattern="{cmd.path}" "-C{config.path}" {upload.verbose} {upload.verify} -p{build.mcu} -c{upload.protocol} -P{serial.port} -b{upload.speed} -D "-Uflash:w:{build.path}/{build.project_name}.hex:i"
+tools.avrdude.upload.pattern="{cmd.path}" "-C{config.path}" {upload.verbose} {upload.verify} -p{build.mcu} -c{upload.protocol} "-P{serial.port}" -b{upload.speed} -D "-Uflash:w:{build.path}/{build.project_name}.hex:i"
 
 tools.avrdude.program.params.verbose=-v
 tools.avrdude.program.params.quiet=-q -q


### PR DESCRIPTION
Other paths in avrdude.upload.pattern are wrapped in double quotes, and this -P{serial.port} causes issues with some platforms. This allows serial port devices which include spaces and other characters. Without this fix a /dev/tty* or /dev/cu* device that includes a space in its name gets truncated when passed to avrdude. Error messages returned from avrdude are cryptic, and workarounds (symlinks) are prone to failure.

Fixes #3693