### PR TITLE
Fix compilation warnings

### DIFF
--- a/hardware/arduino/avr/cores/arduino/HardwareSerial.h
+++ b/hardware/arduino/avr/cores/arduino/HardwareSerial.h
@@ -118,6 +118,7 @@ class HardwareSerial : public Stream
       volatile uint8_t *ubrrh, volatile uint8_t *ubrrl,
       volatile uint8_t *ucsra, volatile uint8_t *ucsrb,
       volatile uint8_t *ucsrc, volatile uint8_t *udr);
+    virtual ~HardwareSerial() {}
     void begin(unsigned long baud) { begin(baud, SERIAL_8N1); }
     void begin(unsigned long, uint8_t);
     void end();

--- a/hardware/arduino/avr/cores/arduino/Print.h
+++ b/hardware/arduino/avr/cores/arduino/Print.h
@@ -44,7 +44,7 @@ class Print
     void setWriteError(int err = 1) { write_error = err; }
   public:
     Print() : write_error(0) {}
-  
+    virtual ~Print() {}
     int getWriteError() { return write_error; }
     void clearWriteError() { setWriteError(0); }
   

--- a/hardware/arduino/avr/cores/arduino/Stream.h
+++ b/hardware/arduino/avr/cores/arduino/Stream.h
@@ -60,8 +60,9 @@ class Stream : public Print
     virtual int read() = 0;
     virtual int peek() = 0;
 
-    Stream() {_timeout=1000;}
-
+    Stream() {_timeout=1000, _startMillis=0;}
+    virtual ~Stream() {}
+    
 // parsing methods
 
   void setTimeout(unsigned long timeout);  // sets maximum milliseconds to wait for stream data, default is 1 second


### PR DESCRIPTION
Remove compilation warnings
- Add virtual destructor in HardwareSerial.h, Stream.h and Print.h
- Add attribute initialization in Stream.h
