### PR TITLE
Add an issue template that is a reminder to read the Contributing Rules

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,1 @@
+Read the Issues section of the Contributing Rules at the "contributing guidelines" link above before submitting an issue report.


### PR DESCRIPTION
GitHub's note to read CONTRIBUTING.md during the issue creation process is a bit too easy to ignore. The text of the ISSUE_TEMPLATE.md file is added directly to the issue body text input field, making this note impossible to miss. It is hoped this will increase compliance with the [Contributing Rules](https://github.com/arduino/Arduino/blob/master/CONTRIBUTING.md).

A similar template could be added for pull requests but it's not clear whether contributing rules non-compliance of pull requests is a significant problem here.