### PR TITLE
Handle unexpected events on serial ports

### DIFF
--- a/app/src/processing/app/AbstractMonitor.java
+++ b/app/src/processing/app/AbstractMonitor.java
@@ -85,7 +85,7 @@ public abstract class AbstractMonitor extends JFrame implements ActionListener {
               suspend();
             }
           } else {
-            if (closed) {
+            if (closed && (Editor.avoidMultipleOperations == false)) {
               resume(boardPort);
             }
           }

--- a/app/src/processing/app/AbstractMonitor.java
+++ b/app/src/processing/app/AbstractMonitor.java
@@ -1,6 +1,7 @@
 package processing.app;
 
 import cc.arduino.packages.BoardPort;
+import cc.arduino.packages.DiscoveryManager;
 import processing.app.legacy.PApplet;
 
 import javax.swing.*;
@@ -9,6 +10,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.util.List;
 
 @SuppressWarnings("serial")
 public abstract class AbstractMonitor extends JFrame implements ActionListener {
@@ -17,6 +19,7 @@ public abstract class AbstractMonitor extends JFrame implements ActionListener {
 
   private StringBuffer updateBuffer;
   private Timer updateTimer;
+  private Timer portExistsTimer;
 
   private BoardPort boardPort;
 
@@ -73,6 +76,26 @@ public abstract class AbstractMonitor extends JFrame implements ActionListener {
     updateTimer = new Timer(33, this);  // redraw serial monitor at 30 Hz
     updateTimer.start();
 
+    ActionListener portExists = new ActionListener() {
+      @Override
+      public void actionPerformed(ActionEvent ae) {
+        try {
+          if (!Base.getDiscoveryManager().discovery().contains(boardPort)) {
+            if (!closed) {
+              suspend();
+            }
+          } else {
+            if (closed) {
+              resume(boardPort);
+            }
+          }
+        } catch (Exception e) {}
+      }
+    };
+
+    portExistsTimer = new Timer(1000, portExists);  // check if the port is still there every second
+    portExistsTimer.start();
+
     closed = false;
   }
 
@@ -90,6 +113,11 @@ public abstract class AbstractMonitor extends JFrame implements ActionListener {
     enableWindow(false);
 
     close();
+  }
+
+  public void dispose() {
+    super.dispose();
+    portExistsTimer.stop();
   }
 
   public void resume(BoardPort boardPort) throws Exception {

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -181,7 +181,7 @@ public class Editor extends JFrame implements RunnerListener {
 
   private int numTools = 0;
 
-  public boolean avoidMultipleOperations = false;
+  static public boolean avoidMultipleOperations = false;
 
   private final EditorToolbar toolbar;
   // these menus are shared so that they needn't be rebuilt for all windows

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -1015,22 +1015,20 @@ public class Editor extends JFrame implements RunnerListener {
     //System.out.println(item.getLabel());
 
     BaseNoGui.selectSerialPort(name);
-    if (serialMonitor != null) {
-      try {
+    try {
+      boolean reopenMonitor = ((serialMonitor != null && serialMonitor.isVisible()) ||
+                                serialPlotter != null && serialPlotter.isVisible());
+      if (serialMonitor != null) {
         serialMonitor.close();
-        serialMonitor.setVisible(false);
-      } catch (Exception e) {
-        // ignore
       }
-    }
-
-    if (serialPlotter != null) {
-      try {
+      if (serialPlotter != null) {
         serialPlotter.close();
-        serialPlotter.setVisible(false);
-      } catch (Exception e) {
-        // ignore
       }
+      if (reopenMonitor) {
+        handleSerial();
+      }
+    } catch (Exception e) {
+      // ignore
     }
 
     onBoardOrPortChange();

--- a/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
+++ b/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
@@ -210,9 +210,9 @@ public class SerialUploader extends Uploader {
 
           // Reuse waitForUploadPort for this task, but this time we are simply waiting
           // for one port to reappear. If no port reappears before the timeout, actualUploadPort is selected
-          finalUploadPort = waitForUploadPort(actualUploadPort, Serial.list(), false);
+          finalUploadPort = waitForUploadPort(actualUploadPort, Serial.list(), false, 2000);
         }
-      } catch (InterruptedException ex) {
+      } catch (RunnerException ex) {
         // noop
       }
     }
@@ -229,13 +229,13 @@ public class SerialUploader extends Uploader {
   }
 
   private String waitForUploadPort(String uploadPort, List<String> before) throws InterruptedException, RunnerException {
-	  return waitForUploadPort(uploadPort, before, verbose);
+	  return waitForUploadPort(uploadPort, before, verbose, 10000);
   }
 
-  private String waitForUploadPort(String uploadPort, List<String> before, boolean verbose) throws InterruptedException, RunnerException {
+  private String waitForUploadPort(String uploadPort, List<String> before, boolean verbose, int timeout) throws InterruptedException, RunnerException {
     // Wait for a port to appear on the list
     int elapsed = 0;
-    while (elapsed < 10000) {
+    while (elapsed < timeout) {
       List<String> now = Serial.list();
       List<String> diff = new ArrayList<>(now);
       diff.removeAll(before);


### PR DESCRIPTION
While working with low power, the serial port can disappear/reappear very often (see https://github.com/arduino-libraries/ArduinoLowPower/issues/7).

This makes using the serial monitor very frustrating (especially on Linux) since the port will acquire another name if reconnected while the monitor is open. Changing port will close the monitor for good, so it must be reopened manually.

This patch tries to add a couple of "helpers" to make the situation less terrible.
- Automatically reopens the serial monitor when changing port.
- Suspend the serial monitor when the board disappears, and try resuming when it reappears.
