### PR TITLE
Regression: fixed wrong BUILTIN_AS_LAST comparator

### DIFF
--- a/arduino-core/src/cc/arduino/contributions/packages/ContributedPlatform.java
+++ b/arduino-core/src/cc/arduino/contributions/packages/ContributedPlatform.java
@@ -87,7 +87,7 @@ public abstract class ContributedPlatform extends DownloadableContribution {
   public static final Comparator<ContributedPlatform> BUILTIN_AS_LAST = (x, y) -> {
     int px = x.isBuiltIn() ? 1 : -1;
     int py = y.isBuiltIn() ? 1 : -1;
-    return py - px;
+    return px - py;
   };
 
   private Map<ContributedToolReference, ContributedTool> resolvedToolReferences;

--- a/build/shared/revisions.txt
+++ b/build/shared/revisions.txt
@@ -7,6 +7,7 @@ ARDUINO 1.8.7 2018.09.11
 * Fixed: IDE doesn't start if a library with invalid version is found.
 * Fixed: Better dialog explaining that MacOSX 10.8 is now required. Thanks @PaulStoffregen
 * Fixed: Slow "File" and "Tools" menus in MacOSX
+* Fixed: Weird Board Manager behaviour if AVR core is downgraded to a version earlier than 1.6.22
 * Improved first-use usability if the user don't select the serial port. Thanks @PaulStoffregen
 * Custom "Tools" menu now keeps the order as defined in boards.txt.
 


### PR DESCRIPTION
This bug has been introduced with b3d01d82810b5ac895623bdaebb647bf82bee1e4

Fix #7973