### PR TITLE
Change error output color to brighter orange

### DIFF
--- a/build/shared/lib/theme/theme.txt
+++ b/build/shared/lib/theme/theme.txt
@@ -29,7 +29,7 @@ console.font = Monospaced,plain,11
 console.font.macosx = Monaco,plain,10
 console.color = #000000
 console.output.color = #eeeeee
-console.error.color = #E34C00
+console.error.color = #FF8300
 
 # GUI - BUTTONS
 buttons.bgcolor = #006468


### PR DESCRIPTION
Addressed issue #7451 by changing the color of error output to a brighter orange color.