### PR TITLE
[IDE] Add support for user-defined theme in sketchbook folder

### DIFF
--- a/app/src/processing/app/EditorTab.java
+++ b/app/src/processing/app/EditorTab.java
@@ -58,6 +58,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.io.File;
 
+import org.apache.commons.lang3.StringUtils;
 import org.fife.ui.autocomplete.AutoCompletion;
 import org.fife.ui.autocomplete.DefaultCompletionProvider;
 import org.fife.ui.rsyntaxtextarea.RSyntaxDocument;
@@ -345,6 +346,20 @@ public class EditorTab extends JPanel implements SketchFile.TextStorage, MouseWh
     }
     // apply changes to the font size for the editor
     Font editorFont = scale(PreferencesData.getFont("editor.font"));
+    
+    // check whether a theme-defined editor font is available
+    Font themeFont = Theme.getFont("editor.font");
+    if (themeFont != null)
+    {
+      // Apply theme font if the editor font has *not* been changed by the user,
+      // This allows themes to specify an editor font which will only be applied
+      // if the user hasn't already changed their editor font via preferences.txt
+      String defaultFontName = StringUtils.defaultIfEmpty(PreferencesData.getDefault("editor.font"), "").split(",")[0];
+      if (defaultFontName.equals(editorFont.getName())) {
+        editorFont = new Font(themeFont.getName(), themeFont.getStyle(), editorFont.getSize());
+      }
+    }
+    
     textarea.setFont(editorFont);
     scrollPane.getGutter().setLineNumberFont(editorFont);
   }

--- a/app/src/processing/app/forms/PasswordAuthorizationDialog.java
+++ b/app/src/processing/app/forms/PasswordAuthorizationDialog.java
@@ -1,12 +1,12 @@
 package processing.app.forms;
 
 import processing.app.Base;
+import processing.app.Theme;
 
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.WindowEvent;
-import java.io.File;
 
 import static processing.app.I18n.tr;
 
@@ -34,7 +34,7 @@ public class PasswordAuthorizationDialog extends JDialog {
 
     typePasswordLabel.setText(dialogText);
 
-    icon.setIcon(new ImageIcon(new File(Base.getContentFile("lib"), "theme/lock.png").getAbsolutePath()));
+    icon.setIcon(new ImageIcon(Theme.getThemeFile("theme/lock.png").getAbsolutePath()));
 
     passwordLabel.setText(tr("Password:"));
 

--- a/app/src/processing/app/syntax/SketchTextArea.java
+++ b/app/src/processing/app/syntax/SketchTextArea.java
@@ -110,7 +110,7 @@ public class SketchTextArea extends RSyntaxTextArea {
   private void setTheme(String name) throws IOException {
     FileInputStream defaultXmlInputStream = null;
     try {
-      defaultXmlInputStream = new FileInputStream(new File(BaseNoGui.getContentFile("lib"), "theme/syntax/" + name + ".xml"));
+      defaultXmlInputStream = new FileInputStream(processing.app.Theme.getThemeFile("theme/syntax/" + name + ".xml"));
       Theme theme = Theme.load(defaultXmlInputStream);
       theme.apply(this);
     } finally {


### PR DESCRIPTION
### Summary

This pull request provides a small enhancement to the way themes are handled within the IDE, providing support for a user-defined `theme` folder placed in the sketchbook folder to override elements in the internal `theme` folder.

### Description

This small change provides the following features:

* Allows user-defined theme changes to be persisted across IDE versions, in particular if the user only wishes to customise a single element of the IDE this becomes much easier, example below.
* Correspondingly, provides a possible fix for #7013 
* Makes it possible for third parties to provide prepackaged themes which can be installed without needing to overwrite the original theme resources in the application directory. *(Possible enhancement, support prepackaged themes in a zip file in the same location, such as `<sketchbook>/theme/theme.zip`. I'd be happy to add this if there's any interest.)*
* Normally theme image resources are preferentially selected `.svg` first and `.png` otherwise. This PR preserves this relationship *within* a theme type, but a `.png` resource in a user-defined theme can still override an `.svg` resource in the default theme.
* Resources which normally reside in the `lib` folder directly are first checked in the user-defined theme folder, 
* Themes can specify the `editor.font` property if a user-defined theme wishes to customise the font, however the custom font is *not* applied if the user has already defined a non-standard font in their `preferences.txt`. This is intended so that third-party theme designers can specify an editor font as part of their theme but previous user preferences will still take precedence.

### Examples

* Installing [this dark theme](https://github.com/jeffThompson/DarkArduinoTheme) can be achieved by downloading or cloning the repo and simply placing the `theme` folder inside the arduino sketch folder:
  
  ![Jeff Thompson's Dark Theme](http://eq2.co.uk/pr/arduino/dark.png)

* Simple customisations can be applied on top of the default theme by creating a `theme.txt` with only the required customised settings. For example this barebones `theme.txt`:
  
  ```php
  # editor font - only overrides if not configured by user in preferences.txt
  editor.font = Consolas,plain,12
  
  # foreground and background colors
  editor.fgcolor = #000000
  editor.bgcolor = #c5edee
  
  # TEXT - COMMENTS
  editor.comment1.style = #990000,plain
  editor.comment2.style = #990000,plain
  ```
  
  Results in the following customised theme output:
  
  ![Minimal customisation example](http://eq2.co.uk/pr/arduino/simple.png)
  
  This is intended to provide users with a simple way to customise only a few theme elements (eg. comment colour) without needing to take a kitchen sink approach or have to continually re-apply their specific settings when upgrading to new versions of the IDE.

### Notes

* This is my first pull request to your repo, so I apologise in advance if I have inadvertently violated any style guidelines and will happily rectify any issues. I did consult the contribution guidelines before submitting this PR.
* I have submitted this against 1.9-beta but if you would like a submission against `master` for integration in 1.8.6 then I'm happy to do that, though I assumed that since this is a mainly cosmetic piece of functionality that the beta would be a more sensible target.
* If this PR is the kind of thing you're looking for, I would be happy to work on an integrated or external theme editor of some kind which would allow users to design and customise their own themes more easily.

Thanks for your time and consideration.