### PR TITLE
Update Editor.java

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -1375,7 +1375,7 @@ public class Editor extends JFrame implements RunnerListener {
 
     menu.addSeparator();
 
-    JMenuItem increaseFontSizeItem = newJMenuItem(tr("Increase Font Size"), '+');
+    JMenuItem increaseFontSizeItem = newJMenuItem(tr("Increase Font Size"), KeyEvent.VK_PLUS);
     increaseFontSizeItem.addActionListener(new ActionListener() {
         public void actionPerformed(ActionEvent e) {
           base.handleFontSizeChange(1);
@@ -1383,7 +1383,7 @@ public class Editor extends JFrame implements RunnerListener {
     });
     menu.add(increaseFontSizeItem);
 
-    JMenuItem decreaseFontSizeItem = newJMenuItem(tr("Decrease Font Size"), '-');
+    JMenuItem decreaseFontSizeItem = newJMenuItem(tr("Decrease Font Size"), KeyEvent.VK_MINUS);
     decreaseFontSizeItem.addActionListener(new ActionListener() {
         public void actionPerformed(ActionEvent e) {
           base.handleFontSizeChange(-1);


### PR DESCRIPTION
changed literal char values '+' and '-' in newJMenuItem(...) to symbolic constants KeyEvent.VK_PLUS and KeyEvent.VK_MINUS

Literal char value '+' produced "Ctrl+Unknown keyCode 0x2b" output for the accelerator in the menu entry and defunct keybinding running on Ubuntu 16.04.
Both issues are fixed exchanging '+' with VK_PLUS.

Literale char value '-' worked as expected, nevertheless changing to symbolic constant VK_MINUS seems to be a good idea.