### PR TITLE
Add support for 64 bit integer printing

### DIFF
--- a/hardware/arduino/avr/cores/arduino/Print.h
+++ b/hardware/arduino/avr/cores/arduino/Print.h
@@ -39,15 +39,16 @@ class Print
   private:
     int write_error;
     size_t printNumber(unsigned long, uint8_t);
+    size_t printULLNumber(unsigned long long, uint8_t);
     size_t printFloat(double, uint8_t);
   protected:
     void setWriteError(int err = 1) { write_error = err; }
   public:
     Print() : write_error(0) {}
-  
+
     int getWriteError() { return write_error; }
     void clearWriteError() { setWriteError(0); }
-  
+
     virtual size_t write(uint8_t) = 0;
     size_t write(const char *str) {
       if (str == NULL) return 0;
@@ -71,6 +72,8 @@ class Print
     size_t print(unsigned int, int = DEC);
     size_t print(long, int = DEC);
     size_t print(unsigned long, int = DEC);
+    size_t print(long long, int = DEC);
+    size_t print(unsigned long long, int = DEC);
     size_t print(double, int = 2);
     size_t print(const Printable&);
 
@@ -83,6 +86,8 @@ class Print
     size_t println(unsigned int, int = DEC);
     size_t println(long, int = DEC);
     size_t println(unsigned long, int = DEC);
+    size_t println(long long, int = DEC);
+    size_t println(unsigned long long, int = DEC);
     size_t println(double, int = 2);
     size_t println(const Printable&);
     size_t println(void);


### PR DESCRIPTION
Added support for printing **unsigned long long** and **long long**

solves issue https://github.com/arduino/ArduinoCore-avr/issues/194

Included is a reference implementation (commented out) which is a replica of the print code for **long**.
The code is 2-3x faster with a slightly larger footprint. The performance is gained by working in "16 bit" chunks. Tested on UNO and discussed "long long" ago here - https://forum.arduino.cc/t/serial-print-of-a-64-bit-double/140151

(minor) Cleanup trailing spaces