### PR TITLE
Preferences option to allow use of sketch's platform.sketch.txt file

### DIFF
--- a/app/src/cc/arduino/view/preferences/Preferences.java
+++ b/app/src/cc/arduino/view/preferences/Preferences.java
@@ -130,6 +130,7 @@ public class Preferences extends javax.swing.JDialog {
     checkboxesContainer = new javax.swing.JPanel();
     displayLineNumbersBox = new javax.swing.JCheckBox();
     enableCodeFoldingBox = new javax.swing.JCheckBox();
+    usePlatformSketchTxtBox = new javax.swing.JCheckBox();
     verifyUploadBox = new javax.swing.JCheckBox();
     externalEditorBox = new javax.swing.JCheckBox();
     cacheCompiledCore = new javax.swing.JCheckBox();
@@ -255,6 +256,9 @@ public class Preferences extends javax.swing.JDialog {
 
     enableCodeFoldingBox.setText(tr("Enable Code Folding"));
     checkboxesContainer.add(enableCodeFoldingBox);
+
+    usePlatformSketchTxtBox.setText(tr("Allow use of platform.sketch.txt file"));
+    checkboxesContainer.add(usePlatformSketchTxtBox);
 
     verifyUploadBox.setText(tr("Verify code after upload"));
     checkboxesContainer.add(verifyUploadBox);
@@ -728,6 +732,7 @@ public class Preferences extends javax.swing.JDialog {
   private javax.swing.JLabel comboWarningsLabel;
   private javax.swing.JCheckBox displayLineNumbersBox;
   private javax.swing.JCheckBox enableCodeFoldingBox;
+  private javax.swing.JCheckBox usePlatformSketchTxtBox;
   private javax.swing.JButton extendedAdditionalUrlFieldWindow;
   private javax.swing.JCheckBox externalEditorBox;
   private javax.swing.JCheckBox cacheCompiledCore;
@@ -828,6 +833,8 @@ public class Preferences extends javax.swing.JDialog {
 
     PreferencesData.setBoolean("editor.code_folding", enableCodeFoldingBox.isSelected());
 
+    PreferencesData.setBoolean("builder.use_platform_sketch_txt", usePlatformSketchTxtBox.isSelected());
+
     PreferencesData.setBoolean("upload.verify", verifyUploadBox.isSelected());
 
     PreferencesData.setBoolean("editor.save_on_verify", saveVerifyUploadBox.isSelected());
@@ -901,6 +908,8 @@ public class Preferences extends javax.swing.JDialog {
     displayLineNumbersBox.setSelected(PreferencesData.getBoolean("editor.linenumbers"));
 
     enableCodeFoldingBox.setSelected(PreferencesData.getBoolean("editor.code_folding"));
+
+    usePlatformSketchTxtBox.setSelected(PreferencesData.getBoolean("builder.use_platform_sketch_txt"));
 
     verifyUploadBox.setSelected(PreferencesData.getBoolean("upload.verify"));
 

--- a/arduino-core/src/cc/arduino/Compiler.java
+++ b/arduino-core/src/cc/arduino/Compiler.java
@@ -266,6 +266,10 @@ public class Compiler implements MessageConsumer {
       cmd.add(buildCache.getAbsolutePath());
     }
 
+    if (PreferencesData.getBoolean("builder.use_platform_sketch_txt")) {
+      cmd.add("-use-platform-sketch-txt");
+    }
+
     PreferencesData.getMap()
       .subTree("runtime.build_properties_custom")
       .entrySet()


### PR DESCRIPTION
Allow (or not, by default) arduino-builder to use sketch's `platform.sketch.txt` file.
See: https://github.com/arduino/arduino-builder/pull/282
