### PR TITLE
UnConfigured I2C Slave ISR Causing Reboot

### DIFF
--- a/hardware/arduino/avr/libraries/Wire/src/Wire.cpp
+++ b/hardware/arduino/avr/libraries/Wire/src/Wire.cpp
@@ -17,6 +17,7 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  
   Modified 2012 by Todd Krein (todd@krein.org) to implement repeated starts
+  Modified 2017 by Chuck Todd (ctodd@cableone.net) to correct Unconfigured Slave Mode reboot
 */
 
 extern "C" {
@@ -60,14 +61,14 @@ void TwoWire::begin(void)
   txBufferLength = 0;
 
   twi_init();
+  twi_attachSlaveTxEvent(onRequestService); // default callback must exist
+  twi_attachSlaveRxEvent(onReceiveService); // default callback must exist
 }
 
 void TwoWire::begin(uint8_t address)
 {
-  twi_setAddress(address);
-  twi_attachSlaveTxEvent(onRequestService);
-  twi_attachSlaveRxEvent(onReceiveService);
   begin();
+  twi_setAddress(address);
 }
 
 void TwoWire::begin(int address)


### PR DESCRIPTION
In a MultiMaster I2C environment, The Default value of 0xFE in the TWAR cause the Arduino to respond as an I2C Slave device at address 0x7f.  If the Wire.h library was not configured as a I2C Slave, `Wire.begin(slaveID);` the Callbacks for `twi_onSlaveTransmit()` and `twi_onSlaveReceive()` are never initialized. 
But, they are called during servicing the TWI ISR.  This causes a reboot of the Arduino by jumping to an uninitialized function address (0).
So, this fix initializes them to the Default Wire.h handler which will respond correctly even during Master Mode operations.
A MASTER MODE only Arduino will respond to all Slave Calls that match TWAR, Unless the TWEA bit is disabled outside of Master Transactions.
Chuck.
It also initialized the TWAR to the General Call ID (0x0) and Disables General Call responses.

Chuck.