### PR TITLE
Fix buffer retransmission and flush hang problems in hardware serial support

### DIFF
--- a/hardware/arduino/avr/cores/arduino/HardwareSerial.cpp
+++ b/hardware/arduino/avr/cores/arduino/HardwareSerial.cpp
@@ -246,9 +246,14 @@ size_t HardwareSerial::write(uint8_t c)
   }
 
   _tx_buffer[_tx_buffer_head] = c;
-  _tx_buffer_head = i;
-	
-  sbi(*_ucsrb, UDRIE0);
+
+  // make atomic to prevent execution of ISR between setting the
+  // head pointer and setting the interrupt flag resulting in buffer
+  // retransmission
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+    _tx_buffer_head = i;
+    sbi(*_ucsrb, UDRIE0);
+  }
   
   return 1;
 }

--- a/hardware/arduino/avr/cores/arduino/HardwareSerial.cpp
+++ b/hardware/arduino/avr/cores/arduino/HardwareSerial.cpp
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <inttypes.h>
+#include <util/atomic.h>
 #include "Arduino.h"
 
 #include "HardwareSerial.h"
@@ -75,6 +76,13 @@ void serialEventRun(void)
   if (Serial3_available && serialEvent3 && Serial3_available()) serialEvent3();
 #endif
 }
+
+// macro to guard critical sections when needed for large TX buffer sizes
+#if (SERIAL_TX_BUFFER_SIZE>256)
+#define TX_BUFFER_ATOMIC ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
+#else
+#define TX_BUFFER_ATOMIC
+#endif
 
 // Actual interrupt handlers //////////////////////////////////////////////////////////////
 
@@ -177,15 +185,13 @@ int HardwareSerial::read(void)
 
 int HardwareSerial::availableForWrite(void)
 {
-#if (SERIAL_TX_BUFFER_SIZE>256)
-  uint8_t oldSREG = SREG;
-  cli();
-#endif
-  tx_buffer_index_t head = _tx_buffer_head;
-  tx_buffer_index_t tail = _tx_buffer_tail;
-#if (SERIAL_TX_BUFFER_SIZE>256)
-  SREG = oldSREG;
-#endif
+  tx_buffer_index_t head;
+  tx_buffer_index_t tail;
+
+  TX_BUFFER_ATOMIC {
+    head = _tx_buffer_head;
+    tail = _tx_buffer_tail;
+  }
   if (head >= tail) return SERIAL_TX_BUFFER_SIZE - 1 - head + tail;
   return tail - head - 1;
 }


### PR DESCRIPTION
Fixes #3745 fixes #6821 

Based on #3865 by @NicoHood and suggestions from @matthijskooijman 

Fixes two separate issues both discussed in #3745: serial buffer re-transmissions under heavy interrupt load and flush hangs at high baud rates. Tested with testcase for the buffer transmission problem and @NicoHood's testcase for the flush hang problem as posted in #3745 with both default buffer size and large buffer size (512 bytes) on Arduino Mega.

Also incorporates suggestions from @matthijskooijman:
1. use the ATOMIC_BLOCK macro for guards around critical sections
2. create macro TX_BUFFER_ATOMIC for guards required only for large buffer
3. improve how the TXC bit is cleared to preserve configuration bits and avoid
setting read-only bits in the USCRnA register


