### PR TITLE
Various menus improvements

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1399,7 +1399,7 @@ public class Base {
     // The first custom menu is the "Board" selection submenu
     JMenu boardMenu = new JMenu(tr("Board"));
     boardMenu.putClientProperty("removeOnWindowDeactivation", true);
-    MenuScroller.setScrollerFor(boardMenu);
+    MenuScroller.setScrollerFor(boardMenu).setTopFixedCount(1);
 
     boardMenu.add(new JMenuItem(new AbstractAction(tr("Boards Manager...")) {
       public void actionPerformed(ActionEvent actionevent) {

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -769,6 +769,7 @@ public class Editor extends JFrame implements RunnerListener {
 
     base.rebuildProgrammerMenu();
     programmersMenu = new JMenu(tr("Programmer"));
+    MenuScroller.setScrollerFor(programmersMenu);
     base.getProgrammerMenus().stream().forEach(programmersMenu::add);
     toolsMenu.add(programmersMenu);
 

--- a/app/src/processing/app/tools/MenuScroller.java
+++ b/app/src/processing/app/tools/MenuScroller.java
@@ -13,6 +13,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
+import java.awt.event.KeyEvent;
 
 /**
  * A class that provides scrolling capabilities to a long menu dropdown or
@@ -40,6 +41,7 @@ public class MenuScroller {
   private int bottomFixedCount;
   private int firstIndex = 0;
   private int keepVisibleIndex = -1;
+  private int accelerator = 1;
 
   /**
    * Registers a menu to be scrolled with the default number of items to
@@ -293,6 +295,25 @@ public class MenuScroller {
     this.menu = menu;
     menu.addPopupMenuListener(menuListener);
     menu.addMouseWheelListener(mouseWheelListener);
+
+    ActionListener accel = new ActionListener() {
+      @Override
+        public void actionPerformed(ActionEvent e) {
+          accelerator = 6;
+      }
+    };
+
+    ActionListener decel = new ActionListener() {
+      @Override
+        public void actionPerformed(ActionEvent e) {
+          accelerator = 1;
+      }
+    };
+
+    KeyStroke keystroke_accel = KeyStroke.getKeyStroke(KeyEvent.VK_A, 0, false);
+    KeyStroke keystroke_decel = KeyStroke.getKeyStroke(KeyEvent.VK_A, 0, true);
+    menu.registerKeyboardAction(accel, "accel", keystroke_accel, JComponent.WHEN_IN_FOCUSED_WINDOW);
+    menu.registerKeyboardAction(decel, "decel", keystroke_decel, JComponent.WHEN_IN_FOCUSED_WINDOW);
   }
 
   /**
@@ -492,7 +513,7 @@ public class MenuScroller {
 
   private class MouseScrollListener implements MouseWheelListener {
     public void mouseWheelMoved(MouseWheelEvent mwe) {
-      firstIndex += mwe.getWheelRotation();
+      firstIndex += mwe.getWheelRotation() * accelerator;
       refreshMenu();
       mwe.consume();
     }
@@ -544,7 +565,7 @@ public class MenuScroller {
 
         @Override
         public void actionPerformed(ActionEvent e) {
-          firstIndex += increment;
+          firstIndex += increment * accelerator;
           refreshMenu();
         }
       });


### PR DESCRIPTION
This PR addresses some issues I encountered when dealing with lots of boards entries.

1 - Keep Board Manager entry fixed on top of Boards menu
2 - Make programmers menu scrollable (like https://github.com/arduino/Arduino/pull/6411)
3 - Add an accelerator key to scroll any MenuScroller faster. The key is "A"; keeping it pressed makes the scroll 6 times faster. 
Both keymap and scroll speedup can be changed if needed @00alis  