### PR TITLE
make "Increase Font Size" menu item a newJMenuItemShift() item

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -1240,7 +1240,7 @@ public class Editor extends JFrame implements RunnerListener {
 
     menu.addSeparator();
 
-    JMenuItem increaseFontSizeItem = newJMenuItem(tr("Increase Font Size"), KeyEvent.VK_PLUS);
+    JMenuItem increaseFontSizeItem = newJMenuItemShift(tr("Increase Font Size"), KeyEvent.VK_PLUS);
     increaseFontSizeItem.addActionListener(event -> base.handleFontSizeChange(1));
     menu.add(increaseFontSizeItem);
     // Add alternative shortcut "CTRL SHIFT =" for keyboards that haven't the "+" key


### PR DESCRIPTION
This displays the shift symbol, in the Edit menu next to "Increase Font Size", showing us that we need to hold down shift to increase font size on mac os

do we need to do a OSUtils.isMacOS()?