### PR TITLE
Hi-DPI: tentative auto DPI detection for Linux

### DIFF
--- a/arduino-core/src/processing/app/linux/Platform.java
+++ b/arduino-core/src/processing/app/linux/Platform.java
@@ -25,7 +25,10 @@ package processing.app.linux;
 import processing.app.PreferencesData;
 import processing.app.legacy.PConstants;
 
+import java.awt.Font;
 import java.io.File;
+
+import javax.swing.UIManager;
 
 
 /**
@@ -116,5 +119,20 @@ public class Platform extends processing.app.Platform {
   @Override
   public String getName() {
     return PConstants.platformNames[PConstants.LINUX];
+  }
+
+  private int detectedDpi = -1;
+
+  @Override
+  public int getSystemDPI() {
+    if (detectedDpi != -1)
+      return detectedDpi;
+
+    // we observed that JMenu fonts in java follows the
+    // System DPI settings, so we compare it to the standard
+    // font size (12) to obtain a rough estimate of DPI.
+    Font menuFont = UIManager.getFont("Menu.font");
+    detectedDpi = menuFont.getSize() * 96 / 12;
+    return detectedDpi;
   }
 }


### PR DESCRIPTION
This is a best-effort approach, it works well on my Linux Ubuntu machine, with this patch the IDE is able to detect the "Scale for menu and title" system settings and scale everything accordingly:

![image](https://user-images.githubusercontent.com/423515/28331200-759c9d4c-6bf0-11e7-86a3-8a000c2025a9.png)


Before the patch, only the menus were affected by the setting above.

See #6472
