### PR TITLE
Ability to override ssh upload port from mDNS info

### DIFF
--- a/arduino-core/src/cc/arduino/packages/discoverers/NetworkDiscovery.java
+++ b/arduino-core/src/cc/arduino/packages/discoverers/NetworkDiscovery.java
@@ -84,6 +84,9 @@ public class NetworkDiscovery implements Discovery, ServiceListener, Runnable {
       String name = serviceEvent.getName();
 
       BoardPort port = new BoardPort();
+      port.setProtocol("network");
+      port.setAddress(address);
+      port.setBoardName(name);
 
       String board = null;
       String description = null;
@@ -100,6 +103,7 @@ public class NetworkDiscovery implements Discovery, ServiceListener, Runnable {
         // define "tcp_check=no" TXT property if you are not using TCP
         // define "auth_upload=yes" TXT property if you want to use authenticated generic upload
         String useSSH = info.getPropertyString("ssh_upload");
+        String SSHUploadPort = info.getPropertyString("ssh_upload_port");
         String checkTCP = info.getPropertyString("tcp_check");
         String useAuth = info.getPropertyString("auth_upload");
         if(useSSH == null || !useSSH.contentEquals("no")) useSSH = "yes";
@@ -108,6 +112,10 @@ public class NetworkDiscovery implements Discovery, ServiceListener, Runnable {
         port.getPrefs().put("ssh_upload", useSSH);
         port.getPrefs().put("tcp_check", checkTCP);
         port.getPrefs().put("auth_upload", useAuth);
+
+        if (SSHUploadPort != null) {
+          port.setAddress(address+":"+SSHUploadPort);
+        }
       }
 
       String label = name + " at " + address;
@@ -120,9 +128,6 @@ public class NetworkDiscovery implements Discovery, ServiceListener, Runnable {
         label += " (" + description + ")";
       }
 
-      port.setAddress(address);
-      port.setBoardName(name);
-      port.setProtocol("network");
       port.setLabel(label);
 
       synchronized (boardPortsDiscoveredWithJmDNS) {

--- a/arduino-core/src/cc/arduino/packages/ssh/SSHClientSetupChainRing.java
+++ b/arduino-core/src/cc/arduino/packages/ssh/SSHClientSetupChainRing.java
@@ -41,6 +41,9 @@ public interface SSHClientSetupChainRing {
   /*
   Chain is actually useless as default JSCH behaviour is to follow SSH Server authentication methods list
    */
-  Session setup(BoardPort port, JSch jSch) throws JSchException, IOException;
+  Session setup(BoardPort boardPort, JSch jSch) throws JSchException, IOException;
 
+  String getIpAddress(BoardPort boardPort);
+
+  Integer getPortNumber(BoardPort boardPort);
 }

--- a/arduino-core/src/cc/arduino/packages/ssh/SSHPwdSetup.java
+++ b/arduino-core/src/cc/arduino/packages/ssh/SSHPwdSetup.java
@@ -35,16 +35,16 @@ import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
 import processing.app.PreferencesData;
 
-public class SSHPwdSetup implements SSHClientSetupChainRing {
+public class SSHPwdSetup extends SSHSetup {
 
   @Override
-  public Session setup(BoardPort port, JSch jSch) throws JSchException {
-    String ipAddress = port.getAddress();
+  public Session setup(BoardPort boardPort, JSch jSch) throws JSchException {
+    String ipAddress = getIpAddress(boardPort);
+    Integer portNumber = getPortNumber(boardPort);
 
-    Session session = jSch.getSession("root", ipAddress, 22);
+    Session session = jSch.getSession("root", ipAddress, portNumber);
     session.setPassword(PreferencesData.get("runtime.pwd." + ipAddress));
 
     return session;
   }
-
 }

--- a/arduino-core/src/cc/arduino/packages/ssh/SSHSetup.java
+++ b/arduino-core/src/cc/arduino/packages/ssh/SSHSetup.java
@@ -1,0 +1,23 @@
+package cc.arduino.packages.ssh;
+
+import cc.arduino.packages.BoardPort;
+
+abstract public class SSHSetup implements SSHClientSetupChainRing {
+  @Override
+  public String getIpAddress(BoardPort boardPort) {
+    String[] address = boardPort.getAddress().split(":");
+
+    return address[0];
+  }
+
+  @Override
+  public Integer getPortNumber(BoardPort boardPort) {
+    String[] address = boardPort.getAddress().split(":");
+
+    if (address.length > 1 && address[1] != null) {
+      return Integer.valueOf(address[1]);
+    }
+
+    return 22;
+  }
+}


### PR DESCRIPTION
Adds the ability to specify the `ssh_upload_port` in the mDNS network discovery.

Most networks where I install a yún, don't allow traffic over port 22. So I have changed the default ssh port on the yún. But changing my `.ssh/config` file all the time when I add the yún into a different network costs me a lot of time. This change adds an extra TXT property `ssh_upload_port` so that port can be configured on the yún and that the IDE knows to use the different port. If the `ssh_upload_port` is not specified it will fall back to port `22`.