### PR TITLE
Improve first use experience for Upload before Port selected

### DIFF
--- a/app/src/processing/app/SketchController.java
+++ b/app/src/processing/app/SketchController.java
@@ -709,6 +709,10 @@ public class SketchController {
 
     UploaderUtils uploaderInstance = new UploaderUtils();
     Uploader uploader = uploaderInstance.getUploaderByPreferences(false);
+    if (uploader == null) {
+      editor.statusError(tr("Please select a Port before Upload"));
+      return false;
+    }
 
     EditorConsole.setCurrentEditorConsole(editor.console);
 

--- a/arduino-core/src/cc/arduino/UploaderUtils.java
+++ b/arduino-core/src/cc/arduino/UploaderUtils.java
@@ -55,11 +55,6 @@ public class UploaderUtils {
         return null;
       }
       boardPort = BaseNoGui.getDiscoveryManager().find(port);
-      //if (boardPort == null) {
-        // Is there ever a reason to attempt upload when
-        // the Port is not found by DiscoveryManager?
-        //return null;
-      //}
     }
 
     return new UploaderFactory().newUploader(target.getBoards().get(board), boardPort, noUploadPort);

--- a/arduino-core/src/cc/arduino/UploaderUtils.java
+++ b/arduino-core/src/cc/arduino/UploaderUtils.java
@@ -50,7 +50,16 @@ public class UploaderUtils {
 
     BoardPort boardPort = null;
     if (!noUploadPort) {
-      boardPort = BaseNoGui.getDiscoveryManager().find(PreferencesData.get("serial.port"));
+      String port = PreferencesData.get("serial.port");
+      if (port == null || port.isEmpty()) {
+        return null;
+      }
+      boardPort = BaseNoGui.getDiscoveryManager().find(port);
+      //if (boardPort == null) {
+        // Is there ever a reason to attempt upload when
+        // the Port is not found by DiscoveryManager?
+        //return null;
+      //}
     }
 
     return new UploaderFactory().newUploader(target.getBoards().get(board), boardPort, noUploadPort);

--- a/build/shared/lib/preferences.txt
+++ b/build/shared/lib/preferences.txt
@@ -267,7 +267,8 @@ programmer = arduino:avrispmkii
 upload.using = bootloader
 upload.verify = true
 
-serial.port=COM1
+#default port is empty to prevent running AVRDUDE before Port selected (issue #7943)
+serial.port=
 serial.databits=8
 serial.stopbits=1
 serial.parity=N


### PR DESCRIPTION
Fixes #7943

When running the IDE for the first time, this appears if Upload is attempted before selecting a Port.

![capture](https://user-images.githubusercontent.com/965463/44908882-129a1e80-acd2-11e8-8484-42a0867a8a5b.png)
