### PR TITLE
Add "Manage libraries..." to the "Tools" menu too and add a shortcut for it.

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1070,6 +1070,10 @@ public class Base {
     importMenu.removeAll();
 
     JMenuItem menu = new JMenuItem(tr("Manage Libraries..."));
+    // Ctrl+Shift+I on Windows and Linux, Command+Shift+I on macOS
+    menu.setAccelerator(KeyStroke.getKeyStroke('I',
+        Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() |
+        ActionEvent.SHIFT_MASK));
     menu.addActionListener(e -> openLibraryManager("", ""));
     importMenu.add(menu);
     importMenu.addSeparator();

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -158,7 +158,7 @@ public class Editor extends JFrame implements RunnerListener {
 
   static volatile AbstractMonitor serialMonitor;
   static AbstractMonitor serialPlotter;
-  
+
   final EditorHeader header;
   EditorStatus status;
   EditorConsole console;
@@ -248,7 +248,7 @@ public class Editor extends JFrame implements RunnerListener {
 
     //PdeKeywords keywords = new PdeKeywords();
     //sketchbook = new Sketchbook(this);
-    
+
     buildMenuBar();
 
     // For rev 0120, placing things inside a JPanel
@@ -399,8 +399,7 @@ public class Editor extends JFrame implements RunnerListener {
         statusNotice(tr("One file added to the sketch."));
 
       } else {
-        statusNotice(
-	    I18n.format(tr("{0} files added to the sketch."), successful));
+        statusNotice(I18n.format(tr("{0} files added to the sketch."), successful));
       }
       return true;
     }
@@ -947,14 +946,14 @@ public class Editor extends JFrame implements RunnerListener {
     } finally {
       if (zipFile != null) {
         try {
-          zipFile.close();
-        } catch (IOException e) {
-          // noop
-        }
-      }
-    }
-    return null;
-	}
+           zipFile.close();
+         } catch (IOException e) {
+           // noop
+         }
+       }
+     }
+     return null;
+   }
 
   public void updateKeywords(PdeKeywords keywords) {
     for (EditorTab tab : tabs)
@@ -2096,18 +2095,19 @@ public class Editor extends JFrame implements RunnerListener {
       names[i] = portMenu.getItem(i).getText();
     }
 
+    // FIXME: This is horribly unreadable
     String result = (String)
-      JOptionPane.showInputDialog(this,
-	I18n.format(
-	  tr("Serial port {0} not found.\n" +
-	    "Retry the upload with another serial port?"),
-	  PreferencesData.get("serial.port")
-	),
-				  "Serial port not found",
-                                  JOptionPane.PLAIN_MESSAGE,
-                                  null,
-                                  names,
-                                  0);
+    JOptionPane.showInputDialog(this,
+     I18n.format(
+      tr("Serial port {0} not found.\n" +
+       "Retry the upload with another serial port?"),
+      PreferencesData.get("serial.port")
+     ),
+     "Serial port not found",
+     JOptionPane.PLAIN_MESSAGE,
+     null,
+     names,
+     0);
     if (result == null) return false;
     selectSerialPort(result);
     base.onBoardOrPortChange();
@@ -2321,7 +2321,7 @@ public class Editor extends JFrame implements RunnerListener {
         return;
       }
     }
-  
+
     if (serialMonitor != null) {
       // The serial monitor already exists
 
@@ -2351,14 +2351,14 @@ public class Editor extends JFrame implements RunnerListener {
     }
 
     serialMonitor = new MonitorFactory().newMonitor(port);
-    
+
     if (serialMonitor == null) {
       String board = port.getPrefs().get("board");
       String boardName = BaseNoGui.getPlatform().resolveDeviceByBoardID(BaseNoGui.packages, board);
       statusError(I18n.format(tr("Serial monitor is not supported on network ports such as {0} for the {1} in this release"), PreferencesData.get("serial.port"), boardName));
       return;
     }
-    
+
     Base.setIcon(serialMonitor);
 
     // If currently uploading, disable the monitor (it will be later
@@ -2418,7 +2418,7 @@ public class Editor extends JFrame implements RunnerListener {
     } while (serialMonitor.requiresAuthorization() && !success);
 
   }
-  
+
   public void handlePlotter() {
     if(serialMonitor != null) {
       if(serialMonitor.isClosed()) {
@@ -2428,7 +2428,7 @@ public class Editor extends JFrame implements RunnerListener {
         return;
       }
     }
-  
+
     if (serialPlotter != null) {
       // The serial plotter already exists
 

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -731,7 +731,7 @@ public class Editor extends JFrame implements RunnerListener {
 
     addInternalTools(toolsMenu);
 
-    JMenuItem item = new JMenuItem(tr("Manage Libraries..."));
+    JMenuItem item = newJMenuItemShift(tr("Manage Libraries..."), 'I');
     item.addActionListener(e -> base.openLibraryManager("", ""));
     toolsMenu.add(item);
 

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -731,16 +731,16 @@ public class Editor extends JFrame implements RunnerListener {
 
     addInternalTools(toolsMenu);
 
-    JMenuItem item = newJMenuItemShift(tr("Serial Monitor"), 'M');
+    JMenuItem item = new JMenuItem(tr("Manage Libraries..."));
+    item.addActionListener(e -> base.openLibraryManager("", ""));
+    toolsMenu.add(item);
+
+    item = newJMenuItemShift(tr("Serial Monitor"), 'M');
     item.addActionListener(e -> handleSerial());
     toolsMenu.add(item);
 
     item = newJMenuItemShift(tr("Serial Plotter"), 'L');
-    item.addActionListener(new ActionListener() {
-        public void actionPerformed(ActionEvent e) {
-          handlePlotter();
-        }
-    });
+    item.addActionListener(e -> handlePlotter());
     toolsMenu.add(item);
 
     addTools(toolsMenu, BaseNoGui.getToolsFolder());
@@ -1475,6 +1475,7 @@ public class Editor extends JFrame implements RunnerListener {
   /**
    * Like newJMenuItem() but adds shift as a modifier for the key command.
    */
+  // Control + Shift + K seems to not be working on linux (Xubuntu 17.04, 2017-08-19)
   static public JMenuItem newJMenuItemShift(String title, int what) {
     JMenuItem menuItem = new JMenuItem(title);
     menuItem.setAccelerator(KeyStroke.getKeyStroke(what, SHORTCUT_KEY_MASK | ActionEvent.SHIFT_MASK));

--- a/app/src/processing/app/helpers/Keys.java
+++ b/app/src/processing/app/helpers/Keys.java
@@ -220,7 +220,7 @@ public class Keys {
   }
 
   /**
-   * Creates a KeyCode for the "menu shortcut" + shift + the key passed in. By
+   * Creates a KeyCode for the "menu shortcut" + alt + the key passed in. By
    * default, the menu shortcut is the ctrl key (hence the method name), but
    * platforms might use a different key (like the Apple key on OSX).
    *


### PR DESCRIPTION
 **Disclaimer:** The original intent of this pull request was to move the "Manage Libraries..." item to the Tools Menu". The original text is available below.

This pull request adds the Menu+Shift+I shortcut for easy acess to the Library Manager, thus fixing #6335

It also adds the "Manage Libraries..." item to be available in the Tools menu, while also keeping the old entry.

The result can be seem in the last image of the original text.

------ 

Original:

~Description from the commit message:~
>It's easier to access it there
>
>Also, a shortcut was added to it: <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>O</kbd>
>
>  My original plan was for it to be "Control + Shift + K", but for some
>reason it doesn't work on Xubuntu 17.04

This is my attempt at fixing #6335

If you think changing menu location is too big of a change, I can close this pull request and open a new one that only adds the shortcut.

Before:\
![image](https://user-images.githubusercontent.com/4926869/29489489-96e0c0de-84f8-11e7-8d72-fcb64065f115.png)

Now:\
![image](https://user-images.githubusercontent.com/4926869/29489474-5d79a18a-84f8-11e7-97c7-b25f9eacd53b.png)

