### PR TITLE
Replace boolean type with bool in examples

### DIFF
--- a/build/shared/examples/04.Communication/SerialEvent/SerialEvent.ino
+++ b/build/shared/examples/04.Communication/SerialEvent/SerialEvent.ino
@@ -19,7 +19,7 @@
 */
 
 String inputString = "";         // a String to hold incoming data
-boolean stringComplete = false;  // whether the string is complete
+bool stringComplete = false;  // whether the string is complete
 
 void setup() {
   // initialize serial:

--- a/build/shared/examples/09.USB/Mouse/JoystickMouseControl/JoystickMouseControl.ino
+++ b/build/shared/examples/09.USB/Mouse/JoystickMouseControl/JoystickMouseControl.ino
@@ -44,7 +44,7 @@ int responseDelay = 5;        // response delay of the mouse, in ms
 int threshold = range / 4;    // resting threshold
 int center = range / 2;       // resting position value
 
-boolean mouseIsActive = false;    // whether or not to control the mouse
+bool mouseIsActive = false;    // whether or not to control the mouse
 int lastSwitchState = LOW;        // previous switch state
 
 void setup() {

--- a/build/shared/examples/10.StarterKit_BasicKit/p12_KnockLock/p12_KnockLock.ino
+++ b/build/shared/examples/10.StarterKit_BasicKit/p12_KnockLock/p12_KnockLock.ino
@@ -46,7 +46,7 @@ const int quietKnock = 10;
 const int loudKnock = 100;
 
 // variable to indicate if locked or not
-boolean locked = false;
+bool locked = false;
 // how many valid knocks you've received
 int numberOfKnocks = 0;
 
@@ -146,7 +146,7 @@ void loop() {
 }
 
 // this function checks to see if a detected knock is within max and min range
-boolean checkForKnock(int value) {
+bool checkForKnock(int value) {
   // if the value of the knock is greater than the minimum, and larger
   // than the maximum
   if (value > quietKnock && value < loudKnock) {


### PR DESCRIPTION
This is part of a move to encourage use of the standard `bool` type over Arduino's non-standard `boolean` type alias.

As approved by cmaglie: https://github.com/arduino/Arduino/issues/6657#issuecomment-355597633