### PR TITLE
Fix renaming of newly added files

### DIFF
--- a/arduino-core/src/processing/app/SketchFile.java
+++ b/arduino-core/src/processing/app/SketchFile.java
@@ -177,7 +177,7 @@ public class SketchFile {
   public void renameTo(String newName) throws IOException {
     File newFile = new File(file.getParentFile(), newName);
     sketch.checkNewFilename(newFile);
-    if (file.renameTo(newFile)) {
+    if (!file.exists() || file.renameTo(newFile)) {
       renamedTo(newFile);
     } else {
       String msg = I18n.format(tr("Failed to rename \"{0}\" to \"{1}\""), file.getName(), newName);


### PR DESCRIPTION
Before 72f815bcf (Refactor file adding and renaming, and save as handling)
renaming a file would first save it and then rename it. Since that
commit, renaming an unsaved, newly added file would try to rename a
non-existing file on disk, causing an error message.

This is fixed by only moving the on-disk file if it exists, otherwise
just the in-memory filename is updated and the file will be written
during the next save.

Fixes: #6265