### PR TITLE
Add editor zoom "CTRL =" shortcut

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -1270,12 +1270,14 @@ public class Editor extends JFrame implements RunnerListener {
     JMenuItem increaseFontSizeItem = newJMenuItem(tr("Increase Font Size"), KeyEvent.VK_PLUS);
     increaseFontSizeItem.addActionListener(event -> base.handleFontSizeChange(1));
     menu.add(increaseFontSizeItem);
-    // Add alternative shortcut "CTRL SHIFT =" for keyboards that haven't the "+" key
-    // in the base layer. This workaround covers all the keyboards that have the "+"
-    // key available as "SHIFT =" that seems to be very common.
+    // Many keyboards have '+' and '=' on the same key. Allowing "CTRL +",
+    // "CTRL SHIFT +" and "CTRL =" covers the generally expected behavior.
     KeyStroke ctrlShiftEq = KeyStroke.getKeyStroke(KeyEvent.VK_EQUALS, SHORTCUT_KEY_MASK | ActionEvent.SHIFT_MASK);
     menu.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(ctrlShiftEq, "IncreaseFontSize");
+    KeyStroke ctrlEq = KeyStroke.getKeyStroke(KeyEvent.VK_EQUALS, SHORTCUT_KEY_MASK);
+    menu.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(ctrlEq, "IncreaseFontSize");
     menu.getActionMap().put("IncreaseFontSize", new AbstractAction() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         base.handleFontSizeChange(1);
       }


### PR DESCRIPTION
Add "CTRL =" as additional shortcut to increase the editor font size. This shortcut should be added because the '+' and '=' characters are often on the same key on the keyboard and having to press SHIFT as well is not intuitive for all users (especially since many common applications support "CTRL =").