### PR TITLE
Avoid performing non trivial operations on files

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -1754,46 +1754,15 @@ public class Editor extends JFrame implements RunnerListener {
       } else {
         String properParent = fileName.substring(0, fileName.length() - 4);
 
-        Object[] options = {tr("OK"), tr("Cancel")};
+        Object[] options = {tr("OK")};
         String prompt = I18n.format(tr("The file \"{0}\" needs to be inside\n" +
-            "a sketch folder named \"{1}\".\n" +
-            "Create this folder, move the file, and continue?"),
+            "a sketch folder named \"{1}\".\n"),
           fileName,
           properParent);
 
-        int result = JOptionPane.showOptionDialog(this, prompt, tr("Moving"), JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null, options, options[0]);
+        int result = JOptionPane.showOptionDialog(this, prompt, tr("Error"), JOptionPane.OK_OPTION, JOptionPane.ERROR_MESSAGE, null, options, options[0]);
 
-        if (result != JOptionPane.YES_OPTION) {
-          return false;
-        }
-
-        // create properly named folder
-        File properFolder = new File(sketchFile.getParent(), properParent);
-        if (properFolder.exists()) {
-          Base.showWarning(tr("Error"), I18n.format(tr("A folder named \"{0}\" already exists. " +
-            "Can't open sketch."), properParent), null);
-          return false;
-        }
-        if (!properFolder.mkdirs()) {
-          //throw new IOException("Couldn't create sketch folder");
-          Base.showWarning(tr("Error"), tr("Could not create the sketch folder."), null);
-          return false;
-        }
-        // copy the sketch inside
-        File properPdeFile = new File(properFolder, sketchFile.getName());
-        try {
-          FileUtils.copy(new File(sketchFile.getParent()), properFolder);
-        } catch (IOException e) {
-          Base.showWarning(tr("Error"), tr("Could not copy to a proper location."), e);
-          return false;
-        }
-
-        // remove the original file, so user doesn't get confused
-        sketchFile.delete();
-
-        // update with the new path
-        file = properPdeFile;
-
+        return false;
       }
     }
 


### PR DESCRIPTION
Fixes https://github.com/arduino/Arduino/issues/7843 as per @cmaglie comment.

Translations should be updated removing the second part of the information text.

RATIONALE:
* The IDE used to ask the user if s/he wanted to move a file inside the folder with the same name (on double click, for example)
* This approach only works for single file sketches; for anything more complicated, the file would be moved but not the whole project (causing compile failures)
* #6404 tried to fix this by moving ALL the files inside a folder with the same name (works if you downloaded a project from github as ProjectName-master)

Problem: most of the times .ino files downloads from the web are being saved in the Download folder, so the move operation copied the whole Downloads content into that folder :flushed: 

@cmaglie suggested the IDE shouldn't be allowed to do this kind of operations; this patch removes the automatic move and requires the user to create the folder and move .ino file inside it manually
 