### PR TITLE
CLI: fixed missing "runtime.platform.path"

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -261,6 +261,10 @@ public class Base {
     if (!isCommandLine()) {
       rebuildBoardsMenu();
       rebuildProgrammerMenu();
+    } else {
+      TargetBoard lastSelectedBoard = BaseNoGui.getTargetBoard();
+      if (lastSelectedBoard != null)
+        BaseNoGui.selectBoard(lastSelectedBoard);
     }
 
     // Setup board-dependent variables.

--- a/build/shared/revisions.txt
+++ b/build/shared/revisions.txt
@@ -3,6 +3,7 @@ ARDUINO 1.8.4
 [ide]
 * Environment variable LIBRARY_INDEX_URL is now correctly parsed (LIBRARY_INDEX_URL_GZ can also be optinally specified). Thanks @xardael
 * Added per-board generic option in config file boards.txt for disabling control of dtr+rts. Thanks @d-a-v
+* CLI: fixed missing "runtime.platform.path" when running without the `--board` option
 
 ARDUINO 1.8.3 2017.05.31
 


### PR DESCRIPTION
This happens when the CLI is runned without the `--board` option.

Fix #6463 

/cc @Sorunome