### PR TITLE
CLI: Add --version to CLI option

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -483,6 +483,9 @@ public class Base {
       System.exit(0);
     } else if (parser.isGetPrefMode()) {
       BaseNoGui.dumpPrefs(parser);
+    } else if (parser.isVersionMode()) {
+      System.out.print("Arduino: " + BaseNoGui.VERSION_NAME_LONG);
+      System.exit(0);
     }
   }
 

--- a/app/test/processing/app/CommandLineTest.java
+++ b/app/test/processing/app/CommandLineTest.java
@@ -144,4 +144,19 @@ public class CommandLineTest {
     Assertions.assertThat(new String(IOUtils.toByteArray(pr.getInputStream())))
       .matches("Arduino: \\d+\\.\\d+\\.\\d+.*");
   }
+
+  @Test
+  public void testCommandLineMultipleAction() throws Exception {
+    Runtime rt = Runtime.getRuntime();
+    Process pr = rt.exec(new String[]{
+      arduinoPath.getAbsolutePath(),
+      "--version",
+      "--verify",
+    });
+    pr.waitFor();
+
+    Assertions.assertThat(pr.exitValue())
+      .as("Multiple Action will be rejected")
+      .isEqualTo(3);
+  }
 }

--- a/app/test/processing/app/CommandLineTest.java
+++ b/app/test/processing/app/CommandLineTest.java
@@ -142,9 +142,6 @@ public class CommandLineTest {
       .as("Process will finish with exit code 0 in --version")
       .isEqualTo(0);
     Assertions.assertThat(new String(IOUtils.toByteArray(pr.getInputStream())))
-      .matches("Arduino: \\d+\\.\\d+\\.\\d+.*\n");
-    Assertions.assertThat(new String(IOUtils.toByteArray(pr.getInputStream())))
-      .as("Currently, STDERR is not used in --version.")
-      .isEqualTo("");
+      .matches("Arduino: \\d+\\.\\d+\\.\\d+.*");
   }
 }

--- a/app/test/processing/app/CommandLineTest.java
+++ b/app/test/processing/app/CommandLineTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.*;
 import java.io.File;
 
 import org.apache.commons.compress.utils.IOUtils;
+import org.fest.assertions.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -126,5 +127,24 @@ public class CommandLineTest {
 
     prefs = new PreferencesMap(prefFile);
     assertEquals("preference should be saved", "xxx", prefs.get("test_pref"));
-}
+  }
+
+  @Test
+  public void testCommandLineVersion() throws Exception {
+    Runtime rt = Runtime.getRuntime();
+    Process pr = rt.exec(new String[]{
+      arduinoPath.getAbsolutePath(),
+      "--version",
+    });
+    pr.waitFor();
+
+    Assertions.assertThat(pr.exitValue())
+      .as("Process will finish with exit code 0 in --version")
+      .isEqualTo(0);
+    Assertions.assertThat(new String(IOUtils.toByteArray(pr.getInputStream())))
+      .matches("Arduino: \\d+\\.\\d+\\.\\d+.*\n");
+    Assertions.assertThat(new String(IOUtils.toByteArray(pr.getInputStream())))
+      .as("Currently, STDERR is not used in --version.")
+      .isEqualTo("");
+  }
 }

--- a/arduino-core/src/processing/app/helpers/CommandlineParser.java
+++ b/arduino-core/src/processing/app/helpers/CommandlineParser.java
@@ -85,10 +85,6 @@ public class CommandlineParser {
           }
           libraryToInstall = args[i];
         }
-        if (a == ACTION.VERSION) {
-          BaseNoGui.showMessage("Arduino", BaseNoGui.VERSION_NAME_LONG);
-          System.exit(0);
-        }
         action = a;
         continue;
       }
@@ -343,6 +339,10 @@ public class CommandlineParser {
 
   public boolean isInstallLibrary() {
     return action == ACTION.INSTALL_LIBRARY;
+  }
+
+  public boolean isVersionMode() {
+    return action == ACTION.VERSION;
   }
 
   public String getBoardToInstall() {

--- a/arduino-core/src/processing/app/helpers/CommandlineParser.java
+++ b/arduino-core/src/processing/app/helpers/CommandlineParser.java
@@ -16,7 +16,7 @@ import static processing.app.I18n.tr;
 public class CommandlineParser {
 
   private enum ACTION {
-    GUI, NOOP, VERIFY("--verify"), UPLOAD("--upload"), GET_PREF("--get-pref"), INSTALL_BOARD("--install-boards"), INSTALL_LIBRARY("--install-library");
+    GUI, NOOP, VERIFY("--verify"), UPLOAD("--upload"), GET_PREF("--get-pref"), INSTALL_BOARD("--install-boards"), INSTALL_LIBRARY("--install-library"), VERSION("--version");
 
     final String value;
 
@@ -52,6 +52,7 @@ public class CommandlineParser {
     actions.put("--get-pref", ACTION.GET_PREF);
     actions.put("--install-boards", ACTION.INSTALL_BOARD);
     actions.put("--install-library", ACTION.INSTALL_LIBRARY);
+    actions.put("--version", ACTION.VERSION);
   }
 
   public void parseArgumentsPhase1() {
@@ -83,6 +84,10 @@ public class CommandlineParser {
             BaseNoGui.showError(null, I18n.format(tr("Argument required for {0}"), a.value), 3);
           }
           libraryToInstall = args[i];
+        }
+        if (a == ACTION.VERSION) {
+          BaseNoGui.showMessage("Arduino", BaseNoGui.VERSION_NAME_LONG);
+          System.exit(0);
         }
         action = a;
         continue;

--- a/build/shared/manpage.adoc
+++ b/build/shared/manpage.adoc
@@ -33,6 +33,8 @@ SYNOPSIS
 
 *arduino* [*--install-library* __library name__[:__version__][,__library name__[:__version__],__library name__[:__version__]]
 
+*arduino* [*--version*]
+
 DESCRIPTION
 -----------
 The 'arduino' integrated development environment allows editing,
@@ -82,6 +84,9 @@ ACTIONS
 *--install-library* __library name__[:__version__]::
 	Fetches available libraries list and install the specified one. If __version__ is omitted, the latest is installed. If a library with the same version is already installed, nothing is installed and program exits with exit code 1. If a library with a different version is already installed, it's replaced.
 	Multiple libraries can be specified, separated by a comma.
+
+*--version*::
+	Print the version information and exit.
 
 OPTIONS
 -------


### PR DESCRIPTION
I added to get the Arduino IDE version from the command line
It will allow to check easily if the new Arduino is already installed.

This feature makes it easier to build external systems linked to specific versions of Arduino.

1. I added `--version` action, which shows version name and exit
    1. Currently, VERSION_NAME_LONG (like `1.8.5`, `1.9.0-beta`, `1.8.6 Hourly Build XXX`, etc...) is used. Because I want to know its version number and stable/beta/hourly.
    2. Finish with `0`. Because it is `SUCCESSFLLY FINISHED`.
2. Updated man page.