### PR TITLE
Fixed incorrect encoding of compiler log

### DIFF
--- a/build/windows/launcher/arduino.l4j.ini
+++ b/build/windows/launcher/arduino.l4j.ini
@@ -1,2 +1,3 @@
 -Xms128M
 -Xmx512M
+-Dfile.encoding=UTF8


### PR DESCRIPTION
This commit fixes #8212 by passing '-Dfile.encoding=UTF8' to the arduino.l4j.ini file (windows launcher).

This property define the file encoding (UTF-8) that is required.