### PR TITLE
Add contextual menus to input fields

### DIFF
--- a/app/src/cc/arduino/contributions/ui/FilterJTextField.java
+++ b/app/src/cc/arduino/contributions/ui/FilterJTextField.java
@@ -124,4 +124,23 @@ public class FilterJTextField extends JTextField {
       setFont(getFont().deriveFont(Font.PLAIN));
     }
   }
+
+  @Override
+  public void paste() {
+
+    // Same precondition check as JTextComponent#paste().
+    if (!isEditable() || !isEnabled()) {
+      return;
+    }
+
+    // Disable hint to prevent the focus handler from clearing the pasted text.
+    if (showingHint) {
+      showingHint = false;
+      setText("");
+      updateStyle();
+    }
+
+    // Perform the paste.
+    super.paste();
+  }
 }

--- a/app/src/cc/arduino/contributions/ui/InstallerJDialog.java
+++ b/app/src/cc/arduino/contributions/ui/InstallerJDialog.java
@@ -45,8 +45,10 @@ import java.awt.event.KeyEvent;
 import java.awt.event.WindowEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseMotionListener;
+import java.awt.event.WindowAdapter;
 import java.util.function.Predicate;
 
+import javax.swing.Action;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
@@ -54,6 +56,7 @@ import javax.swing.JComboBox;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
@@ -64,6 +67,7 @@ import javax.swing.border.EmptyBorder;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
+import javax.swing.text.DefaultEditorKit;
 
 import cc.arduino.contributions.ui.listeners.AbstractKeyListener;
 import processing.app.Base;
@@ -129,6 +133,31 @@ public abstract class InstallerJDialog<T> extends JDialog {
           updateIndexFilter(filters, categoryFilter);
         }
       };
+
+      // Add cut/copy/paste contextual menu to the search filter input field.
+      JPopupMenu menu = new JPopupMenu();
+
+      Action cut = new DefaultEditorKit.CutAction();
+      cut.putValue(Action.NAME, tr("Cut"));
+      menu.add(cut);
+
+      Action copy = new DefaultEditorKit.CopyAction();
+      copy.putValue(Action.NAME, tr("Copy"));
+      menu.add(copy);
+
+      Action paste = new DefaultEditorKit.PasteAction();
+      paste.putValue(Action.NAME, tr("Paste"));
+      menu.add(paste);
+
+      filterField.setComponentPopupMenu(menu);
+      
+      // Focus the filter field when the window opens.
+      addWindowListener(new WindowAdapter() {
+        @Override
+        public void windowOpened(WindowEvent e) {
+          filterField.requestFocus();
+        }
+      });
 
       filtersContainer = new JPanel();
       filtersContainer.setLayout(new BoxLayout(filtersContainer, BoxLayout.X_AXIS));

--- a/app/src/processing/app/AbstractTextMonitor.java
+++ b/app/src/processing/app/AbstractTextMonitor.java
@@ -14,6 +14,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.StringTokenizer;
 
+import javax.swing.Action;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
@@ -21,11 +22,13 @@ import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
 import javax.swing.text.DefaultCaret;
+import javax.swing.text.DefaultEditorKit;
 
 import cc.arduino.packages.BoardPort;
 
@@ -81,6 +84,23 @@ public abstract class AbstractTextMonitor extends AbstractMonitor {
         textField.requestFocusInWindow();
       }
     });
+
+    // Add cut/copy/paste contextual menu to the text input field.
+    JPopupMenu menu = new JPopupMenu();
+
+    Action cut = new DefaultEditorKit.CutAction();
+    cut.putValue(Action.NAME, tr("Cut"));
+    menu.add(cut);
+
+    Action copy = new DefaultEditorKit.CopyAction();
+    copy.putValue(Action.NAME, tr("Copy"));
+    menu.add(copy);
+
+    Action paste = new DefaultEditorKit.PasteAction();
+    paste.putValue(Action.NAME, tr("Paste"));
+    menu.add(paste);
+
+    textField.setComponentPopupMenu(menu);
 
     sendButton = new JButton(tr("Send"));
     clearButton = new JButton(tr("Clear output"));


### PR DESCRIPTION
- Add contextual menus to text-based monitors (serial / network monitor).
- Add contextual menu to installer dialog search filter fields (library manager / contribution manager).
- Make installer dialogs focus the search filter field on window-open. This prevents pastes from ending up elsewhere in the case that they are performed before the field has been focussed at least once.
Fixes #8423.