### PR TITLE
Select (first) target board when port is selected and has known board

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -109,6 +109,8 @@ public class Base {
   //  int editorCount;
   List<Editor> editors = Collections.synchronizedList(new ArrayList<Editor>());
   Editor activeEditor;
+  
+  private static JMenu boardMenu;
 
   // these menus are shared so that the board and serial port selections
   // are the same for all windows (since the board and serial port that are
@@ -1312,6 +1314,28 @@ public class Base {
 
   private static String priorPlatformFolder;
   private static boolean newLibraryImported;
+  
+  public void selectTargetBoard(TargetBoard targetBoard) {
+    for (int i = 0; i < boardMenu.getItemCount(); i++) {
+      JMenuItem menuItem = boardMenu.getItem(i);
+      if (!(menuItem instanceof JRadioButtonMenuItem)) {
+        continue;
+      }
+      
+      JRadioButtonMenuItem radioButtonMenuItem = ((JRadioButtonMenuItem) menuItem);
+      if (targetBoard.getName().equals(radioButtonMenuItem.getText())) {
+        radioButtonMenuItem.setSelected(true);
+        break;
+      }
+    }
+    
+    BaseNoGui.selectBoard(targetBoard);
+    filterVisibilityOfSubsequentBoardMenus(boardsCustomMenus, targetBoard, 1);
+  
+    onBoardOrPortChange();
+    rebuildImportMenu(Editor.importMenu);
+    rebuildExamplesMenu(Editor.examplesMenu);
+  }
 
   public void onBoardOrPortChange() {
     BaseNoGui.onBoardOrPortChange();
@@ -1406,7 +1430,7 @@ public class Base {
     boardsCustomMenus = new LinkedList<>();
 
     // The first custom menu is the "Board" selection submenu
-    JMenu boardMenu = new JMenu(tr("Board"));
+    boardMenu = new JMenu(tr("Board"));
     boardMenu.putClientProperty("removeOnWindowDeactivation", true);
     MenuScroller.setScrollerFor(boardMenu).setTopFixedCount(1);
 
@@ -1512,12 +1536,7 @@ public class Base {
     @SuppressWarnings("serial")
     Action action = new AbstractAction(board.getName()) {
       public void actionPerformed(ActionEvent actionevent) {
-        BaseNoGui.selectBoard((TargetBoard) getValue("b"));
-        filterVisibilityOfSubsequentBoardMenus(boardsCustomMenus, (TargetBoard) getValue("b"), 1);
-
-        onBoardOrPortChange();
-        rebuildImportMenu(Editor.importMenu);
-        rebuildExamplesMenu(Editor.examplesMenu);
+        selectTargetBoard((TargetBoard) getValue("b"));
       }
     };
     action.putValue("b", board);

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -33,6 +33,9 @@ import cc.arduino.CompilerProgressListener;
 import com.jcraft.jsch.JSchException;
 import jssc.SerialPortException;
 import processing.app.debug.RunnerException;
+import processing.app.debug.TargetBoard;
+import processing.app.debug.TargetPackage;
+import processing.app.debug.TargetPlatform;
 import processing.app.forms.PasswordAuthorizationDialog;
 import processing.app.helpers.DocumentTextChangeListener;
 import processing.app.helpers.Keys;
@@ -1006,19 +1009,21 @@ public class Editor extends JFrame implements RunnerListener {
   class SerialMenuListener implements ActionListener {
 
     private final String serialPort;
+    private final String boardId;
 
-    public SerialMenuListener(String serialPort) {
+    public SerialMenuListener(String serialPort, String boardId) {
       this.serialPort = serialPort;
+      this.boardId = boardId;
     }
 
     public void actionPerformed(ActionEvent e) {
-      selectSerialPort(serialPort);
+      selectSerialPort(serialPort, boardId);
       base.onBoardOrPortChange();
     }
 
   }
 
-  private void selectSerialPort(String name) {
+  private void selectSerialPort(String name, String boardId) {
     if(portMenu == null) {
       System.out.println(tr("serialMenu is null"));
       return;
@@ -1056,6 +1061,13 @@ public class Editor extends JFrame implements RunnerListener {
         serialPlotter.setVisible(false);
       } catch (Exception e) {
         // ignore
+      }
+    }
+    
+    if (boardId != null) {
+      TargetBoard targetBoard = BaseNoGui.getPlatform().resolveBoardById(BaseNoGui.packages, boardId);
+      if (targetBoard != null) {
+        base.selectTargetBoard(targetBoard);
       }
     }
 
@@ -1102,9 +1114,10 @@ public class Editor extends JFrame implements RunnerListener {
       }
       String address = port.getAddress();
       String label = port.getLabel();
+      String boardId = port.getBoardId();
 
       JCheckBoxMenuItem item = new JCheckBoxMenuItem(label, address.equals(selectedPort));
-      item.addActionListener(new SerialMenuListener(address));
+      item.addActionListener(new SerialMenuListener(address, boardId));
       portMenu.add(item);
     }
 
@@ -2111,7 +2124,7 @@ public class Editor extends JFrame implements RunnerListener {
      names,
      0);
     if (result == null) return false;
-    selectSerialPort(result);
+    selectSerialPort(result, null);
     base.onBoardOrPortChange();
     return true;
   }

--- a/arduino-core/src/cc/arduino/packages/BoardPort.java
+++ b/arduino-core/src/cc/arduino/packages/BoardPort.java
@@ -36,6 +36,7 @@ public class BoardPort {
   private String address;
   private String protocol;
   private String boardName;
+  private String boardId;
   private String vid;
   private String pid;
   private String iserial;
@@ -71,6 +72,14 @@ public class BoardPort {
     this.boardName = boardName;
   }
 
+  public String getBoardId() {
+    return boardId;
+  }
+
+  public void setBoardId(String boardId) {
+    this.boardId = boardId;
+  }
+  
   public PreferencesMap getPrefs() {
     return prefs;
   }

--- a/arduino-core/src/cc/arduino/packages/discoverers/NetworkDiscovery.java
+++ b/arduino-core/src/cc/arduino/packages/discoverers/NetworkDiscovery.java
@@ -124,6 +124,7 @@ public class NetworkDiscovery implements Discovery, ServiceListener {
 
       port.setAddress(address);
       port.setBoardName(name);
+      port.setBoardId(board);
       port.setProtocol("network");
       port.setLabel(label);
 

--- a/arduino-core/src/cc/arduino/packages/discoverers/serial/SerialBoardsLister.java
+++ b/arduino-core/src/cc/arduino/packages/discoverers/serial/SerialBoardsLister.java
@@ -155,6 +155,7 @@ public class SerialBoardsLister extends TimerTask {
             label += " (" + boardName + ")";
           }
           boardPort.setBoardName(boardName);
+          boardPort.setBoardId(board.getId());
         }
       } else {
         if (!parts[1].equals("0000")) {

--- a/arduino-core/src/processing/app/Platform.java
+++ b/arduino-core/src/processing/app/Platform.java
@@ -269,17 +269,25 @@ public class Platform {
     return null;
   }
 
-  public String resolveDeviceByBoardID(Map<String, TargetPackage> packages, String boardId) {
+  public TargetBoard resolveBoardById(Map<String, TargetPackage> packages, String boardId) {
     assert packages != null;
     assert boardId != null;
     for (TargetPackage targetPackage : packages.values()) {
       for (TargetPlatform targetPlatform : targetPackage.getPlatforms().values()) {
         for (TargetBoard board : targetPlatform.getBoards().values()) {
           if (boardId.equals(board.getId())) {
-            return board.getName();
+            return board;
           }
         }
       }
+    }
+    return null;
+  }
+
+  public String resolveDeviceByBoardID(Map<String, TargetPackage> packages, String boardId) {
+    TargetBoard targetBoard = resolveBoardById(packages, boardId);
+    if (targetBoard != null) {
+      return targetBoard.getName();
     }
     return null;
   }


### PR DESCRIPTION
Proposal to auto select the right target board type when a port is selected and we can identify the board via USB VID/PID.

This saves a menu click when switching between two connected boards. We could add a preference to enable this behaviour. cc/ @00alis