### PR TITLE
Added `librariesDependencies` in package_index.json

### DIFF
--- a/app/src/cc/arduino/contributions/libraries/ui/LibraryManagerUI.java
+++ b/app/src/cc/arduino/contributions/libraries/ui/LibraryManagerUI.java
@@ -85,7 +85,7 @@ public class LibraryManagerUI extends InstallerJDialog<ContributedLibraryRelease
         if (mayInstalledLibrary.isPresent() && selectedLibrary.isIDEBuiltIn()) {
           onRemovePressed(mayInstalledLibrary.get());
         } else {
-          onInstallPressed(selectedLibrary, mayInstalledLibrary);
+          onInstallPressed(selectedLibrary);
         }
       }
 
@@ -212,12 +212,12 @@ public class LibraryManagerUI extends InstallerJDialog<ContributedLibraryRelease
     installerThread.start();
   }
 
-  public void onInstallPressed(final ContributedLibrary lib, final Optional<ContributedLibrary> mayReplaced) {
+  public void onInstallPressed(final ContributedLibrary lib) {
     clearErrorMessage();
     installerThread = new Thread(() -> {
       try {
         setProgressVisible(true, tr("Installing..."));
-        installer.install(lib, mayReplaced, this::setProgress);
+        installer.install(lib, this::setProgress);
         onIndexesUpdated();
         // TODO: Do a better job in refreshing only the needed element
         ((LibrariesIndexTableModel) contribModel).update();

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -278,8 +278,8 @@ public class Base {
     pdeKeywords = new PdeKeywords();
     pdeKeywords.reload();
 
-    contributionInstaller = new ContributionInstaller(new GPGDetachedSignatureVerifier());
     libraryInstaller = new LibraryInstaller();
+    contributionInstaller = new ContributionInstaller(libraryInstaller, new GPGDetachedSignatureVerifier());
 
     parser.parseArgumentsPhase2();
 

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -366,7 +366,7 @@ public class Base {
                       library, mayInstalled.get().getParsedVersion())));
           libraryInstaller.remove(mayInstalled.get(), progressListener);
         } else {
-          libraryInstaller.install(selected, mayInstalled, progressListener);
+          libraryInstaller.install(selected, progressListener);
         }
       }
 

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -278,8 +278,8 @@ public class Base {
     pdeKeywords = new PdeKeywords();
     pdeKeywords.reload();
 
-    contributionInstaller = new ContributionInstaller(BaseNoGui.getPlatform(), new GPGDetachedSignatureVerifier());
-    libraryInstaller = new LibraryInstaller(BaseNoGui.getPlatform());
+    contributionInstaller = new ContributionInstaller(new GPGDetachedSignatureVerifier());
+    libraryInstaller = new LibraryInstaller();
 
     parser.parseArgumentsPhase2();
 
@@ -293,7 +293,7 @@ public class Base {
     if (parser.isInstallBoard()) {
       ContributionsIndexer indexer = new ContributionsIndexer(
           BaseNoGui.getSettingsFolder(), BaseNoGui.getHardwareFolder(),
-          BaseNoGui.getPlatform(), new GPGDetachedSignatureVerifier());
+          new GPGDetachedSignatureVerifier());
       ProgressListener progressListener = new ConsoleProgressListener();
 
       List<String> downloadedPackageIndexFiles = contributionInstaller.updateIndex(progressListener);

--- a/app/src/processing/app/syntax/SketchTextArea.java
+++ b/app/src/processing/app/syntax/SketchTextArea.java
@@ -33,8 +33,6 @@ package processing.app.syntax;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -49,7 +47,6 @@ import org.fife.ui.rsyntaxtextarea.Token;
 import org.fife.ui.rtextarea.RTextArea;
 import org.fife.ui.rtextarea.RTextAreaUI;
 import processing.app.Base;
-import processing.app.BaseNoGui;
 import processing.app.PreferencesData;
 
 import javax.swing.event.EventListenerList;
@@ -58,14 +55,6 @@ import javax.swing.event.HyperlinkListener;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Segment;
 import java.awt.*;
-import java.awt.event.MouseEvent;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Map;
-import java.util.logging.Logger;
 import processing.app.helpers.OSUtils;
 
 /**

--- a/app/test/cc/arduino/packages/contributions/HostDependentDownloadableContributionTest.java
+++ b/app/test/cc/arduino/packages/contributions/HostDependentDownloadableContributionTest.java
@@ -30,7 +30,6 @@
 package cc.arduino.packages.contributions;
 
 import org.junit.Test;
-import processing.app.Platform;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -46,19 +45,7 @@ public class HostDependentDownloadableContributionTest {
       }
     };
 
-    Platform platform = new Platform() {
-      @Override
-      public String getOsName() {
-        return "Mac OS X";
-      }
-
-      @Override
-      public String getOsArch() {
-        return "x86_64";
-      }
-    };
-
-    assertTrue(contribution.isCompatible(platform));
+    assertTrue(contribution.isCompatible("Mac OS X", "x86_64"));
   }
 
   @Test
@@ -70,19 +57,7 @@ public class HostDependentDownloadableContributionTest {
       }
     };
 
-    Platform platform = new Platform() {
-      @Override
-      public String getOsName() {
-        return "Linux";
-      }
-
-      @Override
-      public String getOsArch() {
-        return "amd64";
-      }
-    };
-
-    assertFalse(contribution.isCompatible(platform));
+    assertFalse(contribution.isCompatible("Linux", "amd64"));
   }
 
   @Test
@@ -94,19 +69,7 @@ public class HostDependentDownloadableContributionTest {
       }
     };
 
-    Platform platform = new Platform() {
-      @Override
-      public String getOsName() {
-        return "Mac OS X";
-      }
-
-      @Override
-      public String getOsArch() {
-        return "i686";
-      }
-    };
-
-    assertFalse(contribution.isCompatible(platform));
+    assertFalse(contribution.isCompatible("Mac OS X", "i686"));
   }
 
 }

--- a/arduino-core/src/cc/arduino/contributions/VersionHelper.java
+++ b/arduino-core/src/cc/arduino/contributions/VersionHelper.java
@@ -64,4 +64,7 @@ public class VersionHelper {
     }
   }
 
+  public static int compare(String a, String b) {
+    return valueOf(a).compareTo(valueOf(b));
+  }
 }

--- a/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibrary.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibrary.java
@@ -39,6 +39,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static processing.app.I18n.tr;
+import cc.arduino.contributions.VersionHelper;
 
 public abstract class ContributedLibrary extends DownloadableContribution {
 
@@ -166,6 +167,14 @@ public abstract class ContributedLibrary extends DownloadableContribution {
     ContributedLibrary other = (ContributedLibrary) obj;
     return Objects.equals(getParsedVersion(), other.getParsedVersion()) &&
            Objects.equals(getName(), other.getName());
+  }
+
+  public boolean isBefore(ContributedLibrary other) {
+    return VersionHelper.compare(getVersion(), other.getVersion()) < 0;
+  }
+
+  public static ContributedLibrary max(ContributedLibrary x, ContributedLibrary y) {
+    return x.isBefore(y) ? y : x;
   }
 
   @Override

--- a/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibrary.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibrary.java
@@ -35,6 +35,7 @@ import processing.app.packages.UserLibrary;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import static processing.app.I18n.tr;
@@ -163,22 +164,12 @@ public abstract class ContributedLibrary extends DownloadableContribution {
       return false;
     }
     ContributedLibrary other = (ContributedLibrary) obj;
-    String thisVersion = getParsedVersion();
-    String otherVersion = other.getParsedVersion();
+    return Objects.equals(getParsedVersion(), other.getParsedVersion()) &&
+           Objects.equals(getName(), other.getName());
+  }
 
-    boolean versionEquals = (thisVersion != null && otherVersion != null
-                             && thisVersion.equals(otherVersion));
-
-    // Important: for legacy libs, versions are null. Two legacy libs must
-    // always pass this test.
-    if (thisVersion == null && otherVersion == null)
-      versionEquals = true;
-
-    String thisName = getName();
-    String otherName = other.getName();
-
-    boolean nameEquals = thisName == null || otherName == null || thisName.equals(otherName);
-
-    return versionEquals && nameEquals;
+  @Override
+  public int hashCode() {
+    return Objects.hash(getParsedVersion(), getName());
   }
 }

--- a/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibrary.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibrary.java
@@ -64,7 +64,7 @@ public abstract class ContributedLibrary extends DownloadableContribution {
 
   public abstract List<String> getTypes();
 
-  public abstract List<ContributedLibraryReference> getRequires();
+  public abstract List<ContributedLibraryDependency> getRequires();
 
   public abstract List<String> getProvidesIncludes();
 
@@ -147,7 +147,7 @@ public abstract class ContributedLibrary extends DownloadableContribution {
     res += "\n";
     res += "            requires :\n";
     if (getRequires() != null)
-      for (ContributedLibraryReference r : getRequires()) {
+      for (ContributedLibraryDependency r : getRequires()) {
         res += "                       " + r;
       }
     res += "\n";

--- a/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibraryDependency.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/ContributedLibraryDependency.java
@@ -29,16 +29,14 @@
 
 package cc.arduino.contributions.libraries;
 
-public abstract class ContributedLibraryReference {
+public abstract class ContributedLibraryDependency {
 
   public abstract String getName();
-
-  public abstract String getMaintainer();
 
   public abstract String getVersion();
 
   @Override
   public String toString() {
-    return getName() + " " + getVersion() + " (" + getMaintainer() + ")";
+    return getName() + " " + getVersion();
   }
 }

--- a/arduino-core/src/cc/arduino/contributions/libraries/LibrariesIndex.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/LibrariesIndex.java
@@ -59,6 +59,15 @@ public abstract class LibrariesIndex {
     return null;
   }
 
+  public ContributedLibrary find(ContributedLibraryDependency dep) {
+    if (dep.getVersion() == null) {
+      return find(dep.getName()).stream(). //
+          reduce(ContributedLibrary::max). //
+          orElseGet(null);
+    }
+    return find(dep.getName(), dep.getVersion());
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();

--- a/arduino-core/src/cc/arduino/contributions/libraries/LibraryInstaller.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/LibraryInstaller.java
@@ -37,7 +37,6 @@ import cc.arduino.utils.ArchiveExtractor;
 import cc.arduino.utils.MultiStepProgress;
 import processing.app.BaseNoGui;
 import processing.app.I18n;
-import processing.app.Platform;
 import processing.app.helpers.FileUtils;
 
 import java.io.File;
@@ -49,12 +48,6 @@ import java.util.List;
 import static processing.app.I18n.tr;
 
 public class LibraryInstaller {
-
-  private final Platform platform;
-
-  public LibraryInstaller(Platform platform) {
-    this.platform = platform;
-  }
 
   public synchronized void updateIndex(ProgressListener progressListener) throws Exception {
     final MultiStepProgress progress = new MultiStepProgress(2);
@@ -129,7 +122,7 @@ public class LibraryInstaller {
     File libsFolder = BaseNoGui.getSketchbookLibrariesFolder().folder;
     File tmpFolder = FileUtils.createTempFolder(libsFolder);
     try {
-      new ArchiveExtractor(platform).extract(lib.getDownloadedFile(), tmpFolder, 1);
+      new ArchiveExtractor().extract(lib.getDownloadedFile(), tmpFolder, 1);
     } catch (Exception e) {
       if (tmpFolder.exists())
         FileUtils.recursiveDelete(tmpFolder);

--- a/arduino-core/src/cc/arduino/contributions/libraries/LibraryInstaller.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/LibraryInstaller.java
@@ -43,6 +43,8 @@ import processing.app.helpers.FileUtils;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 import static processing.app.I18n.tr;
 
@@ -82,11 +84,19 @@ public class LibraryInstaller {
     rescanLibraryIndex(progress, progressListener);
   }
 
-  public synchronized void install(ContributedLibrary lib, ProgressListener progressListener) throws Exception {
-    final MultiStepProgress progress = new MultiStepProgress(4);
+  public void install(ContributedLibrary lib, ProgressListener progressListener) throws Exception {
+    List<ContributedLibrary> libs = new ArrayList<>();
+    libs.add(lib);
+    install(libs, progressListener);
+  }
 
-    // Do install library (3 steps)
-    performInstall(lib, progressListener, progress);
+  public synchronized void install(List<ContributedLibrary> libs, ProgressListener progressListener) throws Exception {
+    MultiStepProgress progress = new MultiStepProgress(3 * libs.size() + 1);
+
+    for (ContributedLibrary lib : libs) {
+      // Do install library (3 steps)
+      performInstall(lib, progressListener, progress);
+    }
 
     // Rescan index (1 step)
     rescanLibraryIndex(progress, progressListener);

--- a/arduino-core/src/cc/arduino/contributions/libraries/LibraryInstaller.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/LibraryInstaller.java
@@ -85,7 +85,10 @@ public class LibraryInstaller {
 
   public synchronized void install(List<ContributedLibrary> libs, ProgressListener progressListener) throws Exception {
     MultiStepProgress progress = new MultiStepProgress(3 * libs.size() + 1);
+    install(libs, progressListener, progress);
+  }
 
+  public synchronized void install(List<ContributedLibrary> libs, ProgressListener progressListener, MultiStepProgress progress) throws Exception {
     for (ContributedLibrary lib : libs) {
       // Do install library (3 steps)
       performInstall(lib, progressListener, progress);

--- a/arduino-core/src/cc/arduino/contributions/libraries/LibraryInstaller.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/LibraryInstaller.java
@@ -100,6 +100,9 @@ public class LibraryInstaller {
 
   private void performInstall(ContributedLibrary lib, ProgressListener progressListener, MultiStepProgress progress) throws Exception {
     if (lib.isLibraryInstalled()) {
+      progress.stepDone();
+      progress.stepDone();
+      progress.stepDone();
       System.out.println(I18n.format(tr("Library is already installed: {0}:{1}"), lib.getName(), lib.getParsedVersion()));
       return;
     }

--- a/arduino-core/src/cc/arduino/contributions/libraries/LibraryInstaller.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/LibraryInstaller.java
@@ -84,14 +84,22 @@ public class LibraryInstaller {
   }
 
   public synchronized void install(ContributedLibrary lib, Optional<ContributedLibrary> mayReplacedLib, ProgressListener progressListener) throws Exception {
+    final MultiStepProgress progress = new MultiStepProgress(4);
+
+    // Do install library (3 steps)
+    performInstall(lib, mayReplacedLib, progressListener, progress);
+
+    // Rescan index (1 step)
+    rescanLibraryIndex(progress, progressListener);
+  }
+
+  private void performInstall(ContributedLibrary lib, Optional<ContributedLibrary> mayReplacedLib, ProgressListener progressListener, MultiStepProgress progress) throws Exception {
     if (lib.isLibraryInstalled()) {
       System.out.println(I18n.format(tr("Library is already installed: {0}:{1}"), lib.getName(), lib.getParsedVersion()));
       return;
     }
 
     DownloadableContributionsDownloader downloader = new DownloadableContributionsDownloader(BaseNoGui.librariesIndexer.getStagingFolder());
-
-    final MultiStepProgress progress = new MultiStepProgress(3);
 
     // Step 1: Download library
     try {
@@ -100,6 +108,7 @@ public class LibraryInstaller {
       // Download interrupted... just exit
       return;
     }
+    progress.stepDone();
 
     // TODO: Extract to temporary folders and move to the final destination only
     // once everything is successfully unpacked. If the operation fails remove
@@ -126,9 +135,6 @@ public class LibraryInstaller {
     File destFolder = new File(libsFolder, lib.getName().replaceAll(" ", "_"));
     tmpFolder.renameTo(destFolder);
     progress.stepDone();
-
-    // Step 4: Rescan index
-    rescanLibraryIndex(progress, progressListener);
   }
 
   public synchronized void remove(ContributedLibrary lib, ProgressListener progressListener) throws IOException {

--- a/arduino-core/src/cc/arduino/contributions/packages/ContributedPlatform.java
+++ b/arduino-core/src/cc/arduino/contributions/packages/ContributedPlatform.java
@@ -30,6 +30,8 @@
 package cc.arduino.contributions.packages;
 
 import cc.arduino.contributions.DownloadableContribution;
+import cc.arduino.contributions.libraries.ContributedLibraryDependency;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.io.File;
@@ -47,6 +49,8 @@ public abstract class ContributedPlatform extends DownloadableContribution {
 
   @Override
   public abstract String getChecksum();
+
+  public abstract List<ContributedLibraryDependency> getLibrariesDependencies();
 
   public abstract List<ContributedToolReference> getToolsDependencies();
 

--- a/arduino-core/src/cc/arduino/contributions/packages/ContributedTool.java
+++ b/arduino-core/src/cc/arduino/contributions/packages/ContributedTool.java
@@ -30,7 +30,6 @@
 package cc.arduino.contributions.packages;
 
 import cc.arduino.contributions.DownloadableContribution;
-import processing.app.Platform;
 
 import java.io.File;
 import java.util.List;
@@ -87,9 +86,9 @@ public abstract class ContributedTool {
     return contributedPackage.getName();
   }
 
-  public DownloadableContribution getDownloadableContribution(Platform platform) {
+  public DownloadableContribution getDownloadableContribution() {
     for (HostDependentDownloadableContribution c : getSystems()) {
-      if (c.isCompatible(platform))
+      if (c.isCompatible())
         return c;
     }
     return null;
@@ -97,17 +96,11 @@ public abstract class ContributedTool {
 
   @Override
   public String toString() {
-    return toString(null);
-  }
-
-  public String toString(Platform platform) {
     String res;
     res = "Tool name : " + getName() + " " + getVersion() + "\n";
     for (HostDependentDownloadableContribution sys : getSystems()) {
       res += "     sys";
-      if (platform != null) {
-        res += sys.isCompatible(platform) ? "*" : " ";
-      }
+      res += sys.isCompatible() ? "*" : " ";
       res += " : " + sys + "\n";
     }
     return res;

--- a/arduino-core/src/cc/arduino/contributions/packages/ContributionInstaller.java
+++ b/arduino-core/src/cc/arduino/contributions/packages/ContributionInstaller.java
@@ -66,8 +66,8 @@ public class ContributionInstaller {
   private final Platform platform;
   private final SignatureVerifier signatureVerifier;
 
-  public ContributionInstaller(Platform platform, SignatureVerifier signatureVerifier) {
-    this.platform = platform;
+  public ContributionInstaller(SignatureVerifier signatureVerifier) {
+    this.platform = BaseNoGui.getPlatform();
     this.signatureVerifier = signatureVerifier;
   }
 
@@ -80,7 +80,7 @@ public class ContributionInstaller {
     // Do not download already installed tools
     List<ContributedTool> tools = new ArrayList<>();
     for (ContributedTool tool : contributedPlatform.getResolvedTools()) {
-      DownloadableContribution downloadable = tool.getDownloadableContribution(platform);
+      DownloadableContribution downloadable = tool.getDownloadableContribution();
       if (downloadable == null) {
         throw new Exception(format(tr("Tool {0} is not available for your operating system."), tool.getName()));
       }
@@ -106,7 +106,7 @@ public class ContributionInstaller {
       for (ContributedTool tool : tools) {
         String msg = format(tr("Downloading tools ({0}/{1})."), i, tools.size());
         i++;
-        downloader.download(tool.getDownloadableContribution(platform), progress, msg, progressListener);
+        downloader.download(tool.getDownloadableContribution(), progress, msg, progressListener);
         progress.stepDone();
       }
     } catch (InterruptedException e) {
@@ -137,9 +137,9 @@ public class ContributionInstaller {
 
       Files.createDirectories(destFolder);
 
-      DownloadableContribution toolContrib = tool.getDownloadableContribution(platform);
+      DownloadableContribution toolContrib = tool.getDownloadableContribution();
       assert toolContrib.getDownloadedFile() != null;
-      new ArchiveExtractor(platform).extract(toolContrib.getDownloadedFile(), destFolder.toFile(), 1);
+      new ArchiveExtractor().extract(toolContrib.getDownloadedFile(), destFolder.toFile(), 1);
       try {
         findAndExecutePostInstallScriptIfAny(destFolder.toFile(), contributedPlatform.getParentPackage().isTrusted(), PreferencesData.getBoolean(Constants.PREF_CONTRIBUTIONS_TRUST_ALL));
       } catch (IOException e) {
@@ -156,7 +156,7 @@ public class ContributionInstaller {
     File platformFolder = new File(packageFolder, "hardware" + File.separator + contributedPlatform.getArchitecture());
     File destFolder = new File(platformFolder, contributedPlatform.getParsedVersion());
     Files.createDirectories(destFolder.toPath());
-    new ArchiveExtractor(platform).extract(contributedPlatform.getDownloadedFile(), destFolder, 1);
+    new ArchiveExtractor().extract(contributedPlatform.getDownloadedFile(), destFolder, 1);
     contributedPlatform.setInstalled(true);
     contributedPlatform.setInstalledFolder(destFolder);
     try {

--- a/arduino-core/src/cc/arduino/contributions/packages/ContributionsIndexer.java
+++ b/arduino-core/src/cc/arduino/contributions/packages/ContributionsIndexer.java
@@ -40,7 +40,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.mrbean.MrBeanModule;
 import org.apache.commons.compress.utils.IOUtils;
 import processing.app.I18n;
-import processing.app.Platform;
 import processing.app.PreferencesData;
 import processing.app.debug.TargetPackage;
 import processing.app.debug.TargetPlatform;
@@ -64,14 +63,12 @@ public class ContributionsIndexer {
   private final File stagingFolder;
   private final File preferencesFolder;
   private final File builtInHardwareFolder;
-  private final Platform platform;
   private final SignatureVerifier signatureVerifier;
   private final ContributionsIndex index;
 
-  public ContributionsIndexer(File preferencesFolder, File builtInHardwareFolder, Platform platform, SignatureVerifier signatureVerifier) {
+  public ContributionsIndexer(File preferencesFolder, File builtInHardwareFolder, SignatureVerifier signatureVerifier) {
     this.preferencesFolder = preferencesFolder;
     this.builtInHardwareFolder = builtInHardwareFolder;
-    this.platform = platform;
     this.signatureVerifier = signatureVerifier;
     index = new EmptyContributionIndex();
     packagesFolder = new File(preferencesFolder, "packages");
@@ -306,7 +303,7 @@ public class ContributionsIndexer {
     if (tool == null) {
       return null;
     }
-    DownloadableContribution contrib = tool.getDownloadableContribution(platform);
+    DownloadableContribution contrib = tool.getDownloadableContribution();
     if (contrib == null) {
       System.err.println(tool + " seems to have no downloadable contributions for your operating system, but it is installed in\n" + installationFolder);
       return null;

--- a/arduino-core/src/cc/arduino/contributions/packages/HostDependentDownloadableContribution.java
+++ b/arduino-core/src/cc/arduino/contributions/packages/HostDependentDownloadableContribution.java
@@ -30,7 +30,6 @@
 package cc.arduino.contributions.packages;
 
 import cc.arduino.contributions.DownloadableContribution;
-import processing.app.Platform;
 
 public abstract class HostDependentDownloadableContribution extends DownloadableContribution {
 
@@ -41,12 +40,13 @@ public abstract class HostDependentDownloadableContribution extends Downloadable
     return getHost() + " " + super.toString();
   }
 
-  public boolean isCompatible(Platform platform) {
-    String osName = platform.getOsName();
-    assert osName != null;
-    String osArch = platform.getOsArch();
-    assert osArch != null;
+  public boolean isCompatible() {
+    String osName = System.getProperty("os.name");
+    String osArch = System.getProperty("os.arch");
+    return isCompatible(osName, osArch);
+  }
 
+  public boolean isCompatible(String osName, String osArch) {
     String host = getHost();
 
     if (osName.contains("Linux")) {

--- a/arduino-core/src/cc/arduino/utils/ArchiveExtractor.java
+++ b/arduino-core/src/cc/arduino/utils/ArchiveExtractor.java
@@ -37,6 +37,8 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.utils.IOUtils;
+
+import processing.app.BaseNoGui;
 import processing.app.I18n;
 import processing.app.Platform;
 
@@ -50,9 +52,8 @@ public class ArchiveExtractor {
 
   private final Platform platform;
 
-  public ArchiveExtractor(Platform platform) {
-    assert platform != null;
-    this.platform = platform;
+  public ArchiveExtractor() {
+    platform = BaseNoGui.getPlatform();
   }
 
   /**

--- a/arduino-core/src/processing/app/BaseNoGui.java
+++ b/arduino-core/src/processing/app/BaseNoGui.java
@@ -476,8 +476,7 @@ public class BaseNoGui {
   }
 
   static public void initPackages() throws Exception {
-    indexer = new ContributionsIndexer(getSettingsFolder(), getHardwareFolder(), getPlatform(),
-        new GPGDetachedSignatureVerifier());
+    indexer = new ContributionsIndexer(getSettingsFolder(), getHardwareFolder(), new GPGDetachedSignatureVerifier());
 
     try {
       indexer.parseIndex();

--- a/arduino-core/src/processing/app/SketchFile.java
+++ b/arduino-core/src/processing/app/SketchFile.java
@@ -30,6 +30,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -245,6 +246,11 @@ public class SketchFile {
   @Override
   public boolean equals(Object o) {
     return (o instanceof SketchFile) && file.equals(((SketchFile) o).file);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(file);
   }
 
   /**

--- a/arduino-core/src/processing/app/packages/UserLibrary.java
+++ b/arduino-core/src/processing/app/packages/UserLibrary.java
@@ -30,7 +30,7 @@ package processing.app.packages;
 
 import cc.arduino.Constants;
 import cc.arduino.contributions.VersionHelper;
-import cc.arduino.contributions.libraries.ContributedLibraryReference;
+import cc.arduino.contributions.libraries.ContributedLibraryDependency;
 import processing.app.helpers.PreferencesMap;
 import processing.app.packages.UserLibraryFolder.Location;
 
@@ -222,7 +222,7 @@ public class UserLibrary {
     return maintainer;
   }
 
-  public List<ContributedLibraryReference> getRequires() {
+  public List<ContributedLibraryDependency> getRequires() {
     return null;
   }
 


### PR DESCRIPTION
This change allows to install additional libraries in user sketchbook when a platform is installed.
As already explained in #3082:
> This would allow some third party board which relies on some library to work right out of the box.

The change in the `package_index.json` format is the following:
```diff
      "platforms": [
        {
          "name": "Arduino SAM Boards (32-bits ARM Cortex-M3)",
          "architecture": "sam",
          "version": "1.6.10",
          "category": "Arduino",
          "url": "http://downloads.arduino.cc/cores/sam-1.6.10.tar.bz2",
          "archiveFileName": "sam-1.6.10.tar.bz2",
          "checksum": "SHA-256:c53afc342c4017a4f67b96826ace41653f795f4a82e648eb9a190ad995388906",
          "size": "16474738",
          "boards": [
            {"name": "Arduino Due"}
          ],
+         "librariesDependencies" : [
+           { "name": "alib" },
+           { "name": "anotherlib" },
+           { "name": "yetanotherlib" }
+         ],
          "toolsDependencies": [
            {
              "packager": "arduino",
              "name": "arm-none-eabi-gcc",
              "version": "4.8.3-2014q1"
            },
            {
              "packager": "arduino",
              "name": "bossac",
              "version": "1.6.1-arduino"
            }
          ]
        }
      ],
```



Fixes #3082
