### PR TITLE
Add a note about ATmega32U4 incompatibility to SerialEvent example

### DIFF
--- a/build/shared/examples/04.Communication/SerialEvent/SerialEvent.ino
+++ b/build/shared/examples/04.Communication/SerialEvent/SerialEvent.ino
@@ -8,6 +8,9 @@
  A good test for this is to try it with a GPS receiver
  that sends out NMEA 0183 sentences.
 
+ NOTE: The serialEvent() feature is not available on the
+ Leonardo, Micro, or other ATmega32U4 based boards.
+ 
  Created 9 May 2011
  by Tom Igoe
 


### PR DESCRIPTION
`serialEvent()` does not work on the ATmega32U4 boards.

Reference: https://github.com/arduino/Arduino/issues/1031

If the issue also applies to any of the non-AVR official Arduino boards that should be added to the note. I don't have any of those boards to test with but am happy to update this PR if anyone can confirm this.