### PR TITLE
Add proper handling of ADMUXA and ADMUXB for Attiny 841 and Attiny 441

### DIFF
--- a/hardware/arduino/avr/cores/arduino/wiring_analog.c
+++ b/hardware/arduino/avr/cores/arduino/wiring_analog.c
@@ -69,6 +69,9 @@ int analogRead(uint8_t pin)
 #else
 	ADMUX = (analog_reference << 6) | (pin & 0x07);
 #endif
+#elif defined(ADMUXA)
+        ADMUXA = (pin & 0x07);
+        ADMUXB = (analog_reference << 5);
 #endif
 
 	// without a delay, we seem to read from the wrong channel


### PR DESCRIPTION
Attiny841/44 with 12+5 ADCs use ADMUXA and ADMUXB instead of ADMUX to select analog reference and channel. Just look at hardware/tools/avr/avr/include/avr/iotn841.h and hardware/tools/avr/avr/include/avr/iotn441.h.

With this change ADMUXA and ADMUXB is properly initialized to make ADC usable, tested with Attiny841, thanks @awatterott for the hint.