### PR TITLE
Updated with Functionality to configure Hostname in Sketch

### DIFF
--- a/libraries/Ethernet/examples/DhcpHostName/DhcpHostName.ino
+++ b/libraries/Ethernet/examples/DhcpHostName/DhcpHostName.ino
@@ -1,0 +1,74 @@
+/*
+  DHCP-based IP printer
+
+ This sketch uses the DHCP extensions to the Ethernet library
+ to get an IP address via DHCP and print the address obtained.
+ using an Arduino Wiznet Ethernet shield.
+
+ Circuit:
+ * Ethernet shield attached to pins 10, 11, 12, 13
+
+ created 12 April 2011
+ modified 9 Apr 2012
+ by Tom Igoe
+
+ Modified by Sudheer Thimmaiya 
+ Updated on 15 Sept 2017
+ Set DHCP Host Name:
+ char SetHostName[] = "HOSTNAMEUINO";
+ Ethernet.hostName(SetHostName);
+ Print Host Name:
+ Serial.println(Ethernet.getHostName());   
+ */
+
+#include <SPI.h>
+#include <Ethernet.h>
+
+// Enter a MAC address for your controller below.
+// Newer Ethernet shields have a MAC address printed on a sticker on the shield
+byte mac[] = {
+  0x00, 0xAA, 0xBB, 0xCC, 0xDE, 0x02
+};
+
+// Host Name MAX 12 Characters
+char SetHostName[] = "HOSTNAMEUINO";
+
+// Initialize the Ethernet client library
+// with the IP address and port of the server
+// that you want to connect to (port 80 is default for HTTP):
+EthernetClient client;
+
+void setup() {
+   // Open serial communications and wait for port to open:
+  Serial.begin(9600);
+  // this check is only needed on the Leonardo:
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for Leonardo only
+  }
+
+  // Set DHCP Host Name - New Feature (Updated)
+  Ethernet.hostName(SetHostName);
+ // start the Ethernet connection:
+  if (Ethernet.begin(mac) == 0) {
+    Serial.println("Failed to configure Ethernet using DHCP");
+    // no point in carrying on, so do nothing forevermore:
+    for (;;)
+      ;
+  }
+  // print your local IP address:
+  Serial.print("My IP address: ");
+  for (byte thisByte = 0; thisByte < 4; thisByte++) {
+    // print the value of each byte of the IP address:
+    Serial.print(Ethernet.localIP()[thisByte], DEC);
+    Serial.print(".");
+  }
+  Serial.println();
+  Serial.print("Host Name: ");
+  Serial.print(Ethernet.getHostName());
+}
+
+void loop() {
+
+}
+
+

--- a/libraries/Ethernet/src/Dhcp.cpp
+++ b/libraries/Ethernet/src/Dhcp.cpp
@@ -9,6 +9,12 @@
 #include "Arduino.h"
 #include "utility/util.h"
 
+char HOST_NAME[12] = "WIZNet";
+
+void DhcpClass::setHostName(char *dhcpHost) {
+	strcpy(HOST_NAME, dhcpHost);
+}
+//
 int DhcpClass::beginWithDHCP(uint8_t *mac, unsigned long timeout, unsigned long responseTimeout)
 {
     _dhcpLeaseTime=0;
@@ -203,6 +209,8 @@ void DhcpClass::send_DHCP_MESSAGE(uint8_t messageType, uint16_t secondsElapsed)
     memcpy(buffer + 10, _dhcpMacAddr, 6);
 
     // OPT - host name
+	if (strcmp ("WIZNet",HOST_NAME) == 0)  // If Default Host Name.
+	{
     buffer[16] = hostName;
     buffer[17] = strlen(HOST_NAME) + 6; // length of hostname + last 3 bytes of mac address
     strcpy((char*)&(buffer[18]), HOST_NAME);
@@ -210,8 +218,15 @@ void DhcpClass::send_DHCP_MESSAGE(uint8_t messageType, uint16_t secondsElapsed)
     printByte((char*)&(buffer[24]), _dhcpMacAddr[3]);
     printByte((char*)&(buffer[26]), _dhcpMacAddr[4]);
     printByte((char*)&(buffer[28]), _dhcpMacAddr[5]);
-
-    //put data in W5100 transmit buffer
+	}
+	else
+	{
+		buffer[16] = hostName;
+		buffer[17] = strlen(HOST_NAME); // length of hostname + last 3 bytes of mac address
+		strcpy((char*)&(buffer[18]), HOST_NAME);
+	}
+	
+   //put data in W5100 transmit buffer
     _dhcpUdpSocket.write(buffer, 30);
 
     if(messageType == DHCP_REQUEST)
@@ -457,6 +472,11 @@ IPAddress DhcpClass::getDhcpServerIp()
 IPAddress DhcpClass::getDnsServerIp()
 {
     return IPAddress(_dhcpDnsServerIp);
+}
+
+//Get Host Name.
+char * DhcpClass::getHostName() {
+	return HOST_NAME;
 }
 
 void DhcpClass::printByte(char * buf, uint8_t n ) {

--- a/libraries/Ethernet/src/Dhcp.h
+++ b/libraries/Ethernet/src/Dhcp.h
@@ -44,7 +44,7 @@
 #define MAGIC_COOKIE		0x63825363
 #define MAX_DHCP_OPT	16
 
-#define HOST_NAME "WIZnet"
+//#define HOST_NAME "WIZnet"  // Commented Modififed by Sudheer Thimmaiya
 #define DEFAULT_LEASE	(900) //default lease time in seconds
 
 #define DHCP_CHECK_NONE         (0)
@@ -172,6 +172,9 @@ public:
   
   int beginWithDHCP(uint8_t *, unsigned long timeout = 60000, unsigned long responseTimeout = 4000);
   int checkLease();
+  //
+  void setHostName(char *);
+  char * getHostName();
 };
 
 #endif

--- a/libraries/Ethernet/src/Ethernet.cpp
+++ b/libraries/Ethernet/src/Ethernet.cpp
@@ -8,6 +8,12 @@ uint8_t EthernetClass::_state[MAX_SOCK_NUM] = {
 uint16_t EthernetClass::_server_port[MAX_SOCK_NUM] = { 
   0, 0, 0, 0 };
 
+//DHCP Set Host Name.
+void EthernetClass::hostName(char *dhcp_HostName){
+	_dhcp->setHostName(dhcp_HostName);
+}
+
+
 int EthernetClass::begin(uint8_t *mac_address, unsigned long timeout, unsigned long responseTimeout)
 {
   static DhcpClass s_dhcp;
@@ -133,4 +139,10 @@ IPAddress EthernetClass::dnsServerIP()
   return _dnsServerAddress;
 }
 
+char *EthernetClass::getHostName()
+{
+	char *_getDhcpHostName = _dhcp ->getHostName();
+	return _getDhcpHostName;
+}
+//
 EthernetClass Ethernet;

--- a/libraries/Ethernet/src/Ethernet.h
+++ b/libraries/Ethernet/src/Ethernet.h
@@ -27,6 +27,9 @@ public:
   void begin(uint8_t *mac_address, IPAddress local_ip, IPAddress dns_server, IPAddress gateway, IPAddress subnet);
   int maintain();
 
+  void hostName(char *dhcp_HostName);
+  char* getHostName();
+
   IPAddress localIP();
   IPAddress subnetMask();
   IPAddress gatewayIP();


### PR DESCRIPTION
Updated with Functionality to configure Host name in sktech.
When Host name is not set, it defaults to "WIZNet"
Max Host Name size, 12 characters, buffer for WIZNet + MAC Address was used for setting Host Name
Added Example sketch for setting Host Name.

Thank You
Sudheer
