### PR TITLE
Remove unused variable from StringAdditionOperator example

### DIFF
--- a/build/shared/examples/08.Strings/StringAdditionOperator/StringAdditionOperator.ino
+++ b/build/shared/examples/08.Strings/StringAdditionOperator/StringAdditionOperator.ino
@@ -58,7 +58,6 @@ void loop() {
   Serial.println(stringThree);    // prints "Sensor Value: 401" or whatever value analogRead(A0) has
 
   // adding a variable long integer to a string:
-  long currentTime = millis();
   stringOne = "millis() value: ";
   stringThree = stringOne + millis();
   Serial.println(stringThree);    // prints "The millis: 345345" or whatever value currentTime has


### PR DESCRIPTION
- Avoids confusing beginners who assume there must be some reason for this useless line of code.
- Fixes `warning: unused variable 'currentTime'` compiler warning.

Closes https://github.com/arduino/Arduino/issues/693