### PR TITLE
Fix OSX "slow" menus

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -508,7 +508,7 @@ public class Editor extends JFrame implements RunnerListener {
         if (!components.contains(sketchbookMenu)) {
           fileMenu.insert(sketchbookMenu, 3);
         }
-        if (!components.contains(sketchbookMenu)) {
+        if (!components.contains(examplesMenu)) {
           fileMenu.insert(examplesMenu, 4);
         }
         fileMenu.revalidate();

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -262,8 +262,6 @@ public class Editor extends JFrame implements RunnerListener {
         // added for 1.0.5
         // http://dev.processing.org/bugs/show_bug.cgi?id=1260
         public void windowDeactivated(WindowEvent e) {
-          fileMenu.remove(sketchbookMenu);
-          fileMenu.remove(examplesMenu);
           List<Component> toolsMenuItemsToRemove = new LinkedList<>();
           for (Component menuItem : toolsMenu.getMenuComponents()) {
             if (menuItem instanceof JComponent) {
@@ -504,7 +502,7 @@ public class Editor extends JFrame implements RunnerListener {
     fileMenu.addMenuListener(new StubMenuListener() {
       @Override
       public void menuSelected(MenuEvent e) {
-        List<Component> components = Arrays.asList(fileMenu.getComponents());
+        List<Component> components = Arrays.asList(fileMenu.getMenuComponents());
         if (!components.contains(sketchbookMenu)) {
           fileMenu.insert(sketchbookMenu, 3);
         }
@@ -537,7 +535,7 @@ public class Editor extends JFrame implements RunnerListener {
     toolsMenu.addMenuListener(new StubMenuListener() {
       @Override
       public void menuSelected(MenuEvent e) {
-        List<Component> components = Arrays.asList(toolsMenu.getComponents());
+        List<Component> components = Arrays.asList(toolsMenu.getMenuComponents());
         int offset = 0;
         for (JMenu menu : base.getBoardsCustomMenus()) {
           if (!components.contains(menu)) {


### PR DESCRIPTION
JRE 8u161 made `JMenu.insert()` MUCH slower on OSX.
This exposed a bug lurking there for years; in fact the menu entries were rebuilt every time since `JMenu.getComponent()` returns an empty list.
The correct function is `JMenu.getMenuComponents()`
In the meantime, also remove `sketchbookMenu` and `examplesMenu` deletion on board change; only their content needs to be updated, not the container itself.

Fixes #7924