### PR TITLE
Added delete operators to comply with new gcc [C++17]

### DIFF
--- a/hardware/arduino/avr/cores/arduino/new.cpp
+++ b/hardware/arduino/avr/cores/arduino/new.cpp
@@ -34,3 +34,11 @@ void operator delete[](void * ptr) {
   free(ptr);
 }
 
+void operator delete(void * ptr, size_t) {
+  free(ptr);
+}
+
+void operator delete[](void * ptr, size_t) {
+  free(ptr);
+}
+

--- a/hardware/arduino/avr/cores/arduino/new.h
+++ b/hardware/arduino/avr/cores/arduino/new.h
@@ -25,6 +25,9 @@ void * operator new(size_t size);
 void * operator new[](size_t size);
 void operator delete(void * ptr);
 void operator delete[](void * ptr);
+void operator delete(void * ptr, size_t);
+void operator delete[](void * ptr, size_t);
+
 
 #endif
 


### PR DESCRIPTION
Earlier, when compiled with `-fsized-deallocation` warning enabled, this file caused problems. I also added `noexcept` specifier. Now it  compiles with gcc 7.2 and `-std=gnu++17` without problems.