### PR TITLE
Only rescan libraries folders when really needed

### DIFF
--- a/arduino-core/src/cc/arduino/contributions/libraries/LibrariesIndexer.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/LibrariesIndexer.java
@@ -60,7 +60,7 @@ public class LibrariesIndexer {
   private LibrariesIndex index;
   private final LibraryList installedLibraries = new LibraryList();
   private final LibraryList installedLibrariesWithDuplicates = new LibraryList();
-  private List<File> librariesFolders;
+  private ArrayList<File> librariesFolders;
   private final File indexFile;
   private final File stagingFolder;
   private File sketchbookLibrariesFolder;
@@ -101,9 +101,13 @@ public class LibrariesIndexer {
     }
   }
 
-  public void setLibrariesFolders(List<File> _librariesFolders) {
+  public void setLibrariesFolders(ArrayList<File> _librariesFolders) {
     librariesFolders = _librariesFolders;
     rescanLibraries();
+  }
+
+  public ArrayList<File> getLibrariesFolders() {
+    return librariesFolders;
   }
 
   public void rescanLibraries() {

--- a/arduino-core/src/cc/arduino/contributions/libraries/LibrariesIndexer.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/LibrariesIndexer.java
@@ -60,7 +60,7 @@ public class LibrariesIndexer {
   private LibrariesIndex index;
   private final LibraryList installedLibraries = new LibraryList();
   private final LibraryList installedLibrariesWithDuplicates = new LibraryList();
-  private ArrayList<File> librariesFolders;
+  private List<File> librariesFolders;
   private final File indexFile;
   private final File stagingFolder;
   private File sketchbookLibrariesFolder;
@@ -101,12 +101,12 @@ public class LibrariesIndexer {
     }
   }
 
-  public void setLibrariesFolders(ArrayList<File> _librariesFolders) {
+  public void setLibrariesFolders(List<File> _librariesFolders) {
     librariesFolders = _librariesFolders;
     rescanLibraries();
   }
 
-  public ArrayList<File> getLibrariesFolders() {
+  public List<File> getLibrariesFolders() {
     return librariesFolders;
   }
 

--- a/arduino-core/src/cc/arduino/contributions/libraries/LibrariesIndexer.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/LibrariesIndexer.java
@@ -102,8 +102,10 @@ public class LibrariesIndexer {
   }
 
   public void setLibrariesFolders(List<File> _librariesFolders) {
-    librariesFolders = _librariesFolders;
-    rescanLibraries();
+    if (librariesFolders != _librariesFolders && !librariesFolders.equals(_librariesFolders)) {
+      librariesFolders = _librariesFolders;
+      rescanLibraries();
+    }
   }
 
   public List<File> getLibrariesFolders() {

--- a/arduino-core/src/processing/app/BaseNoGui.java
+++ b/arduino-core/src/processing/app/BaseNoGui.java
@@ -87,7 +87,7 @@ public class BaseNoGui {
   public static Map<String, LibraryList> importToLibraryTable;
 
   // XXX: Remove this field
-  static private List<File> librariesFolders;
+  static private ArrayList<File> librariesFolders;
 
   static UserNotifier notifier = new BasicUserNotifier();
 
@@ -245,7 +245,7 @@ public class BaseNoGui {
     return getHardwareFolder().getAbsolutePath();
   }
 
-  static public List<File> getLibrariesPath() {
+  static public ArrayList<File> getLibrariesPath() {
     return librariesFolders;
   }
 
@@ -679,8 +679,9 @@ public class BaseNoGui {
     // Libraries located in the latest folders on the list can override
     // other libraries with the same name.
     librariesIndexer.setSketchbookLibrariesFolder(getSketchbookLibrariesFolder());
-    librariesIndexer.setLibrariesFolders(librariesFolders);
-    librariesIndexer.rescanLibraries();
+    if (librariesIndexer.getLibrariesFolders() == null || !librariesIndexer.getLibrariesFolders().equals(librariesFolders)) {
+      librariesIndexer.setLibrariesFolders(librariesFolders);
+    }
 
     populateImportToLibraryTable();
   }

--- a/arduino-core/src/processing/app/BaseNoGui.java
+++ b/arduino-core/src/processing/app/BaseNoGui.java
@@ -679,9 +679,7 @@ public class BaseNoGui {
     // Libraries located in the latest folders on the list can override
     // other libraries with the same name.
     librariesIndexer.setSketchbookLibrariesFolder(getSketchbookLibrariesFolder());
-    if (librariesIndexer.getLibrariesFolders() == null || !librariesIndexer.getLibrariesFolders().equals(librariesFolders)) {
-      librariesIndexer.setLibrariesFolders(librariesFolders);
-    }
+    librariesIndexer.setLibrariesFolders(librariesFolders);
 
     populateImportToLibraryTable();
   }


### PR DESCRIPTION
Scanning libraries is an heavy task if the sketchbook becomes huge;
This patch targets two points:

- remove the rescan() after setLibrariesFolders(), which already performs a rescan
- call setLibrariesFolders() only when the folder list has changed
  - This ensures that no scan is performed when changing board in the same architecture

Could mitigate #6350