### PR TITLE
Fixed the bug that doesn't updates the title when an example sketch is saved

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -1970,7 +1970,7 @@ public class Editor extends JFrame implements RunnerListener {
     return true;
   }
 
-  private void updateTitle() {
+  public void updateTitle() {
     if (sketchController == null) {
       return;
     }

--- a/app/src/processing/app/SketchController.java
+++ b/app/src/processing/app/SketchController.java
@@ -438,7 +438,7 @@ public class SketchController {
     //editor.sketchbook.rebuildMenusAsync();
     editor.base.rebuildSketchbookMenus();
     editor.header.rebuild();
-
+    editor.updateTitle();
     // Make sure that it's not an untitled sketch
     setUntitled(false);
 


### PR DESCRIPTION
Added a line to update the title when a example sketch is saved, also changed the updateTitle method from private to public 

Resolves: #6216