### PR TITLE
Correct messages regarding sketch/library folder name restrictions

### DIFF
--- a/app/src/processing/app/SketchController.java
+++ b/app/src/processing/app/SketchController.java
@@ -846,8 +846,9 @@ public class SketchController {
 
     if (!newName.equals(origName)) {
       String msg =
-        tr("The sketch name had to be modified. Sketch names can only consist\n" +
-          "of ASCII characters and numbers and be less than 64 characters long.");
+        tr("The sketch name had to be modified.\n" +
+          "Sketch names must start with a letter or number, followed by letters,\n" +
+          "numbers, dashes, dots and underscores. Maximum length is 63 characters.");
       System.out.println(msg);
     }
     return newName;

--- a/arduino-core/src/cc/arduino/contributions/libraries/LibrariesIndexer.java
+++ b/arduino-core/src/cc/arduino/contributions/libraries/LibrariesIndexer.java
@@ -178,8 +178,8 @@ public class LibrariesIndexer {
           badLibNotified.add(subfolderName);
 
           String mess = I18n.format(tr("The library \"{0}\" cannot be used.\n"
-              + "Library names must contain only basic letters and numbers.\n"
-              + "(ASCII only and no spaces, and it cannot start with a number)"),
+              + "Library folder names must start with a letter or number, followed by letters,\n"
+              + "numbers, dashes, dots and underscores. Maximum length is 63 characters."),
               subfolderName);
           BaseNoGui.showMessage(tr("Ignoring bad library name"), mess);
         }


### PR DESCRIPTION
- Specify that library name error is about folder name.
  - We would normally expect "library name" to mean the "fancy name" (as defined by the library.properties name field).
- Specify exactly which characters are allowed.
- State that spaces are prohibited in sketch folder name.
- Make sketch and library messages consistent.
- Remove outdated message about library folders not being allowed to start with a number.
  - This restriction was removed by 4545283).
- State library folder name length restriction.

Fixes https://github.com/arduino/Arduino/issues/7613