### PR TITLE
Add StringView

### DIFF
--- a/hardware/arduino/avr/cores/arduino/StringView.cpp
+++ b/hardware/arduino/avr/cores/arduino/StringView.cpp
@@ -1,0 +1,190 @@
+// Written by Steve Weinrich 2018
+// This code is given freely and without restriction of any kind to the Arduino community
+
+#include <StringView.h>
+#include <ctype.h>
+#include <stdlib.h>
+
+StringView::StringView (const_pointer str)
+    : mData(str), mLength(strlen(str))
+{
+}
+
+StringView::StringView (StringView && rval)
+    : mData(rval.mData), mLength(rval.mLength)
+{
+    rval.mData   = nullptr;
+    rval.mLength = 0;
+}
+
+StringView & StringView::operator = (StringView && rval)
+{
+    mData   = rval.mData;
+    mLength = rval.mLength;
+
+    rval.mData   = nullptr;
+    rval.mLength = 0;
+
+    return *this;
+}
+
+int StringView::compareTo (StringView rhs) const
+{
+    if (length() < rhs.length())
+        return -1;
+    else if (length() > rhs.length())
+        return 1;
+    else
+        return memcmp(begin(), rhs.begin(), length());
+}
+
+bool StringView::equalsIgnoreCase (StringView rhs) const
+{
+    if (length() != rhs.length()) return false;
+    if (length() == 0) return true;
+
+    const_pointer p1 = begin();
+    const_pointer p2 = rhs.begin();
+
+    for (size_t i = 0; i < length(); ++i)
+        if (tolower(*p1++) != tolower(*p2++)) return false;
+
+    return true;
+}
+
+bool StringView::startsWith (StringView prefix, size_type offset) const
+{
+    if (!*this || !prefix || (offset > length() - prefix.length())) return false;
+    return 0 == memcmp(begin() + offset, prefix.begin(), prefix.length());
+}
+
+bool StringView::endsWith (StringView suffix) const
+{
+    if (!*this || !suffix || length() < suffix.length()) return false;
+    return 0 == memcmp(end() - suffix.length(), suffix.begin(), suffix.length());
+}
+
+StringView::value_type StringView::operator [] (size_t index) const
+{
+    if (index >= length()) return 0;
+    return begin()[index];
+}
+
+void StringView::getBytes (unsigned char * buf, size_t bufsize, size_t index) const
+{
+    if (!bufsize || !buf) return;
+
+    if (index >= length())
+    {
+        buf[0] = '\0';
+        return;
+    }
+
+    size_t n = bufsize - 1;
+    if (n > length() - index) n = length() - index;
+    memcpy(buf, begin() + index, n);
+    buf[n] = '\0';
+}
+
+int StringView::indexOf (value_type ch, size_type fromIndex) const
+{
+    if (fromIndex >= length()) return -1;
+
+    const_pointer r = memchr(begin() + fromIndex, ch, length() - fromIndex);
+    if (r == NULL) return -1;
+    return r - begin();
+}
+
+int StringView::indexOf (StringView str, size_type fromIndex) const
+{
+    if (!str || fromIndex >= length() || str.length() > length() - fromIndex) return -1;
+
+    const_pointer p1 = begin() + fromIndex;
+    for (size_t i = fromIndex; i < length() - fromIndex; ++i, ++p1)
+        if (0 == memcmp(p1, str.begin(), str.length())) return i;
+
+    return -1;
+}
+
+int StringView::lastIndexOf (value_type ch, size_type fromIndex) const
+{
+    if (fromIndex >= length()) return -1;
+
+    const_pointer r = memrchr(begin() + fromIndex, ch, length() - fromIndex);
+    if (r == NULL) return -1;
+    return r - begin();
+}
+
+int StringView::lastIndexOf (StringView str, size_type fromIndex) const
+{
+    if (!str || fromIndex >= length() || str.length() > length() - fromIndex) return -1;
+
+    const_pointer p1 = end() - str.length();
+    for (size_type i = length() - str.length(); i > fromIndex; --i, --p1)
+        if (0 == memcmp(p1, str.begin(), str.length())) return i;
+
+    return -1;
+}
+
+StringView StringView::substring (size_type beginIndex, size_type endIndex) const
+{
+    if (beginIndex >= length() || endIndex == 0) return StringView();
+
+    size_type end = endIndex;
+    if (end >= length()) end = length() - 1;
+
+    return StringView(begin() + beginIndex, end - beginIndex + 1);
+}
+
+void StringView::trim ()
+{
+    if (!*this) return;
+
+    const_pointer s = begin();
+    while (isspace(*s)) ++s;
+
+    const_pointer e = end() - 1;
+    while (isspace(*e) && e >= begin()) --e;
+
+    mData = s;
+    mLength = e + 1 - s;
+}
+
+void StringView::copyForConversion (pointer buffer, size_type bufLength)
+{
+    --bufLength;
+
+    StringView v(*this);
+    v.trim();
+    size_type l = v.length();
+    if (l > bufLength) l = bufLength;
+
+    memcpy(buffer, v.begin(), l);
+    buffer[l] = '\0';
+}
+
+long StringView::toInt() const
+{
+    if (!*this) 0;
+
+    // atol() requires a null terminated C-string.
+    value_type cstr[31];
+    copyForConversion(cstr, 31);
+    return atol(cstr);
+}
+
+float StringView::toFloat () const
+{
+    return float(toDouble());
+}
+
+double StringView::toDouble () const
+{
+    if (!*this) return 0;
+
+    // atof() requires a null terminated C-string.
+    value_type cstr[31];
+    copyForConversion(cstr, 31);
+    return atof(cstr);
+}
+

--- a/hardware/arduino/avr/cores/arduino/StringView.h
+++ b/hardware/arduino/avr/cores/arduino/StringView.h
@@ -1,0 +1,95 @@
+// Written by Steve Weinrich 2018
+// This code is given freely and without restriction of any kind to the Arduino community
+
+#ifndef StringView_H
+#define StringView_H
+
+#include <string.h>
+
+class StringView
+{
+    // Use a function pointer to allow for "if (s)" without the
+    // complications of an operator bool(). For more information, see:
+    // http://www.artima.com/cppsource/safebool.html
+    typedef void (StringView::*StringViewIfHelperType)() const;
+    void StringViewIfHelper () const {}
+
+ public:
+    // types
+    typedef char               value_type;
+    typedef value_type *       pointer;
+    typedef const value_type * const_pointer;
+    typedef const value_type & const_reference;
+    typedef size_t             size_type;
+
+    // construction and assignment
+    StringView ()
+        : mData(nullptr), mLength(0)
+    {}
+
+    StringView (const StringView &) = default;
+    
+    // When constructing from a C-String, the null terminator is dropped.
+    StringView (const_pointer str);
+
+    StringView (const_pointer str, size_type len)
+        : mData(str), mLength(len)
+    {}
+
+    StringView (StringView && rval);
+
+    StringView & operator = (const StringView &) = default;
+    StringView & operator = (StringView && rval);
+
+    size_t length () const { return mLength; }
+
+    operator StringViewIfHelperType () const { return length() ? &StringView::StringViewIfHelper : 0; }
+    int compareTo (StringView rhs) const; 
+    bool equals (StringView rhs) const { return 0 == compareTo(rhs); }
+    bool equalsIgnoreCase (StringView rhs) const;
+    bool startsWith (StringView prefix, size_type offset = 0) const;
+    bool endsWith (StringView suffix) const;
+
+    // character acccess
+    value_type charAt (size_type index) const { return operator[](index); }
+    value_type operator [] (size_type index) const;
+    void getBytes (unsigned char * buf, size_t bufsize, size_t index = 0) const;
+    void toCharArray (pointer buf, size_t bufsize) const
+    {
+        getBytes((unsigned char *)buf, bufsize);
+    }
+    const_pointer begin () const { return mData; }
+    const_pointer end () const { return begin() + length(); }
+
+    // search
+    int indexOf (value_type ch, size_type fromIndex = 0) const;
+    int indexOf (StringView str, size_type fromIndex = 0) const;
+    int lastIndexOf (value_type ch, size_type fromIndex = 0) const;
+    int lastIndexOf (StringView str, size_type fromIndex = 0) const;
+    StringView substring (size_type beginIndex) const { return substring(beginIndex, length() - 1); } 
+    StringView substring (size_type beginIndex, size_type endIndex) const;
+
+    // modification
+    void trim ();
+
+    // parsing/conversion
+    long toInt () const;
+    float toFloat () const;
+    double toDouble () const;
+
+ private:
+    const_pointer mData;
+    size_type     mLength;
+
+    void copyForConversion (pointer buffer, size_type bufLength);
+};
+
+// non-member comparison functions
+inline bool operator == (StringView x, StringView y) { return x.compareTo(y) == 0; }
+inline bool operator != (StringView x, StringView y) { return x.compareTo(y) != 0; }
+inline bool operator <  (StringView x, StringView y) { return x.compareTo(y) < 0; }
+inline bool operator >  (StringView x, StringView y) { return x.compareTo(y) > 0; }
+inline bool operator <= (StringView x, StringView y) { return x.compareTo(y) != 1; }
+inline bool operator >= (StringView x, StringView y) { return x.compareTo(y) != -1; }
+
+#endif

--- a/hardware/arduino/avr/cores/arduino/WString.cpp
+++ b/hardware/arduino/avr/cores/arduino/WString.cpp
@@ -43,6 +43,27 @@ String::String(const __FlashStringHelper *pstr)
 	*this = pstr;
 }
 
+// We do not use copy() in this constructor as copy() uses strcpy(), which will stop 
+// if it encounters a '\0'.  StringView's are not '\0' terminated strings, so the
+// constructor should honor the StringView length().
+String::String(StringView str)
+{
+    init();
+    if (str)
+    {
+        if (!reserve(str.length()))
+        {
+            invalidate();
+        }
+        else
+        {
+            len = str.length();
+            memcpy(buffer, str.begin(), len);
+            buffer[len] = '\0';
+        }
+    }
+}
+
 #if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
 String::String(String &&rval)
 {

--- a/hardware/arduino/avr/cores/arduino/WString.h
+++ b/hardware/arduino/avr/cores/arduino/WString.h
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <avr/pgmspace.h>
+#include <StringView.h>
 
 // When compiling programs with this class, the following gcc parameters
 // dramatically increase performance and memory (RAM) efficiency, typically
@@ -59,6 +60,7 @@ public:
 	String(const char *cstr = "");
 	String(const String &str);
 	String(const __FlashStringHelper *str);
+    String(StringView str);
        #if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
 	String(String &&rval);
 	String(StringSumHelper &&rval);
@@ -191,6 +193,8 @@ public:
 	long toInt(void) const;
 	float toFloat(void) const;
 	double toDouble(void) const;
+
+    operator StringView () const { return StringView(buffer, len); }
 
 protected:
 	char *buffer;	        // the actual char array


### PR DESCRIPTION
Add the StringView class.  A StringView is a read-only, non-owning reference to a C-string or a String. 
Although the name is based on the C++17 std::string_view, this implementation parallels the String interface and ignores the std::string_view interface.  

I also have a sketch that contains validation code for this class, but I don't see anywhere to put it!