### PR TITLE
Fixed READ EEPROM in stk500v2 bootloader

### DIFF
--- a/hardware/arduino/avr/bootloaders/stk500v2/stk500boot.c
+++ b/hardware/arduino/avr/bootloaders/stk500v2/stk500boot.c
@@ -1063,10 +1063,13 @@ int main(void)
 						else
 						{
 							/* Read EEPROM */
+							uint16_t ii = address >> 1;
 							do {
-								EEARL	=	address;			// Setup EEPROM address
-								EEARH	=	((address >> 8));
-								address++;					// Select next EEPROM byte
+								EEARL	=	ii;			// Setup EEPROM address
+								EEARH	=	((ii >> 8));
+								address += 2; // Select next EEPROM byte
+								ii++;
+
 								EECR	|=	(1<<EERE);			// Read EEPROM
 								*p++	=	EEDR;				// Send EEPROM data
 								size--;


### PR DESCRIPTION
As per #6455 

CMD_READ_EEPROM_ISP was addressing EEPROM as 16bit instead of 8bit data.
Changed to mimic CMD_PROGRAM_EEPROM_ISP workaround.
