### PR TITLE
Remove last editor window after saving its properties

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -932,9 +932,10 @@ public class Base {
     }
 
     if (editors.size() == 1) {
+      handleQuit();
+      // Everything called after handleQuit will only affect OSX
       editor.setVisible(false);
       editors.remove(editor);
-      handleQuit();
     } else {
       // More than one editor window open,
       // proceed with closing the current window.


### PR DESCRIPTION
Only OSX needs the "app" to stay open after handleQuit and to remove the editor windows when called.

Fixes #8337