### PR TITLE
Java now requires MacOSX 10.8 Mountain Lion or later

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -402,7 +402,7 @@
             mainclassname="processing.app.Base"
             copyright="Arduino LLC"
             applicationCategory="public.app-category.education"
-            minimumsystemversion="10.7"
+            minimumsystemversion="10.8"
             highresolutioncapable="true">
 
       <runtime dir="${MACOSX_BUNDLED_JVM}"/>


### PR DESCRIPTION
Fixes #7945.

Users with 10.7 will see message, instead of having the IDE appear to start and then crash for no apparent reason.

![mac10 8](https://user-images.githubusercontent.com/965463/44903932-abc13900-acc2-11e8-863f-8bd62b3e7144.png)

