### PR TITLE
Fix unneeded "Select port on upload" message

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -2345,6 +2345,8 @@ public class Editor extends JFrame implements RunnerListener {
           SwingUtilities.invokeLater(() -> statusError(tr("Error while burning bootloader.")));
           // error message will already be visible
         }
+      } catch (SerialNotFoundException e) {
+        SwingUtilities.invokeLater(() -> statusError(tr("Error while burning bootloader: please select a serial port.")));
       } catch (PreferencesMapException e) {
         SwingUtilities.invokeLater(() -> {
           statusError(I18n.format(

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -1961,25 +1961,23 @@ public class Editor extends JFrame implements RunnerListener {
       names[i] = portMenu.getItem(i).getText();
     }
 
-    // FIXME: This is horribly unreadable
-    String result = (String)
-    JOptionPane.showInputDialog(this,
-     I18n.format(
-      tr("Serial port {0} not found.\n" +
-       "Retry the upload with another serial port?"),
-      PreferencesData.get("serial.port")
-     ),
-     "Serial port not found",
-     JOptionPane.PLAIN_MESSAGE,
-     null,
-     names,
-     0);
-    if (result == null) return false;
+    String port = PreferencesData.get("serial.port");
+    String title;
+    if (port == null || port.isEmpty()) {
+      title = tr("Serial port not selected.");
+    } else {
+      title = I18n.format(tr("Serial port {0} not found."), port);
+    }
+    String question = tr("Retry the upload with another serial port?");
+    String result = (String) JOptionPane
+        .showInputDialog(this, title + "\n" + question, title,
+                         JOptionPane.PLAIN_MESSAGE, null, names, 0);
+    if (result == null)
+      return false;
     selectSerialPort(result);
     base.onBoardOrPortChange();
     return true;
   }
-
 
   /**
    * Called by Sketch &rarr; Export.

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -1060,7 +1060,8 @@ public class Editor extends JFrame implements RunnerListener {
     Collections.sort(ports, new Comparator<BoardPort>() {
       @Override
       public int compare(BoardPort o1, BoardPort o2) {
-        return BOARD_PROTOCOLS_ORDER.indexOf(o1.getProtocol()) - BOARD_PROTOCOLS_ORDER.indexOf(o2.getProtocol());
+        return (BOARD_PROTOCOLS_ORDER.indexOf(o1.getProtocol()) - BOARD_PROTOCOLS_ORDER.indexOf(o2.getProtocol())) * 10 +
+               o1.getAddress().compareTo(o2.getAddress());
       }
     });
 

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -2036,9 +2036,15 @@ public class Editor extends JFrame implements RunnerListener {
           statusNotice(tr("Done uploading."));
         }
       } catch (SerialNotFoundException e) {
-        if (portMenu.getItemCount() == 0) statusError(e);
-        else if (serialPrompt()) run();
-        else statusNotice(tr("Upload canceled."));
+        if (portMenu.getItemCount() == 0) {
+          statusError(tr("Serial port not selected."));
+        } else {
+          if (serialPrompt()) {
+            run();
+          } else {
+            statusNotice(tr("Upload canceled."));
+          }
+        }
       } catch (PreferencesMapException e) {
         statusError(I18n.format(
                     tr("Error while uploading: missing '{0}' configuration parameter"),

--- a/app/src/processing/app/EditorLineStatus.java
+++ b/app/src/processing/app/EditorLineStatus.java
@@ -110,11 +110,17 @@ public class EditorLineStatus extends JComponent {
     g.drawString(text, scale(6), baseline);
 
     g.setColor(messageForeground);
-    String tmp = I18n.format(tr("{0} on {1}"), name, serialport);
-    
-    Rectangle2D bounds = g.getFontMetrics().getStringBounds(tmp, null);
-    
-    g.drawString(tmp, size.width - (int) bounds.getWidth() - RESIZE_IMAGE_SIZE,
+
+    String statusText;
+    if (serialport != null && !serialport.isEmpty()) {
+      statusText = I18n.format(tr("{0} on {1}"), name, serialport);
+    } else {
+      statusText = name;
+    }
+
+    Rectangle2D bounds = g.getFontMetrics().getStringBounds(statusText, null);
+
+    g.drawString(statusText, size.width - (int) bounds.getWidth() - RESIZE_IMAGE_SIZE,
                  baseline);
 
     if (OSUtils.isMacOS()) {

--- a/app/src/processing/app/SketchController.java
+++ b/app/src/processing/app/SketchController.java
@@ -709,10 +709,6 @@ public class SketchController {
 
     UploaderUtils uploaderInstance = new UploaderUtils();
     Uploader uploader = uploaderInstance.getUploaderByPreferences(false);
-    if (uploader == null) {
-      editor.statusError(tr("Please select a Port before Upload"));
-      return false;
-    }
 
     EditorConsole.setCurrentEditorConsole(editor.console);
 

--- a/arduino-core/src/cc/arduino/Compiler.java
+++ b/arduino-core/src/cc/arduino/Compiler.java
@@ -405,7 +405,7 @@ public class Compiler implements MessageConsumer {
     String[] cmdArray;
     String cmd = prefs.getOrExcept(recipe);
     try {
-      cmdArray = StringReplacer.formatAndSplit(cmd, dict, true);
+      cmdArray = StringReplacer.formatAndSplit(cmd, dict);
     } catch (Exception e) {
       throw new RunnerException(e);
     }

--- a/arduino-core/src/cc/arduino/UploaderUtils.java
+++ b/arduino-core/src/cc/arduino/UploaderUtils.java
@@ -35,7 +35,7 @@ import cc.arduino.packages.UploaderFactory;
 import processing.app.BaseNoGui;
 import processing.app.PreferencesData;
 import processing.app.Sketch;
-import processing.app.debug.TargetPlatform;
+import processing.app.debug.TargetBoard;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -45,9 +45,6 @@ import static processing.app.I18n.tr;
 public class UploaderUtils {
 
   public Uploader getUploaderByPreferences(boolean noUploadPort) {
-    TargetPlatform target = BaseNoGui.getTargetPlatform();
-    String board = PreferencesData.get("board");
-
     BoardPort boardPort = null;
     if (!noUploadPort) {
       String port = PreferencesData.get("serial.port");
@@ -57,7 +54,8 @@ public class UploaderUtils {
       boardPort = BaseNoGui.getDiscoveryManager().find(port);
     }
 
-    return new UploaderFactory().newUploader(target.getBoards().get(board), boardPort, noUploadPort);
+    TargetBoard board = BaseNoGui.getTargetBoard();
+    return new UploaderFactory().newUploader(board, boardPort, noUploadPort);
   }
 
   public boolean upload(Sketch data, Uploader uploader, String suggestedClassName, boolean usingProgrammer, boolean noUploadPort, List<String> warningsAccumulator) throws Exception {

--- a/arduino-core/src/cc/arduino/UploaderUtils.java
+++ b/arduino-core/src/cc/arduino/UploaderUtils.java
@@ -48,9 +48,6 @@ public class UploaderUtils {
     BoardPort boardPort = null;
     if (!noUploadPort) {
       String port = PreferencesData.get("serial.port");
-      if (port == null || port.isEmpty()) {
-        return null;
-      }
       boardPort = BaseNoGui.getDiscoveryManager().find(port);
     }
 

--- a/arduino-core/src/cc/arduino/packages/uploaders/GenericNetworkUploader.java
+++ b/arduino-core/src/cc/arduino/packages/uploaders/GenericNetworkUploader.java
@@ -95,7 +95,7 @@ public class GenericNetworkUploader extends Uploader {
       pattern = prefs.get("upload.network_pattern");
       if(pattern == null)
         pattern = prefs.getOrExcept("upload.pattern");
-      String[] cmd = StringReplacer.formatAndSplit(pattern, prefs, true);
+      String[] cmd = StringReplacer.formatAndSplit(pattern, prefs);
       uploadResult = executeUploadCommand(cmd);
     } catch (RunnerException e) {
       throw e;

--- a/arduino-core/src/cc/arduino/packages/uploaders/SSHUploader.java
+++ b/arduino-core/src/cc/arduino/packages/uploaders/SSHUploader.java
@@ -165,7 +165,7 @@ public class SSHUploader extends Uploader {
     }
 
     String pattern = prefs.getOrExcept("upload.pattern");
-    String command = StringUtils.join(StringReplacer.formatAndSplit(pattern, prefs, true), " ");
+    String command = StringUtils.join(StringReplacer.formatAndSplit(pattern, prefs), " ");
     if (verbose) {
       System.out.println(command);
     }

--- a/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
+++ b/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
@@ -108,7 +108,7 @@ public class SerialUploader extends Uploader {
       boolean uploadResult;
       try {
         String pattern = prefs.getOrExcept("upload.pattern");
-        String[] cmd = StringReplacer.formatAndSplit(pattern, prefs, true);
+        String[] cmd = StringReplacer.formatAndSplit(pattern, prefs);
         uploadResult = executeUploadCommand(cmd);
       } catch (Exception e) {
         throw new RunnerException(e);
@@ -200,7 +200,7 @@ public class SerialUploader extends Uploader {
     boolean uploadResult;
     try {
       String pattern = prefs.getOrExcept("upload.pattern");
-      String[] cmd = StringReplacer.formatAndSplit(pattern, prefs, true);
+      String[] cmd = StringReplacer.formatAndSplit(pattern, prefs);
       uploadResult = executeUploadCommand(cmd);
     } catch (RunnerException e) {
       throw e;
@@ -330,7 +330,7 @@ public class SerialUploader extends Uploader {
 
     try {
       String pattern = prefs.getOrExcept("program.pattern");
-      String[] cmd = StringReplacer.formatAndSplit(pattern, prefs, true);
+      String[] cmd = StringReplacer.formatAndSplit(pattern, prefs);
       return executeUploadCommand(cmd);
     } catch (RunnerException e) {
       throw e;
@@ -394,12 +394,12 @@ public class SerialUploader extends Uploader {
     new LoadVIDPIDSpecificPreferences().load(prefs);
 
     String pattern = prefs.getOrExcept("erase.pattern");
-    String[] cmd = StringReplacer.formatAndSplit(pattern, prefs, true);
+    String[] cmd = StringReplacer.formatAndSplit(pattern, prefs);
     if (!executeUploadCommand(cmd))
       return false;
 
     pattern = prefs.getOrExcept("bootloader.pattern");
-    cmd = StringReplacer.formatAndSplit(pattern, prefs, true);
+    cmd = StringReplacer.formatAndSplit(pattern, prefs);
     return executeUploadCommand(cmd);
   }
 }

--- a/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
+++ b/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
@@ -124,11 +124,8 @@ public class SerialUploader extends Uploader {
     // this wait a moment for the bootloader to enumerate. On Windows, also must
     // deal with the fact that the COM port number changes from bootloader to
     // sketch.
-    String t = prefs.get("upload.use_1200bps_touch");
-    boolean doTouch = t != null && t.equals("true");
-
-    t = prefs.get("upload.wait_for_upload_port");
-    boolean waitForUploadPort = (t != null) && t.equals("true");
+    boolean doTouch = prefs.getBoolean("upload.use_1200bps_touch");
+    boolean waitForUploadPort = prefs.getBoolean("upload.wait_for_upload_port");
 
     String userSelectedUploadPort = prefs.getOrExcept("serial.port");
     String actualUploadPort = null;

--- a/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
+++ b/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
@@ -332,12 +332,6 @@ public class SerialUploader extends Uploader {
       prefs.put("program.verify", prefs.get("program.params.noverify", ""));
 
     try {
-      // if (prefs.get("program.disable_flushing") == null
-      // || prefs.get("program.disable_flushing").toLowerCase().equals("false"))
-      // {
-      // flushSerialBuffer();
-      // }
-
       String pattern = prefs.getOrExcept("program.pattern");
       String[] cmd = StringReplacer.formatAndSplit(pattern, prefs, true);
       return executeUploadCommand(cmd);

--- a/arduino-core/src/processing/app/debug/Sizer.java
+++ b/arduino-core/src/processing/app/debug/Sizer.java
@@ -60,7 +60,7 @@ public class Sizer implements MessageConsumer {
     int r = 0;
     try {
       String pattern = prefs.get("recipe.size.pattern");
-      String cmd[] = StringReplacer.formatAndSplit(pattern, prefs, true);
+      String cmd[] = StringReplacer.formatAndSplit(pattern, prefs);
 
       exception = null;
       textSize = -1;

--- a/arduino-core/src/processing/app/helpers/StringReplacer.java
+++ b/arduino-core/src/processing/app/helpers/StringReplacer.java
@@ -27,16 +27,13 @@ import java.util.Map;
 
 public class StringReplacer {
 
-  public static String[] formatAndSplit(String src, Map<String, String> dict,
-                                        boolean recursive) throws Exception {
+  public static String[] formatAndSplit(String src, Map<String, String> dict) throws Exception {
     String res;
 
     // Recursive replace with a max depth of 10 levels.
     for (int i = 0; i < 10; i++) {
       // Do a replace with dictionary
       res = StringReplacer.replaceFromMapping(src, dict);
-      if (!recursive)
-        break;
       if (res.equals(src))
         break;
       src = res;

--- a/arduino-core/src/processing/app/helpers/StringReplacer.java
+++ b/arduino-core/src/processing/app/helpers/StringReplacer.java
@@ -24,8 +24,49 @@ package processing.app.helpers;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public class StringReplacer {
+
+  public static void checkIfRequiredKeyIsMissingOrExcept(String key, String src, PreferencesMap inDict) throws PreferencesMapException {
+    // If the key is not missing -> everything is OK
+    String checkedValue = inDict.get(key);
+    if (checkedValue != null && !checkedValue.isEmpty())
+      return;
+
+    PreferencesMap dict = new PreferencesMap(inDict);
+
+    // Find a random tag that is not contained in the dictionary and the src pattern
+    String tag;
+    while (true) {
+      tag = UUID.randomUUID().toString();
+      if (src.contains(tag))
+        continue;
+      if (dict.values().contains(tag))
+        continue;
+      if (dict.keySet().contains(tag))
+        continue;
+      break;
+    }
+
+    // Inject tag inside the dictionary
+    dict.put(key, tag);
+
+    // Recursive replace with a max depth of 10 levels.
+    String res;
+    for (int i = 0; i < 10; i++) {
+      // Do a replace with dictionary
+      res = StringReplacer.replaceFromMapping(src, dict);
+      if (res.equals(src))
+        break;
+      src = res;
+    }
+
+    // If the resulting string contains the tag, then the key is required
+    if (src.contains(tag)) {
+      throw new PreferencesMapException(key);
+    }
+  }
 
   public static String[] formatAndSplit(String src, Map<String, String> dict) throws Exception {
     String res;

--- a/build/shared/lib/preferences.txt
+++ b/build/shared/lib/preferences.txt
@@ -267,8 +267,8 @@ programmer = arduino:avrispmkii
 upload.using = bootloader
 upload.verify = true
 
-#default port is empty to prevent running AVRDUDE before Port selected (issue #7943)
-serial.port=
+# default port is not defined to prevent running AVRDUDE before Port selected (issue #7943)
+#serial.port=
 serial.databits=8
 serial.stopbits=1
 serial.parity=N


### PR DESCRIPTION
This turned out to be really tricky: to reliably understand if the serial port is actually needed the only way is to check if the recipe contains the variable `{serial.port}` considering also the fact that the tag `{serial.port}` may be hidden inside another variable like `extra_params` or similar.

Some other cleanups in this PR:
- the two duplicated "Upload" handlers `DefaultExportAppHandler` and `DefaultExportHandler` that are basically 99% the same are now merged and renamed to `UploadHandler`.
- removed a lot of code duplication in `SerialUploader`, now it should be much more consistent when running upload (w/ or w/out programmer) and burn bootloader.
- while Uploading (with or without programmer) there was already a nice dialog that asks to choose an upload port, I've reused that (and fixed the port selection...) whenever possible.
- other small cleanups