### PR TITLE
Gracefully handle libraries having unparsable version info

### DIFF
--- a/arduino-core/src/processing/app/packages/UserLibrary.java
+++ b/arduino-core/src/processing/app/packages/UserLibrary.java
@@ -149,6 +149,10 @@ public class UserLibrary {
 
     String declaredVersion = properties.get("version").trim();
     Version version = VersionHelper.valueOf(declaredVersion);
+    if (version == null) {
+      System.err.println("Can't parse library version in " + propertiesFile.toString());
+      version = VersionHelper.valueOf("0.0.1"); // version must not be null
+    }
 
     UserLibrary res = new UserLibrary();
     res.installedFolder = libFolder;


### PR DESCRIPTION
If any library has malformed version info in its library.properties file, the Arduino IDE fails to launch.  If run from the command line, or arduino-debug.exe on Windows, the user sees a very unhelpful error telling then only "Invalid version found", but not *which* library is causing the problem.

This patch adds a more helpful message, and falls back to version "0.0.1" to allow the IDE to launch.

To test for this problem, simply install any library, then edit its library.properties.  I tested with DMXSerial2, changing it to "version=1.02.0".  The IDE is unable to start, and the user gets stuck without any reasonable way to discover which file is causing the problem.