### PR TITLE
String relational operators

### DIFF
--- a/hardware/arduino/avr/cores/arduino/WString.cpp
+++ b/hardware/arduino/avr/cores/arduino/WString.cpp
@@ -441,6 +441,16 @@ int String::compareTo(const String &s) const
 	return strcmp(buffer, s.buffer);
 }
 
+int String::compareTo(const char *cstr) const
+{
+	if (!buffer || !cstr) {
+		if (cstr && !*cstr) return 0 - *(unsigned char *)cstr;
+		if (buffer && len > 0) return *(unsigned char *)buffer;
+		return 0;
+	}
+	return strcmp(buffer, cstr);
+}
+
 unsigned char String::equals(const String &s2) const
 {
 	return (len == s2.len && compareTo(s2) == 0);
@@ -451,26 +461,6 @@ unsigned char String::equals(const char *cstr) const
 	if (len == 0) return (cstr == NULL || *cstr == 0);
 	if (cstr == NULL) return buffer[0] == 0;
 	return strcmp(buffer, cstr) == 0;
-}
-
-unsigned char String::operator<(const String &rhs) const
-{
-	return compareTo(rhs) < 0;
-}
-
-unsigned char String::operator>(const String &rhs) const
-{
-	return compareTo(rhs) > 0;
-}
-
-unsigned char String::operator<=(const String &rhs) const
-{
-	return compareTo(rhs) <= 0;
-}
-
-unsigned char String::operator>=(const String &rhs) const
-{
-	return compareTo(rhs) >= 0;
 }
 
 unsigned char String::equalsIgnoreCase( const String &s2 ) const

--- a/hardware/arduino/avr/cores/arduino/WString.h
+++ b/hardware/arduino/avr/cores/arduino/WString.h
@@ -137,16 +137,30 @@ public:
 	// comparison (only works w/ Strings and "strings")
 	operator StringIfHelperType() const { return buffer ? &String::StringIfHelper : 0; }
 	int compareTo(const String &s) const;
+	int compareTo(const char *cstr) const;
 	unsigned char equals(const String &s) const;
 	unsigned char equals(const char *cstr) const;
-	unsigned char operator == (const String &rhs) const {return equals(rhs);}
-	unsigned char operator == (const char *cstr) const {return equals(cstr);}
-	unsigned char operator != (const String &rhs) const {return !equals(rhs);}
-	unsigned char operator != (const char *cstr) const {return !equals(cstr);}
-	unsigned char operator <  (const String &rhs) const;
-	unsigned char operator >  (const String &rhs) const;
-	unsigned char operator <= (const String &rhs) const;
-	unsigned char operator >= (const String &rhs) const;
+
+	friend unsigned char operator == (const String &a, const String &b) { return a.equals(b); }
+	friend unsigned char operator == (const String &a, const char   *b) { return a.equals(b); }
+	friend unsigned char operator == (const char   *a, const String &b) { return b == a; }
+	friend unsigned char operator <  (const String &a, const String &b) { return a.compareTo(b) < 0; }
+	friend unsigned char operator <  (const String &a, const char   *b) { return a.compareTo(b) < 0; }
+	friend unsigned char operator <  (const char   *a, const String &b) { return b.compareTo(a) > 0; }
+
+	friend unsigned char operator != (const String &a, const String &b) { return !(a == b); }
+	friend unsigned char operator != (const String &a, const char   *b) { return !(a == b); }
+	friend unsigned char operator != (const char   *a, const String &b) { return !(a == b); }
+	friend unsigned char operator >  (const String &a, const String &b) { return b < a; }
+	friend unsigned char operator >  (const String &a, const char   *b) { return b < a; }
+	friend unsigned char operator >  (const char   *a, const String &b) { return b < a; }
+	friend unsigned char operator <= (const String &a, const String &b) { return !(b < a); }
+	friend unsigned char operator <= (const String &a, const char   *b) { return !(b < a); }
+	friend unsigned char operator <= (const char   *a, const String &b) { return !(b < a); }
+	friend unsigned char operator >= (const String &a, const String &b) { return !(a < b); }
+	friend unsigned char operator >= (const String &a, const char   *b) { return !(a < b); }
+	friend unsigned char operator >= (const char   *a, const String &b) { return !(a < b); }
+
 	unsigned char equalsIgnoreCase(const String &s) const;
 	unsigned char startsWith( const String &prefix) const;
 	unsigned char startsWith(const String &prefix, unsigned int offset) const;


### PR DESCRIPTION
The String class has an incomplete set of relational operators with
`const char*`. The 6 operators `==`,`!=`,`<`,`>`,`<=`,`>=` must be
defined between String and String, but also between String and `const
char*`.

The motivation is to treat left and right operands symmetrically.  str
== "hello" works, but swapping arguments to "hello" == str doesn't,
which is a potential user surprise.

As String is implicitly convertible from `const char*`, but this incurs
a "strdup". So it also makes sense to provide relational operators
directly with const char* to avoid the expensive promotion of const
char* to temporary String, just to do a string value comparison.

Resolves: #7139