### PR TITLE
[IDE] Translation-related corrections

### DIFF
--- a/app/src/cc/arduino/i18n/Languages.java
+++ b/app/src/cc/arduino/i18n/Languages.java
@@ -102,7 +102,7 @@ public class Languages {
       new Language(tr("Telugu"), "తెలుగు", "te"),
       new Language(tr("Thai"), "ภาษาไทย", "th"),
       new Language(tr("Turkish"), "Türk", "tr"),
-      new Language(tr("Ukrainian"), "Український", "uk"),
+      new Language(tr("Ukrainian"), "Українська", "uk"),
       new Language(tr("Vietnamese"), "Tiếng Việt", "vi"),
       new Language(tr("Western Frisian"), "Western Frisian", "fy")
     };

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1103,7 +1103,7 @@ public class Base {
             importMenu.addSeparator();
           }
           lastLibType = lib.getTypes().get(0);
-          JMenuItem platformItem = new JMenuItem(I18n.format(tr("{0} libraries"), lastLibType));
+          JMenuItem platformItem = new JMenuItem(I18n.format(tr("{0} libraries"), tr(lastLibType)));
           platformItem.setEnabled(false);
           importMenu.add(platformItem);
         }


### PR DESCRIPTION
1. In menu Sketch / Include Library: library types (Arduino|Recommended|Contributed…) are not translated into selected «Editor language» although the types are translated in .po files. Variable `lastLibType` was not wrapped by `tr()` function.
2. In Preferences dialogue, Editor language drop-down list: incorrect grammatical gender for Ukrainian in Ukrainian (Українськ*ий* but must be Українськ*а*, see [Ukrainian language](https://en.wikipedia.org/wiki/Ukrainian_language) preamble).