### PR TITLE
Fix incorrect comment in toneMultiple example

### DIFF
--- a/build/shared/examples/02.Digital/toneMultiple/toneMultiple.ino
+++ b/build/shared/examples/02.Digital/toneMultiple/toneMultiple.ino
@@ -34,7 +34,7 @@ void loop() {
 
   // turn off tone function for pin 7:
   noTone(7);
-  // play a note on pin 8 for 500 ms:
+  // play a note on pin 8 for 300 ms:
   tone(8, 523, 300);
   delay(300);
 }


### PR DESCRIPTION
The comment about the note duration didn't match the code.

Fixes https://github.com/arduino/Arduino/issues/6596

