### PR TITLE
Fixed ignoring of LIBRARY_INDEX_URL system property

### DIFF
--- a/arduino-core/src/cc/arduino/Constants.java
+++ b/arduino-core/src/cc/arduino/Constants.java
@@ -80,10 +80,15 @@ public class Constants {
     String externalLibraryIndexUrl = System.getProperty("LIBRARY_INDEX_URL");
     if (externalLibraryIndexUrl != null && !"".equals(externalLibraryIndexUrl)) {
       LIBRARY_INDEX_URL = externalLibraryIndexUrl;
+      LIBRARY_INDEX_URL_GZ = "";
+      String externalLibraryIndexUrlGz = System.getProperty("LIBRARY_INDEX_URL_GZ");
+      if (externalLibraryIndexUrlGz != null && !"".equals(externalLibraryIndexUrlGz)) {
+        LIBRARY_INDEX_URL_GZ = externalLibraryIndexUrlGz;
+      }
     } else {
       LIBRARY_INDEX_URL = "http://downloads.arduino.cc/libraries/library_index.json";
+      LIBRARY_INDEX_URL_GZ = "http://downloads.arduino.cc/libraries/library_index.json.gz";
     }
-    LIBRARY_INDEX_URL_GZ = "http://downloads.arduino.cc/libraries/library_index.json.gz";
   }
 
 }


### PR DESCRIPTION
LibraryInstaller uses only GZippedJsonDownloader, 
https://github.com/arduino/Arduino/blob/master/arduino-core/src/cc/arduino/contributions/libraries/LibraryInstaller.java#L65
which should fall back to JsonDwnloader only if the downloading of gziped JSON fails. (In catch block)
https://github.com/arduino/Arduino/blob/master/arduino-core/src/cc/arduino/contributions/GZippedJsonDownloader.java#L54

But if I set LIBRARY_INDEX_URL  system property, which is then stored into LIBRARY_INDEX_URL constant, it will be ignored since the LIBRARY_INDEX_URL_GZ takes precedence, and it is set to arduino.cc's librayr_index.json. 

So I introduced the possibility to set system property for Gzipped JSON URL as well, and moreover when the LIBRARY_INDEX_URL system property is set and LIBRARY_INDEX_URL_GZ is not, it will get empty string value, and the try block in GZippedJson downloader will fail and JsonDownloader from the catch block will be called. 