### PR TITLE
Symlink the arduino binary

### DIFF
--- a/build/linux/dist/install.sh
+++ b/build/linux/dist/install.sh
@@ -68,7 +68,9 @@ xdg_install_f() {
 
   # Add symlink for arduino so it's in users path
   echo "" # Ensure password request message is on new line
-  sudo ln -s ${SCRIPT_PATH}/arduino /usr/local/bin/arduino
+  if ! ln -s ${SCRIPT_PATH}/arduino /usr/local/bin/arduino; then
+      echo "Adding symlink failed. Hope that's OK. If not then rerun as root with sudo."
+  fi
 
   # Clean up
   rm "${TMP_DIR}/${RESOURCE_NAME}.desktop"
@@ -104,7 +106,9 @@ simple_install_f() {
 
   # Add symlink for arduino so it's in users path
   echo "" # Ensure password request message is on new line
-  sudo ln -s ${SCRIPT_PATH}/arduino /usr/local/bin/arduino
+  if ! ln -s ${SCRIPT_PATH}/arduino /usr/local/bin/arduino; then
+      echo "Adding symlink failed. Hope that's OK. If not then rerun as root with sudo."
+  fi
 
   # Clean up temp dir
   rm "${TMP_DIR}/${RESOURCE_NAME}.desktop"
@@ -148,7 +152,9 @@ xdg_uninstall_f() {
 
   # Remove symlink for arduino
   echo "" # Ensure password request message is on new line
-  sudo rm /usr/local/bin/arduino
+  if ! rm /usr/local/bin/arduino; then
+      echo "Removing symlink failed. Hope that's OK. If not then rerun as root with sudo."
+  fi
 
 }
 
@@ -183,7 +189,9 @@ simple_uninstall_f() {
 
   # Remove symlink for arduino
   echo "" # Ensure password request message is on new line
-  sudo rm /usr/local/bin/arduino
+  if ! rm /usr/local/bin/arduino; then
+      echo "Removing symlink failed. Hope that's OK. If not then rerun as root with sudo."
+  fi
 
 }
 

--- a/build/linux/dist/install.sh
+++ b/build/linux/dist/install.sh
@@ -67,6 +67,7 @@ xdg_install_f() {
   xdg-mime default ${RESOURCE_NAME}.desktop text/x-arduino
 
   # Add symlink for arduino so it's in users path
+  echo "" # Ensure password request message is on new line
   sudo ln -s ${SCRIPT_PATH}/arduino /usr/local/bin/arduino
 
   # Clean up
@@ -102,6 +103,7 @@ simple_install_f() {
   fi
 
   # Add symlink for arduino so it's in users path
+  echo "" # Ensure password request message is on new line
   sudo ln -s ${SCRIPT_PATH}/arduino /usr/local/bin/arduino
 
   # Clean up temp dir
@@ -145,6 +147,7 @@ xdg_uninstall_f() {
   xdg-mime uninstall "${SCRIPT_PATH}/lib/${RESOURCE_NAME}.xml"
 
   # Remove symlink for arduino
+  echo "" # Ensure password request message is on new line
   sudo rm /usr/local/bin/arduino
 
 }
@@ -179,6 +182,7 @@ simple_uninstall_f() {
   fi
 
   # Remove symlink for arduino
+  echo "" # Ensure password request message is on new line
   sudo rm /usr/local/bin/arduino
 
 }

--- a/build/linux/dist/install.sh
+++ b/build/linux/dist/install.sh
@@ -66,6 +66,9 @@ xdg_install_f() {
   # Make Arduino IDE the default application for *.ino
   xdg-mime default ${RESOURCE_NAME}.desktop text/x-arduino
 
+  # Add symlink for arduino so it's in users path
+  sudo ln -s ${SCRIPT_PATH}/arduino /usr/local/bin/arduino
+
   # Clean up
   rm "${TMP_DIR}/${RESOURCE_NAME}.desktop"
   rmdir "$TMP_DIR"
@@ -97,6 +100,9 @@ simple_install_f() {
    # Altering file permissions to avoid "Untrusted Application Launcher" error on Ubuntu
    chmod u+x "${XDG_DESKTOP_DIR}/${RESOURCE_NAME}.desktop"
   fi
+
+  # Add symlink for arduino so it's in users path
+  sudo ln -s ${SCRIPT_PATH}/arduino /usr/local/bin/arduino
 
   # Clean up temp dir
   rm "${TMP_DIR}/${RESOURCE_NAME}.desktop"
@@ -138,6 +144,9 @@ xdg_uninstall_f() {
   # Remove Arduino MIME type
   xdg-mime uninstall "${SCRIPT_PATH}/lib/${RESOURCE_NAME}.xml"
 
+  # Remove symlink for arduino
+  sudo rm /usr/local/bin/arduino
+
 }
 
 # Uninstall by simply removing desktop files (fallback), incl. old one
@@ -168,6 +177,9 @@ simple_uninstall_f() {
   if [ -f "${XDG_DESKTOP_DIR}/${RESOURCE_NAME}.desktop" ]; then
     rm "${XDG_DESKTOP_DIR}/${RESOURCE_NAME}.desktop"
   fi
+
+  # Remove symlink for arduino
+  sudo rm /usr/local/bin/arduino
 
 }
 


### PR DESCRIPTION
install.sh should symlink arduino into `/usr/local/bin/arduino` so arduino is accessible via users PATH.

Related issues:

https://github.com/arduino/Arduino/issues/5780

https://github.com/arduino/Arduino/issues/5366