### PR TITLE
Unblock write operation in HardwareSerial class for multythreading

### DIFF
--- a/hardware/arduino/avr/cores/arduino/HardwareSerial.cpp
+++ b/hardware/arduino/avr/cores/arduino/HardwareSerial.cpp
@@ -235,7 +235,8 @@ size_t HardwareSerial::write(uint8_t c)
       if(bit_is_set(*_ucsra, UDRE0))
 	_tx_udr_empty_irq();
     } else {
-      // nop, the interrupt handler will free up space for us
+      // Share CPU when waiting free space of the buffer
+	    yield();
     }
   }
 


### PR DESCRIPTION
…pport

This fix will allow the HardwareSerial class to be used in simple multitasking applications.