### PR TITLE
Added preference key to disable preferences.txt saving

### DIFF
--- a/arduino-core/src/processing/app/PreferencesData.java
+++ b/arduino-core/src/processing/app/PreferencesData.java
@@ -1,14 +1,9 @@
 package processing.app;
 
-import org.apache.commons.compress.utils.IOUtils;
+import static processing.app.I18n.format;
+import static processing.app.I18n.tr;
 
-import cc.arduino.i18n.Languages;
-import processing.app.helpers.PreferencesHelper;
-import processing.app.helpers.PreferencesMap;
-import processing.app.legacy.PApplet;
-import processing.app.legacy.PConstants;
-
-import java.awt.*;
+import java.awt.Font;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -18,7 +13,13 @@ import java.util.Iterator;
 import java.util.MissingResourceException;
 import java.util.stream.Collectors;
 
-import static processing.app.I18n.tr;
+import org.apache.commons.compress.utils.IOUtils;
+
+import cc.arduino.i18n.Languages;
+import processing.app.helpers.PreferencesHelper;
+import processing.app.helpers.PreferencesMap;
+import processing.app.legacy.PApplet;
+import processing.app.legacy.PConstants;
 
 
 public class PreferencesData {
@@ -136,6 +137,9 @@ public class PreferencesData {
       }
 
       writer.flush();
+    } catch (Throwable e) {
+      System.err.println(format(tr("Could not write preferences file: {0}"), e.getMessage()));
+      return;
     } finally {
       IOUtils.closeQuietly(writer);
     }

--- a/arduino-core/src/processing/app/PreferencesData.java
+++ b/arduino-core/src/processing/app/PreferencesData.java
@@ -114,6 +114,9 @@ public class PreferencesData {
     if (!doSave)
       return;
 
+    if (getBoolean("preferences.readonly"))
+      return;
+
     // on startup, don't worry about it
     // this is trying to update the prefs for who is open
     // before Preferences.init() has been called.

--- a/arduino-core/src/processing/app/legacy/PApplet.java
+++ b/arduino-core/src/processing/app/legacy/PApplet.java
@@ -566,12 +566,9 @@ public class PApplet {
       if (file == null) {
         throw new RuntimeException("File passed to createWriter() was null");
       } else {
-        e.printStackTrace();
-        throw new RuntimeException("Couldn't create a writer for " +
-                                   file.getAbsolutePath());
+        throw new RuntimeException("Couldn't create a writer for " + file.getAbsolutePath(), e);
       }
     }
-    //return null;
   }
 
 

--- a/arduino-core/src/processing/app/legacy/PApplet.java
+++ b/arduino-core/src/processing/app/legacy/PApplet.java
@@ -552,23 +552,20 @@ public class PApplet {
   /**
    * I want to print lines to a file. I have RSI from typing these
    * eight lines of code so many times.
+   * @throws IOException
    */
-  static public PrintWriter createWriter(File file) {
+  static public PrintWriter createWriter(File file) throws IOException {
+    createPath(file);  // make sure in-between folders exist
+    OutputStream output = new FileOutputStream(file);
     try {
-      createPath(file);  // make sure in-between folders exist
-      OutputStream output = new FileOutputStream(file);
       if (file.getName().toLowerCase().endsWith(".gz")) {
         output = new GZIPOutputStream(output);
       }
-      return createWriter(output);
-
-    } catch (Exception e) {
-      if (file == null) {
-        throw new RuntimeException("File passed to createWriter() was null");
-      } else {
-        throw new RuntimeException("Couldn't create a writer for " + file.getAbsolutePath(), e);
-      }
+    } catch (IOException e) {
+      output.close();
+      throw e;
     }
+    return createWriter(output);
   }
 
 

--- a/build/shared/lib/preferences.txt
+++ b/build/shared/lib/preferences.txt
@@ -279,6 +279,9 @@ serial.line_ending=1
 # default chosen language (none for none)
 editor.languages.current = 
 
+# Disable saving of preferences.txt file (settings will not survive Arduino IDE reboot)
+preferences.readonly=false
+
 # Debugging/Development Preferences
 # ---------------------------------
 


### PR DESCRIPTION
This may help with shared portable folders or read-only installations of the Arduino IDE, just change the line in `prefereces.txt` from:
```
preferences.readonly=false
```

to

```
preferences.readonly=true
```

and the IDE will not try to save the file back (any change to the preferences will be lost after closing the IDE)

Fix #5668

@hanabanana
