### PR TITLE
Adding support of "additional library directories" to IDE & compilation

### DIFF
--- a/arduino-core/src/cc/arduino/Compiler.java
+++ b/arduino-core/src/cc/arduino/Compiler.java
@@ -49,8 +49,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -248,6 +250,18 @@ public class Compiler implements MessageConsumer {
 
     addPathFlagIfPathExists(cmd, "-built-in-libraries", BaseNoGui.getContentFile("libraries"));
     addPathFlagIfPathExists(cmd, "-libraries", BaseNoGui.getSketchbookLibrariesFolder().folder);
+
+    // adding several additional library directories, taken from preferences.txt
+    // additional_library_directories=path1[;path2[;...]]
+    Collection<String> additional_library_directories = splitAndTrim(PreferencesData.get("additional_library_directories"), ";");
+    for (String path : additional_library_directories) {
+	File fpath = new File(path);
+	addPathFlagIfPathExists(cmd, "-libraries", fpath);
+
+	if (!fpath.isDirectory()) {
+	    System.err.println(I18n.format(tr("Warning: additional_library_directories: directory '{0}' not found"), path));
+	}
+    }
 
     String fqbn = Stream.of(aPackage.getId(), platform.getId(), board.getId(), boardOptions(board)).filter(s -> !s.isEmpty()).collect(Collectors.joining(":"));
     cmd.add("-fqbn=" + fqbn);
@@ -622,5 +636,14 @@ public class Compiler implements MessageConsumer {
       }
     }
     return null;
+  }
+
+  private Collection<String> splitAndTrim(String text, String separator) {
+    if ((text == null) || (text.length() == 0)) {
+      return Collections.emptyList() ;
+    }
+
+    Collection<String> parts = Arrays.asList(text.split(separator));
+    return parts.stream().map(String::trim).filter(part -> !part.isEmpty()).collect(Collectors.toList());
   }
 }

--- a/arduino-core/src/processing/app/BaseNoGui.java
+++ b/arduino-core/src/processing/app/BaseNoGui.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import cc.arduino.packages.BoardPort;
 
@@ -672,6 +673,19 @@ public class BaseNoGui {
     // Add libraries folder for the sketchbook
     librariesFolders.add(getSketchbookLibrariesFolder());
 
+    // Adding several additional library directories, taken from preferences.txt
+    // additional_library_directories=path1[;path2[;...]]
+    Collection<String> additional_library_directories = splitAndTrim(PreferencesData.get("additional_library_directories"), ";");
+    for (String path : additional_library_directories) {
+       File fpath = new File(path);
+
+       if (fpath.isDirectory()) {
+	   librariesFolders.add(new UserLibraryFolder(fpath, Location.ADDITIONAL));
+       } else {
+           System.err.println(I18n.format(tr("Warning: additional_library_directories: directory '{0}' not found"), path));
+       }
+    }
+
     // Scan for libraries in each library folder.
     // Libraries located in the latest folders on the list can override
     // other libraries with the same name.
@@ -947,6 +961,15 @@ public class BaseNoGui {
 
   static public void showError(String title, String message, Throwable e) {
     notifier.showError(title, message, e, 1);
+  }
+
+  static private Collection<String> splitAndTrim(String text, String separator) {
+    if ((text == null) || (text.length() == 0)) {
+      return Collections.emptyList() ;
+    }
+
+    Collection<String> parts = Arrays.asList(text.split(separator));
+    return parts.stream().map(String::trim).filter(part -> !part.isEmpty()).collect(Collectors.toList());
   }
 
   /**

--- a/arduino-core/src/processing/app/packages/UserLibraryFolder.java
+++ b/arduino-core/src/processing/app/packages/UserLibraryFolder.java
@@ -34,7 +34,7 @@ import java.io.File;
 public class UserLibraryFolder {
 
   public enum Location {
-    SKETCHBOOK, CORE, REFERENCED_CORE, IDE_BUILTIN,
+    SKETCHBOOK, CORE, REFERENCED_CORE, IDE_BUILTIN, ADDITIONAL,
   }
 
   public File folder;

--- a/arduino-core/src/processing/app/packages/UserLibraryPriorityComparator.java
+++ b/arduino-core/src/processing/app/packages/UserLibraryPriorityComparator.java
@@ -38,7 +38,8 @@ public class UserLibraryPriorityComparator implements Comparator<UserLibrary> {
 
   private final static Map<Location, Integer> priorities = new HashMap<>();
   static {
-    priorities.put(Location.SKETCHBOOK, 4);
+    priorities.put(Location.SKETCHBOOK, 5);
+    priorities.put(Location.ADDITIONAL, 4);
     priorities.put(Location.CORE, 3);
     priorities.put(Location.REFERENCED_CORE, 2);
     priorities.put(Location.IDE_BUILTIN, 1);


### PR DESCRIPTION
This commit adds support of "additional library directories" to IDE
(supporting File/Examples menu, Sketch/Include Library menu and
keywords highlighting), and compilation process (by sending additional
-libraries options to arduino-builder).

Those additional library directories (one or more) are setup by adding an
option to preferences.txt :  
additional_library_directories=/path/to/FreeIMU-Updates;[/mnt/ardether[;etc.]]

Use case : you need to use libs from a (different) git repository staying outside your arduino directory/sketchbook.  

Those additional libraries are included as Location.ADDITIONAL.

Modified priorities become Location.SKETCHBOOK > Location.ADDITIONAL > Location.CORE > Location.REFERENCED_CORE > Location.IDE_BUILTIN