### PR TITLE
Auto format : indent namespaces by default

### DIFF
--- a/build/shared/lib/formatter.conf
+++ b/build/shared/lib/formatter.conf
@@ -18,6 +18,7 @@ indent-classes
 indent-switches
 indent-cases
 indent-col1-comments
+indent-namespaces
 
 # put a space around operators
 pad-oper


### PR DESCRIPTION
IMO, namespaces should be indented by default. It would be interesting to see if it was decided (per some guideline) not to indent namespaces or if it was just forgotten.

closes #6812 