### PR TITLE
Sync issue when host sends multiple signon requests

### DIFF
--- a/build/shared/examples/11.ArduinoISP/ArduinoISP/ArduinoISP.ino
+++ b/build/shared/examples/11.ArduinoISP/ArduinoISP/ArduinoISP.ino
@@ -332,7 +332,7 @@ uint8_t spi_transaction(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
 void empty_reply() {
   if (CRC_EOP == getch()) {
     // clear RX buffer. No more host data expected until after SYNC.
-    while(SERIAL.available())
+    while (SERIAL.available())
       SERIAL.read();
     SERIAL.print((char)STK_INSYNC);
     SERIAL.print((char)STK_OK);

--- a/build/shared/examples/11.ArduinoISP/ArduinoISP/ArduinoISP.ino
+++ b/build/shared/examples/11.ArduinoISP/ArduinoISP/ArduinoISP.ino
@@ -333,7 +333,7 @@ void empty_reply() {
   if (CRC_EOP == getch()) {
     // clear RX buffer. No more host data expected until after SYNC.
     while(SERIAL.available())
-        SERIAL.read();
+      SERIAL.read();
     SERIAL.print((char)STK_INSYNC);
     SERIAL.print((char)STK_OK);
   } else {

--- a/build/shared/examples/11.ArduinoISP/ArduinoISP/ArduinoISP.ino
+++ b/build/shared/examples/11.ArduinoISP/ArduinoISP/ArduinoISP.ino
@@ -331,6 +331,9 @@ uint8_t spi_transaction(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
 
 void empty_reply() {
   if (CRC_EOP == getch()) {
+    // clear RX buffer. No more host data expected until after SYNC.
+    while(SERIAL.available())
+        SERIAL.read();
     SERIAL.print((char)STK_INSYNC);
     SERIAL.print((char)STK_OK);
   } else {


### PR DESCRIPTION
If the host sends a signon but does not get a SYNC response it will send again. This will lead to being out of sync with data in the rx buffer that is not consumed. To avoid this we consume all extra host bytes before sending a INSYNC reply.