### PR TITLE
Turn on line highlighter by default

### DIFF
--- a/build/shared/lib/theme/theme.txt
+++ b/build/shared/lib/theme/theme.txt
@@ -64,7 +64,7 @@ editor.bgcolor = #ffffff
 # highlight for the current line
 editor.linehighlight.color=#e2e2e2
 # highlight for the current line
-editor.linehighlight=false
+editor.linehighlight=true
 
 # caret blinking and caret color
 editor.caret.color = #333300


### PR DESCRIPTION
Addresses issue #6438 to highlight current line by default. This helps people who are working with longer codes keep track of where they are typing. 