### PR TITLE
Let serial monitor send newline by default

### DIFF
--- a/build/shared/lib/preferences.txt
+++ b/build/shared/lib/preferences.txt
@@ -272,6 +272,7 @@ serial.databits=8
 serial.stopbits=1
 serial.parity=N
 serial.debug_rate=9600
+serial.line_ending=1
 
 # I18 Preferences
 


### PR DESCRIPTION
The serial.line_ending value was not present in the default
preferences file, so the default was implicitly 0, meaning "No line
ending". Since users often do not realize that they can even choose a
line ending, and "no line ending" is only rarely useful, it seems better
to default to sending a newline. Using both CR & NL would be more
consistent with Stream.println on the Arduino side, but just sending a
newline is probably easier to parse on the Arduino side.