### PR TITLE
Serial & Port shortcut bar Add-On

### DIFF
--- a/app/src/cc/arduino/view/preferences/Preferences.java
+++ b/app/src/cc/arduino/view/preferences/Preferences.java
@@ -136,6 +136,8 @@ public class Preferences extends javax.swing.JDialog {
     checkUpdatesBox = new javax.swing.JCheckBox();
     updateExtensionBox = new javax.swing.JCheckBox();
     saveVerifyUploadBox = new javax.swing.JCheckBox();
+    enableBoardsBarBox = new javax.swing.JCheckBox();
+    enableSerialBarBox = new javax.swing.JCheckBox();
     jLabel1 = new javax.swing.JLabel();
     jLabel2 = new javax.swing.JLabel();
     scaleSpinner = new javax.swing.JSpinner();
@@ -288,6 +290,12 @@ public class Preferences extends javax.swing.JDialog {
 
     saveVerifyUploadBox.setText(tr("Save when verifying or uploading"));
     checkboxesContainer.add(saveVerifyUploadBox);
+    
+    enableBoardsBarBox.setText(tr("Enable boards shortcut bar"));
+    checkboxesContainer.add(enableBoardsBarBox);
+    
+    enableSerialBarBox.setText(tr("Enable serial ports shortcut bar"));
+    checkboxesContainer.add(enableSerialBarBox);
 
     jLabel1.setText(tr("Interface scale:"));
 
@@ -755,6 +763,8 @@ public class Preferences extends javax.swing.JDialog {
   private javax.swing.ButtonGroup proxyTypeButtonGroup;
   private javax.swing.JLabel requiresRestartLabel;
   private javax.swing.JCheckBox saveVerifyUploadBox;
+  private javax.swing.JCheckBox enableBoardsBarBox;
+  private javax.swing.JCheckBox enableSerialBarBox;
   private javax.swing.JSpinner scaleSpinner;
   private javax.swing.JLabel showVerboseLabel;
   private javax.swing.JTextField sketchbookLocationField;
@@ -840,8 +850,10 @@ public class Preferences extends javax.swing.JDialog {
 
     PreferencesData.setBoolean("editor.update_extension", updateExtensionBox.isSelected());
 
-    PreferencesData.setBoolean("editor.save_on_verify", saveVerifyUploadBox.isSelected());
-
+    PreferencesData.setBoolean("editor.enable_boards_bar", enableBoardsBarBox.isSelected());
+    
+    PreferencesData.setBoolean("editor.enable_serial_bar", enableSerialBarBox.isSelected());
+    
     PreferencesData.set("boardsmanager.additional.urls", additionalBoardsManagerField.getText().replace("\r\n", "\n").replace("\r", "\n").replace("\n", ","));
 
     PreferencesData.set(Constants.PREF_PROXY_TYPE, proxyTypeButtonGroup.getSelection().getActionCommand());
@@ -913,7 +925,11 @@ public class Preferences extends javax.swing.JDialog {
     updateExtensionBox.setSelected(PreferencesData.get("editor.update_extension") == null || PreferencesData.getBoolean("editor.update_extension"));
 
     saveVerifyUploadBox.setSelected(PreferencesData.getBoolean("editor.save_on_verify"));
-
+    
+    enableBoardsBarBox.setSelected(PreferencesData.getBoolean("editor.enable_boards_bar"));
+    
+    enableSerialBarBox.setSelected(PreferencesData.getBoolean("editor.enable_serial_bar"));
+    
     additionalBoardsManagerField.setText(PreferencesData.get("boardsmanager.additional.urls"));
 
     disableAllProxyFields();

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1510,7 +1510,7 @@ public class Base {
       public void actionPerformed(ActionEvent actionevent) {
         BaseNoGui.selectBoard((TargetBoard) getValue("b"));
         filterVisibilityOfSubsequentBoardMenus(boardsCustomMenus, (TargetBoard) getValue("b"), 1);
-
+        BoardsBar.addBoardPreference(board.getId(), targetPlatform.getId(), targetPackage.getId());
         onBoardOrPortChange();
         rebuildImportMenu(Editor.importMenu);
         rebuildExamplesMenu(Editor.examplesMenu);

--- a/app/src/processing/app/BoardsBar.java
+++ b/app/src/processing/app/BoardsBar.java
@@ -1,0 +1,188 @@
+/* -*- mode: java; c-basic-offset: 2; indent-tabs-mode: nil -*- */
+
+/*
+  Part of the Processing project - http://processing.org
+
+  Copyright (c) 2004-09 Ben Fry and Casey Reas
+  Copyright (c) 2001-04 Massachusetts Institute of Technology
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+package processing.app;
+import javax.swing.*;
+import javax.swing.event.MouseInputListener;
+import javax.swing.text.SimpleAttributeSet;
+
+import cc.arduino.packages.BoardPort;
+import processing.app.Editor.SerialMenuListener;
+import processing.app.SerialBar.SerialBarListener;
+import processing.app.debug.TargetBoard;
+
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import java.io.File;
+
+import static processing.app.I18n.tr;
+import static processing.app.Theme.scale;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Serial bar to show SerialBarButton(s) representing serial ports, added by Felix Rusu
+ */
+public class BoardsBar extends JPanel {
+  private final Editor editor;
+  
+  class BoardsBarListener implements ActionListener {
+    private final String board;
+
+    public BoardsBarListener(String board) {
+      this.board = board;
+    }
+
+    public void actionPerformed(ActionEvent e) {
+      //editor.selectBoard(board);
+      //editor.base.onBoardOrPortChange();
+      //refresh();
+    }
+  }
+  
+  public BoardsBar(Editor editor) {
+    this.editor = editor;
+    refresh(true);
+  }
+
+  public void refresh(boolean init) {
+    if (!init) this.removeAll();
+    setLayout(new FlowLayout(FlowLayout.LEFT));
+
+    String selBoard = PreferencesData.get("board");
+    String selPackage = PreferencesData.get("target_package");
+    String selPlatform = PreferencesData.get("target_platform");
+
+    int count=0;
+    for (String board : PreferencesData.getCollection("recent.boards")) {
+      String[] brd = board.split(":");
+      if (brd.length != 3) continue;
+
+      //find the board in the Boards menu, and assign the shortcut button the same action as the menu action
+      JMenuItem itemToClick = null;
+      String brdName = brd[0];
+      for (JMenu menu : editor.base.getBoardsCustomMenus()) {
+        for (int i=0;i<menu.getItemCount();i++)
+        {
+          if (menu.getItem(i) instanceof JRadioButtonMenuItem)
+          {
+            JRadioButtonMenuItem menuItem = (JRadioButtonMenuItem) menu.getItem(i);
+            if (menuItem.getAction().getValue("b")!=null)
+            {
+              TargetBoard menuBoard = (TargetBoard)menuItem.getAction().getValue("b");
+              if (menuBoard.getId().equals(brd[0]) && menuBoard.getContainerPlatform().getId().equals(brd[1]) && menuBoard.getContainerPlatform().getContainerPackage().getId().equals(brd[2]))
+              {
+                itemToClick = menuItem;
+                brdName = menuBoard.getName();
+                break;
+              }
+            }
+          }
+        }
+      }
+
+      ShortcutBarButton btn = new ShortcutBarButton(brdName, "", itemToClick, selBoard.equals(brd[0]) && selPlatform.equals(brd[1]) && selPackage.equals(brd[2]), Color.RED);
+      this.add(btn);
+      count++;
+    }
+
+    editor.base.getBoardsCustomMenus();
+
+    if (count == 0) this.add(new JLabel(tr("No boards selected...")));
+    else {
+      addClearButton();
+    }
+    
+    if (!init) {
+      this.revalidate();
+      this.repaint();
+    }
+  }
+  
+  private void addClearButton() {
+    ShortcutBarButton btn = new ShortcutBarButton(tr("[Clear]"), "", null, true, Color.BLUE);
+    btn.addActionListener(new ActionListener() {
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        clear();
+      }
+    });
+    
+    this.add(btn);
+  }
+  
+  public void clear() {
+    for (Component c : this.getComponents()) if (!((ShortcutBarButton)c).selected) this.remove(c);
+    String selBoard = PreferencesData.get("board");
+    String selPackage = PreferencesData.get("target_package");
+    String selPlatform = PreferencesData.get("target_platform");
+    PreferencesData.set("recent.boards", selBoard.concat(":").concat(selPlatform).concat(":").concat(selPackage));
+    this.revalidate();
+    this.repaint();
+  }
+  
+  public static void addBoardPreference(String board, String platform, String pkg) {
+    Set<String> boards = new LinkedHashSet<>();
+    boards.addAll(PreferencesData.getCollection("recent.boards"));
+    for (String brd : boards) if (brd.equals("") || brd.split(":").length!=3) { boards.remove(brd); break; } //cleanup after first init
+    boards.add(board.concat(":").concat(platform).concat(":").concat(pkg));
+
+    int count = boards.size();
+    int keep = 5; //how many shortcut buttons to keep in the bar
+    if (count > keep)
+    {
+      int removed=0;
+      for (String brd: boards) {
+        boards.remove(brd);
+        removed++;
+        if (removed==count-keep) break;
+      }
+    }
+
+    PreferencesData.setCollection("recent.boards", boards);
+  }
+
+  public Dimension getPreferredSize() {
+    return getMinimumSize();
+  }
+
+  public Dimension getMinimumSize() {
+    return new Dimension(100, 32);
+  }
+
+  public Dimension getMaximumSize() {
+    return new Dimension(scale(30000), 32);
+  }
+}

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -179,6 +179,8 @@ public class Editor extends JFrame implements RunnerListener {
   public boolean avoidMultipleOperations = false;
 
   private final EditorToolbar toolbar;
+  private SerialBar toolbar2;
+  private BoardsBar toolbar3;
   // these menus are shared so that they needn't be rebuilt for all windows
   // each time a sketch is created, renamed, or moved.
   static JMenu toolbarMenu;
@@ -281,7 +283,7 @@ public class Editor extends JFrame implements RunnerListener {
     //PdeKeywords keywords = new PdeKeywords();
     //sketchbook = new Sketchbook(this);
 
-    buildMenuBar();
+    //buildMenuBar();
 
     // For rev 0120, placing things inside a JPanel
     Container contentPain = getContentPane();
@@ -299,6 +301,20 @@ public class Editor extends JFrame implements RunnerListener {
     }
     toolbar = new EditorToolbar(this, toolbarMenu);
     upper.add(toolbar);
+    
+    if (PreferencesData.getBoolean("editor.enable_boards_bar"))
+    {
+      toolbar3 = new BoardsBar(this);
+      upper.add(toolbar3);
+    }
+
+    if (PreferencesData.getBoolean("editor.enable_serial_bar"))
+    {
+      toolbar2 = new SerialBar(this);
+      upper.add(toolbar2);
+    }
+
+    buildMenuBar();
 
     header = new EditorHeader(this);
     upper.add(header);
@@ -998,7 +1014,7 @@ public class Editor extends JFrame implements RunnerListener {
 
   }
 
-  private void selectSerialPort(String name) {
+  public void selectSerialPort(String name) {
     if(portMenu == null) {
       System.out.println(tr("serialMenu is null"));
       return;
@@ -2598,6 +2614,7 @@ public class Editor extends JFrame implements RunnerListener {
       lineStatus.setBoardName("-");
     lineStatus.setSerialPort(PreferencesData.get("serial.port"));
     lineStatus.repaint();
+    if (toolbar3 != null) toolbar3.refresh(false);
   }
 
   public void addCompilerProgressListener(CompilerProgressListener listener){

--- a/app/src/processing/app/SerialBar.java
+++ b/app/src/processing/app/SerialBar.java
@@ -1,0 +1,146 @@
+/* -*- mode: java; c-basic-offset: 2; indent-tabs-mode: nil -*- */
+
+/*
+  Part of the Processing project - http://processing.org
+
+  Copyright (c) 2004-09 Ben Fry and Casey Reas
+  Copyright (c) 2001-04 Massachusetts Institute of Technology
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+package processing.app;
+import javax.swing.*;
+import javax.swing.event.MouseInputListener;
+import javax.swing.text.SimpleAttributeSet;
+
+import cc.arduino.packages.BoardPort;
+import processing.app.Editor.SerialMenuListener;
+
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+
+import static processing.app.I18n.tr;
+import static processing.app.Theme.scale;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Serial bar to show SerialBarButton(s) representing serial ports, added by Felix Rusu
+ */
+public class SerialBar extends JPanel {
+  private final Editor editor;
+  
+  class SerialBarListener implements ActionListener {
+    private final String serialPort;
+
+    public SerialBarListener(String serialPort) {
+      this.serialPort = serialPort;
+    }
+
+    public void actionPerformed(ActionEvent e) {
+      editor.selectSerialPort(serialPort);
+      editor.base.onBoardOrPortChange();
+      refresh();
+    }
+  }
+
+  public SerialBar(Editor editor) {
+    this.editor = editor;
+    setLayout(new FlowLayout(FlowLayout.LEFT));
+
+//    JPanel that = this;
+//    JButton btn = new JButton("Random");
+//    btn.addActionListener(new java.awt.event.ActionListener() {
+//      public void actionPerformed(java.awt.event.ActionEvent e) {
+//        JLabel someLabel = new JLabel("[" + Math.random() + "]");
+//        that.add(someLabel);
+//        that.revalidate();
+//        }
+//    });
+//    add(btn);
+    
+    Runnable serialPollRunnable = new Runnable() {
+      public void run() {
+        refresh();
+      }
+    };
+
+    ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+    executor.scheduleAtFixedRate(serialPollRunnable, 0, 1, TimeUnit.SECONDS);
+  }
+  
+  public void refresh() {
+    String selectedPort = PreferencesData.get("serial.port");
+    List<BoardPort> ports = Base.getDiscoveryManager().discovery();
+    ports = editor.platform.filterPorts(ports, PreferencesData.getBoolean("serial.ports.showall"));
+
+    StringBuilder portsString = new StringBuilder();
+    for (BoardPort port : ports) {
+      portsString.append("[");
+      if (selectedPort.equals(port.getAddress()))
+      portsString.append("!");
+      portsString.append(port.getAddress());
+      portsString.append("]");
+    }
+
+    Component[] buttons = this.getComponents();
+    StringBuilder buttonsString = new StringBuilder();
+    for (Component b : buttons) {
+      if (b instanceof ShortcutBarButton)
+      {
+        buttonsString.append(((ShortcutBarButton)b).toString());
+      }
+    }
+
+    if (!(portsString.toString().equals(buttonsString.toString()))) {
+      this.removeAll();
+      int count=0;
+      for (BoardPort port : ports) {
+        String address = port.getAddress();
+        String label = port.getLabel();
+        SerialBarListener listener = new SerialBarListener(address);
+        ShortcutBarButton serBut = new ShortcutBarButton(label, address, null, address.equals(selectedPort), Color.RED);
+        serBut.addActionListener(listener);
+        this.add(serBut);
+        count++;
+      }
+      
+      if (count == 0) this.add(new JLabel(tr("No ports available...")));
+      this.revalidate();
+      this.repaint();
+    }
+  }
+
+  public Dimension getPreferredSize() {
+    return getMinimumSize();
+  }
+
+  public Dimension getMinimumSize() {
+    return new Dimension(100, 32);
+  }
+
+  public Dimension getMaximumSize() {
+    return new Dimension(scale(30000), 32);
+  }
+}

--- a/app/src/processing/app/ShortcutBarButton.java
+++ b/app/src/processing/app/ShortcutBarButton.java
@@ -1,0 +1,46 @@
+package processing.app;
+import java.awt.Color;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import javax.swing.JButton;
+import javax.swing.JMenuItem;
+
+/**
+ * Serial button on serial bar, added by Felix Rusu
+ */
+public class ShortcutBarButton extends JButton {
+  public boolean selected;
+  public String ref;
+  JMenuItem itemToClick;
+  
+  public ShortcutBarButton(String label, String ref, JMenuItem itemToClick, boolean selected, Color selectedColor) {
+    super(label);
+    this.ref = ref;
+    this.selected = selected;
+    this.itemToClick = itemToClick;
+    this.setBackground(selected ? selectedColor : Color.GRAY);
+    this.setForeground(selected ? selectedColor : Color.BLACK);
+    this.setOpaque(true);
+    this.setBorderPainted(false);
+
+    if (itemToClick != null)
+    {
+      addActionListener(new ActionListener() {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+          itemToClick.doClick();
+        }
+      });
+    }
+  }
+  
+  @Override
+  public String toString() {
+    StringBuilder str = new StringBuilder();
+    str.append("[");
+    if (this.selected) str.append("!");
+    str.append(this.ref);
+    str.append("]");
+    return str.toString();
+  }
+}


### PR DESCRIPTION
Super useful shortcut bars to quickly switch between boards & ports.
Enabled via Preferences, they keep last 5 picks for each bar.

Details and video demo + precompiled windows versions here:
https://lowpowerlab.com/2018/03/21/arduino-ide-boards-ports-shortcut-toolbars/

![Image of Yaktocat](https://lowpowerlab.com/wp-content/uploads/2018/03/ArduinoIDE1.png)