### PR TITLE
Fix comparison between signed and unsigned warning in StringLength example

### DIFF
--- a/build/shared/examples/08.Strings/StringLength/StringLength.ino
+++ b/build/shared/examples/08.Strings/StringLength/StringLength.ino
@@ -13,7 +13,7 @@
  */
 
 String txtMsg = "";                         // a string for incoming text
-int lastStringLength = txtMsg.length();     // previous length of the String
+unsigned int lastStringLength = txtMsg.length();     // previous length of the String
 
 void setup() {
   // Open serial communications and wait for port to open:


### PR DESCRIPTION
Fixes `warning: comparison between signed and unsigned integer expressions` compiler warning.

Closes https://github.com/arduino/Arduino/issues/693 (in conjunction with https://github.com/arduino/Arduino/issues/6448)