### PR TITLE
Add USBDevice.isSuspended()

### DIFF
--- a/hardware/arduino/avr/cores/arduino/USBAPI.h
+++ b/hardware/arduino/avr/cores/arduino/USBAPI.h
@@ -65,6 +65,8 @@ public:
 	void detach();	// Serial port goes down too...
 	void poll();
 	bool wakeupHost(); // returns false, when wakeup cannot be processed
+
+	bool isSuspended();
 };
 extern USBDevice_ USBDevice;
 

--- a/hardware/arduino/avr/cores/arduino/USBCore.cpp
+++ b/hardware/arduino/avr/cores/arduino/USBCore.cpp
@@ -862,4 +862,10 @@ bool USBDevice_::wakeupHost()
 	return false;
 }
 
+bool USBDevice_::isSuspended()
+{
+	return (_usbSuspendState & (1 << SUSPI));
+}
+
+
 #endif /* if defined(USBCON) */


### PR DESCRIPTION
This is based on #4241, with only `USBDevice.isSuspended()` picked out, and rebased on top of master. In my tests, the callbacks (especially the wakeup callback) weren't reliably usable, but I could make things work with using `isSuspended()` in my `loop()`.

Having this - or something like it - in Arduino core would be awesome. I have a few devices where I need to be able to run custom code on suspend & wakeup, and this allows me to do just that.