### PR TITLE
Use const pointers in Stream::find() and Stream::findUntil()

### DIFF
--- a/hardware/arduino/avr/cores/arduino/Stream.cpp
+++ b/hardware/arduino/avr/cores/arduino/Stream.cpp
@@ -90,20 +90,20 @@ void Stream::setTimeout(unsigned long timeout)  // sets the maximum number of mi
 }
 
  // find returns true if the target string is found
-bool  Stream::find(char *target)
+bool  Stream::find(const char *target)
 {
   return findUntil(target, strlen(target), NULL, 0);
 }
 
 // reads data from the stream until the target string of given length is found
 // returns true if target string is found, false if timed out
-bool Stream::find(char *target, size_t length)
+bool Stream::find(const char *target, size_t length)
 {
   return findUntil(target, length, NULL, 0);
 }
 
 // as find but search ends if the terminator string is found
-bool  Stream::findUntil(char *target, char *terminator)
+bool  Stream::findUntil(const char *target, const char *terminator)
 {
   return findUntil(target, strlen(target), terminator, strlen(terminator));
 }
@@ -111,7 +111,7 @@ bool  Stream::findUntil(char *target, char *terminator)
 // reads data from the stream until the target string of the given length is found
 // search terminated if the terminator string is found
 // returns true if target string is found, false if terminated or timed out
-bool Stream::findUntil(char *target, size_t targetLen, char *terminator, size_t termLen)
+bool Stream::findUntil(const char *target, size_t targetLen, const char *terminator, size_t termLen)
 {
   if (terminator == NULL) {
     MultiTarget t[1] = {{target, targetLen, 0}};

--- a/hardware/arduino/avr/cores/arduino/Stream.h
+++ b/hardware/arduino/avr/cores/arduino/Stream.h
@@ -67,21 +67,21 @@ class Stream : public Print
   void setTimeout(unsigned long timeout);  // sets maximum milliseconds to wait for stream data, default is 1 second
   unsigned long getTimeout(void) { return _timeout; }
   
-  bool find(char *target);   // reads data from the stream until the target string is found
-  bool find(uint8_t *target) { return find ((char *)target); }
+  bool find(const char *target);   // reads data from the stream until the target string is found
+  bool find(const uint8_t *target) { return find ((const char *)target); }
   // returns true if target string is found, false if timed out (see setTimeout)
 
-  bool find(char *target, size_t length);   // reads data from the stream until the target string of given length is found
-  bool find(uint8_t *target, size_t length) { return find ((char *)target, length); }
+  bool find(const char *target, size_t length);   // reads data from the stream until the target string of given length is found
+  bool find(const uint8_t *target, size_t length) { return find ((const char *)target, length); }
   // returns true if target string is found, false if timed out
 
   bool find(char target) { return find (&target, 1); }
 
-  bool findUntil(char *target, char *terminator);   // as find but search ends if the terminator string is found
-  bool findUntil(uint8_t *target, char *terminator) { return findUntil((char *)target, terminator); }
+  bool findUntil(const char *target, const char *terminator);   // as find but search ends if the terminator string is found
+  bool findUntil(const uint8_t *target, const char *terminator) { return findUntil((const char *)target, terminator); }
 
-  bool findUntil(char *target, size_t targetLen, char *terminate, size_t termLen);   // as above but search ends if the terminate string is found
-  bool findUntil(uint8_t *target, size_t targetLen, char *terminate, size_t termLen) {return findUntil((char *)target, targetLen, terminate, termLen); }
+  bool findUntil(const char *target, size_t targetLen, const char *terminate, size_t termLen);   // as above but search ends if the terminate string is found
+  bool findUntil(const uint8_t *target, size_t targetLen, const char *terminate, size_t termLen) {return findUntil((const char *)target, targetLen, terminate, termLen); }
 
   long parseInt(LookaheadMode lookahead = SKIP_ALL, char ignore = NO_IGNORE_CHAR);
   // returns the first valid (long) integer value from the current position.


### PR DESCRIPTION
Changed the signatures of `Stream::find()` and `Stream::findUntil()` to take const pointers, as they don't change the target.

| Old signature | New signature |
|----|---|
| `find(char *target)` | `find(const char *target)` |
| `findUntil(char *target, char *terminator)` | `findUntil(const char *target, const char *terminator)` |

All the overloads have been changed accordingly.

This should not cause any code to break.