### PR TITLE
Add font size shortcuts (menu and keyboard)

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1839,6 +1839,17 @@ public class Base {
     dialog.setVisible(true);
   }
 
+  /**
+   * Adjust font size
+   */
+  public void handleFontSizeChange(int change) {
+    String pieces[] = PApplet.split(PreferencesData.get("editor.font"), ',');
+    int newSize = Integer.parseInt(pieces[2]) + change;
+    pieces[2] = String.valueOf(newSize);
+    PreferencesData.set("editor.font", PApplet.join(pieces, ','));
+    this.getEditors().forEach(processing.app.Editor::applyPreferences);
+  }
+
   // XXX: Remove this method and make librariesIndexer non-static
   static public LibraryList getLibraries() {
     return BaseNoGui.librariesIndexer.getInstalledLibraries();

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -1374,6 +1374,24 @@ public class Editor extends JFrame implements RunnerListener {
 
     menu.addSeparator();
 
+    JMenuItem increaseFontSizeItem = newJMenuItem(tr("Increase Font Size"), '=');
+    increaseFontSizeItem.addActionListener(new ActionListener() {
+        public void actionPerformed(ActionEvent e) {
+          base.handleFontSizeChange(1);
+        }
+    });
+    menu.add(increaseFontSizeItem);
+
+    JMenuItem decreaseFontSizeItem = newJMenuItem(tr("Decrease Font Size"), '-');
+    decreaseFontSizeItem.addActionListener(new ActionListener() {
+        public void actionPerformed(ActionEvent e) {
+          base.handleFontSizeChange(-1);
+        }
+    });
+    menu.add(decreaseFontSizeItem);
+
+    menu.addSeparator();
+
     JMenuItem findItem = newJMenuItem(tr("Find..."), 'F');
     findItem.addActionListener(new ActionListener() {
       public void actionPerformed(ActionEvent e) {


### PR DESCRIPTION
Having a stab at #6359.
(Scaling font size using keyboard shortcuts.)

I haven't implemented Ctrl-Scroll, but have implemented keyboard shortcuts using the existing menu item pattern.

Let me know if I should go about this a different way!

<img width="299" alt="screen shot 2017-06-18 at 7 17 06 pm" src="https://user-images.githubusercontent.com/1059392/27259639-c5aeecfc-545a-11e7-874f-64e54af24f59.png">