### PR TITLE
Made the Mangler file compile again

### DIFF
--- a/build/shared/tools/Mangler/src/Mangler.java
+++ b/build/shared/tools/Mangler/src/Mangler.java
@@ -32,6 +32,7 @@ import processing.app.Editor;
 import processing.app.tools.Tool;
 
 
+
 /**
  * Example Tools menu entry.
  */
@@ -69,8 +70,9 @@ public class Mangler implements Tool {
 
 
   protected void mangleSelection() {
-    if (editor.isSelectionActive()) {
-      String selection = editor.getSelectedText();
+    //Check if there is selected text
+    if (editor.getCurrentTab().getSelectedText() != null) {
+      String selection = editor.getCurrentTab().getSelectedText();
       char[] stuff = selection.toCharArray();
       // Randomly swap a bunch of characters in the text
       for (int i = 0; i < stuff.length / 10; i++) {
@@ -82,13 +84,12 @@ public class Mangler implements Tool {
         stuff[a] = selection.charAt(b);
         stuff[b] = selection.charAt(a);
       }
-      editor.startCompoundEdit();
-      editor.setSelectedText(new String(stuff));
-      editor.stopCompoundEdit();
+      editor.getCurrentTab().setSelectedText(new String(stuff));
       editor.statusNotice("Now that feels better, doesn't it?");
 
     } else {
-      editor.statusError("No selection, no dice.");
+      //When there is no selected text
+     editor.statusError("No selection, no dice.");
     }
   }
 }


### PR DESCRIPTION
Mangler is the example file included in the IDE for developers that want to make their own tool. This mangler.java file is way outdated and didn't compile on the recent Arduino IDE pde.jar and arduino-core.jar

The .getCurrentTab() was missing, and for some reason it wouldn't compile with the isSelectionActive() , while I did find the file in https://github.com/arduino/Arduino/blob/master/app/src/processing/app/syntax/SketchTextArea.java . But at least people can compile it after these changes

```
src\Mangler.java:84: error: cannot find symbol
    if (editor.getCurrentTab().isSelectionActive()) {
                              ^
  symbol:   method isSelectionActive()
  location: class EditorTab
1 error
```

```
src\Mangler.java:73: error: cannot find symbol
      String selection = editor.getSelectedText();
                               ^
  symbol:   method getSelectedText()
  location: variable editor of type Editor
src\Mangler.java:86: error: cannot find symbol
      editor.setSelectedText(new String(stuff));
            ^
  symbol:   method setSelectedText(String)
  location: variable editor of type Editor
2 errors

```