### PR TITLE
Allow "update" to be used for EERef's operator=

### DIFF
--- a/hardware/arduino/avr/libraries/EEPROM/src/EEPROM.h
+++ b/hardware/arduino/avr/libraries/EEPROM/src/EEPROM.h
@@ -25,12 +25,6 @@
 #include <avr/eeprom.h>
 #include <avr/io.h>
 
-//! The action associated with the EERef assignment operator.
-//! Possible values are "write" and "update", unquoted.
-#ifndef EEPROM_REF_ASSIGN_MODE
-#define EEPROM_REF_ASSIGN_MODE write
-#endif
-
 /***
     EERef class.
     
@@ -50,7 +44,7 @@ struct EERef{
     
     //Assignment/write members.
     EERef &operator=( const EERef &ref ) { return *this = *ref; }
-    EERef &operator=( uint8_t in )       { return EEPROM_REF_ASSIGN_MODE( in ); }
+    EERef &operator=( uint8_t in )       { return do_update ? update( in ) : write( in ); }
     EERef &operator +=( uint8_t in )     { return *this = **this + in; }
     EERef &operator -=( uint8_t in )     { return *this = **this - in; }
     EERef &operator *=( uint8_t in )     { return *this = **this * in; }
@@ -81,7 +75,9 @@ struct EERef{
     }
     
     int index; //Index of current EEPROM cell.
+    static bool do_update;
 };
+bool EERef::do_update = true;
 
 /***
     EEPtr class.

--- a/hardware/arduino/avr/libraries/EEPROM/src/EEPROM.h
+++ b/hardware/arduino/avr/libraries/EEPROM/src/EEPROM.h
@@ -25,6 +25,12 @@
 #include <avr/eeprom.h>
 #include <avr/io.h>
 
+//! The action associated with the EERef assignment operator.
+//! Possible values are "write" and "update", unquoted.
+#ifndef EEPROM_REF_ASSIGN_MODE
+#define EEPROM_REF_ASSIGN_MODE write
+#endif
+
 /***
     EERef class.
     
@@ -44,7 +50,7 @@ struct EERef{
     
     //Assignment/write members.
     EERef &operator=( const EERef &ref ) { return *this = *ref; }
-    EERef &operator=( uint8_t in )       { return eeprom_write_byte( (uint8_t*) index, in ), *this;  }
+    EERef &operator=( uint8_t in )       { return EEPROM_REF_ASSIGN_MODE( in ); }
     EERef &operator +=( uint8_t in )     { return *this = **this + in; }
     EERef &operator -=( uint8_t in )     { return *this = **this - in; }
     EERef &operator *=( uint8_t in )     { return *this = **this * in; }
@@ -56,7 +62,8 @@ struct EERef{
     EERef &operator <<=( uint8_t in )    { return *this = **this << in; }
     EERef &operator >>=( uint8_t in )    { return *this = **this >> in; }
     
-    EERef &update( uint8_t in )          { return  in != *this ? *this = in : *this; }
+    EERef &update( uint8_t in )          { return  in != *this ? write( in ) : *this; }
+    EERef &write( uint8_t in )           { return eeprom_write_byte( (uint8_t*) index, in ), *this; }
     
     /** Prefix increment/decrement **/
     EERef& operator++()                  { return *this += 1; }
@@ -118,7 +125,7 @@ struct EEPROMClass{
     //Basic user access methods.
     EERef operator[]( const int idx )    { return idx; }
     uint8_t read( int idx )              { return EERef( idx ); }
-    void write( int idx, uint8_t val )   { (EERef( idx )) = val; }
+    void write( int idx, uint8_t val )   { EERef( idx ).write( val ); }
     void update( int idx, uint8_t val )  { EERef( idx ).update( val ); }
     
     //STL and C++11 iteration capability.


### PR DESCRIPTION
As one of the new convenience features introduced in EEPROM 2.0, `EEPROM[x] = newval` stands out from the `put` function by not using an `update` behavior. This commit allows users to use the feature while saving EEPROM lifetime by using an `update` behavior instead. To enable it, use `#define EEPROM_REF_ASSIGN_MODE update` before including the Arduino header.

For disambiguation and ease of switching, an explicit `write` function is added to EERef. Like `update`, the separate function is accepted by the compiler with an implicit `inline`. As a result, it is unlikely to adversely impact performance by going through this function instead of a direct `eeprom_write_byte`.

forum-thread: https://forum.arduino.cc/index.php?topic=542365