### PR TITLE
Serial/network monitor and editor console dynamic font size hotkeys and improved updating

### DIFF
--- a/app/src/cc/arduino/packages/MonitorFactory.java
+++ b/app/src/cc/arduino/packages/MonitorFactory.java
@@ -30,23 +30,24 @@
 package cc.arduino.packages;
 
 import processing.app.AbstractMonitor;
+import processing.app.Base;
 import processing.app.NetworkMonitor;
 import processing.app.SerialMonitor;
 
 public class MonitorFactory {
 
-  public AbstractMonitor newMonitor(BoardPort port) {
+  public AbstractMonitor newMonitor(Base base, BoardPort port) {
     if ("network".equals(port.getProtocol())) {
       if ("yes".equals(port.getPrefs().get("ssh_upload"))) {
         // the board is SSH capable
-        return new NetworkMonitor(port); 
+        return new NetworkMonitor(base, port); 
       } else {
         // SSH not supported, no monitor support
         return null;
       }
     }
 
-    return new SerialMonitor(port);
+    return new SerialMonitor(base, port);
   }
 
 }

--- a/app/src/processing/app/AbstractMonitor.java
+++ b/app/src/processing/app/AbstractMonitor.java
@@ -27,6 +27,7 @@ public abstract class AbstractMonitor extends JFrame implements ActionListener {
     this.boardPort = boardPort;
 
     addWindowListener(new WindowAdapter() {
+      @Override
       public void windowClosing(WindowEvent event) {
         try {
           closed = true;
@@ -41,6 +42,7 @@ public abstract class AbstractMonitor extends JFrame implements ActionListener {
     KeyStroke wc = Editor.WINDOW_CLOSE_KEYSTROKE;
     getRootPane().getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(wc, "close");
     getRootPane().getActionMap().put("close", (new AbstractAction() {
+      @Override
       public void actionPerformed(ActionEvent event) {
         try {
           close();
@@ -165,6 +167,7 @@ public abstract class AbstractMonitor extends JFrame implements ActionListener {
     return s;
   }
 
+  @Override
   public void actionPerformed(ActionEvent e) {
     String s = consumeUpdateBuffer();
     if (s.isEmpty()) {

--- a/app/src/processing/app/AbstractMonitor.java
+++ b/app/src/processing/app/AbstractMonitor.java
@@ -173,4 +173,13 @@ public abstract class AbstractMonitor extends JFrame implements ActionListener {
       message(s);
     }
   }
+
+  /**
+   * Read and apply new values from the preferences, either because
+   * the app is just starting up, or the user just finished messing
+   * with things in the Preferences window.
+   */
+  public void applyPreferences() {
+    // Empty.
+  };
 }

--- a/app/src/processing/app/AbstractTextMonitor.java
+++ b/app/src/processing/app/AbstractTextMonitor.java
@@ -45,14 +45,15 @@ public abstract class AbstractTextMonitor extends AbstractMonitor {
   protected JButton clearButton;
   protected JCheckBox autoscrollBox;
   protected JCheckBox addTimeStampBox;
-  protected JComboBox lineEndings;
-  protected JComboBox serialRates;
+  protected JComboBox<String> lineEndings;
+  protected JComboBox<String> serialRates;
 
   public AbstractTextMonitor(Base base, BoardPort boardPort) {
     super(boardPort);
     this.base = base;
   }
 
+  @Override
   protected void onCreateWindow(Container mainPane) {
 
     mainPane.setLayout(new BorderLayout());
@@ -111,6 +112,7 @@ public abstract class AbstractTextMonitor extends AbstractMonitor {
     textField = new JTextField(40);
     // textField is selected every time the window is focused
     addWindowFocusListener(new WindowAdapter() {
+      @Override
       public void windowGainedFocus(WindowEvent e) {
         textField.requestFocusInWindow();
       }
@@ -139,22 +141,17 @@ public abstract class AbstractTextMonitor extends AbstractMonitor {
     minimumSize.setSize(minimumSize.getWidth() / 3, minimumSize.getHeight());
     noLineEndingAlert.setMinimumSize(minimumSize);
 
-    lineEndings = new JComboBox(new String[]{tr("No line ending"), tr("Newline"), tr("Carriage return"), tr("Both NL & CR")});
-    lineEndings.addActionListener(new ActionListener() {
-      public void actionPerformed(ActionEvent event) {
-        PreferencesData.setInteger("serial.line_ending", lineEndings.getSelectedIndex());
-        noLineEndingAlert.setForeground(pane.getBackground());
-      }
+    lineEndings = new JComboBox<String>(new String[]{tr("No line ending"), tr("Newline"), tr("Carriage return"), tr("Both NL & CR")});
+    lineEndings.addActionListener((ActionEvent event) -> {
+      PreferencesData.setInteger("serial.line_ending", lineEndings.getSelectedIndex());
+      noLineEndingAlert.setForeground(pane.getBackground());
     });
-    addTimeStampBox.addActionListener(new ActionListener() {
-      public void actionPerformed(ActionEvent e) {
-        PreferencesData.setBoolean("serial.show_timestamp", addTimeStampBox.isSelected());
-      }
-    });
+    addTimeStampBox.addActionListener((ActionEvent event) ->
+        PreferencesData.setBoolean("serial.show_timestamp", addTimeStampBox.isSelected()));
 
     lineEndings.setMaximumSize(lineEndings.getMinimumSize());
 
-    serialRates = new JComboBox();
+    serialRates = new JComboBox<String>();
     for (String rate : serialRateStrings) {
       serialRates.addItem(rate + " " + tr("baud"));
     }
@@ -177,6 +174,7 @@ public abstract class AbstractTextMonitor extends AbstractMonitor {
     mainPane.add(pane, BorderLayout.SOUTH);
   }
 
+  @Override
   protected void onEnableWindow(boolean enable)
   {
     textArea.setEnabled(enable);
@@ -203,6 +201,7 @@ public abstract class AbstractTextMonitor extends AbstractMonitor {
     serialRates.addActionListener(listener);
   }
 
+  @Override
   public void message(String msg) {
     SwingUtilities.invokeLater(() -> updateTextArea(msg));
   }

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1877,6 +1877,81 @@ public class Base {
     getEditors().forEach(Editor::applyPreferences);
   }
 
+  private MouseWheelListener editorFontResizeMouseWheelListener = null;
+  private KeyListener editorFontResizeKeyListener = null;
+
+  /**
+   * Adds a {@link MouseWheelListener} and {@link KeyListener} to the given
+   * component that will make "CTRL scroll" and "CTRL +/-"
+   * (with optional SHIFT for +) increase/decrease the editor text size.
+   * This method is equivalent to calling
+   * {@link #addEditorFontResizeMouseWheelListener(Component)} and
+   * {@link #addEditorFontResizeKeyListener(Component)} on the given component.
+   * Note that this also affects components that use the editor font settings.
+   * @param comp - The component to add the listener to.
+   */
+  public void addEditorFontResizeListeners(Component comp) {
+    this.addEditorFontResizeMouseWheelListener(comp);
+    this.addEditorFontResizeKeyListener(comp);
+  }
+
+  /**
+   * Adds a {@link MouseWheelListener} to the given component that will
+   * make "CTRL scroll" increase/decrease the editor text size.
+   * When CTRL is not pressed while scrolling, mouse wheel events are passed
+   * on to the parent of the given component.
+   * Note that this also affects components that use the editor font settings.
+   * @param comp - The component to add the listener to.
+   */
+  public void addEditorFontResizeMouseWheelListener(Component comp) {
+    if (this.editorFontResizeMouseWheelListener == null) {
+      this.editorFontResizeMouseWheelListener = (MouseWheelEvent e) -> {
+        if (e.isControlDown()) {
+          if (e.getWheelRotation() < 0) {
+            this.handleFontSizeChange(1);
+          } else {
+            this.handleFontSizeChange(-1);
+          }
+        } else {
+          e.getComponent().getParent().dispatchEvent(e);
+        }
+      };
+    }
+    comp.addMouseWheelListener(this.editorFontResizeMouseWheelListener);
+  }
+
+  /**
+   * Adds a {@link KeyListener} to the given component that will make "CTRL +/-"
+   * (with optional SHIFT for +) increase/decrease the editor text size.
+   * Note that this also affects components that use the editor font settings.
+   * @param comp - The component to add the listener to.
+   */
+  public void addEditorFontResizeKeyListener(Component comp) {
+    if (this.editorFontResizeKeyListener == null) {
+      this.editorFontResizeKeyListener = new KeyAdapter() {
+        @Override
+        public void keyPressed(KeyEvent e) {
+          if (e.getModifiersEx() == KeyEvent.CTRL_DOWN_MASK
+              || e.getModifiersEx() == (KeyEvent.CTRL_DOWN_MASK
+                  | KeyEvent.SHIFT_DOWN_MASK)) {
+            switch (e.getKeyCode()) {
+              case KeyEvent.VK_PLUS:
+              case KeyEvent.VK_EQUALS:
+                Base.this.handleFontSizeChange(1);
+                break;
+              case KeyEvent.VK_MINUS:
+                if (!e.isShiftDown()) {
+                  Base.this.handleFontSizeChange(-1);
+                }
+                break;
+            }
+          }
+        }
+      };
+    }
+    comp.addKeyListener(this.editorFontResizeKeyListener);
+  }
+
   public List<JMenu> getBoardsCustomMenus() {
     return boardsCustomMenus;
   }

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -315,7 +315,7 @@ public class Editor extends JFrame implements RunnerListener {
     status = new EditorStatus(this);
     consolePanel.add(status, BorderLayout.NORTH);
 
-    console = new EditorConsole();
+    console = new EditorConsole(base);
     console.setName("console");
     // windows puts an ugly border on this guy
     console.setBorder(null);

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -495,6 +495,9 @@ public class Editor extends JFrame implements RunnerListener {
       tab.applyPreferences();
     }
     console.applyPreferences();
+    if (serialMonitor != null) {
+      serialMonitor.applyPreferences();
+    }
   }
 
 
@@ -2209,7 +2212,7 @@ public class Editor extends JFrame implements RunnerListener {
       return;
     }
 
-    serialMonitor = new MonitorFactory().newMonitor(port);
+    serialMonitor = new MonitorFactory().newMonitor(base, port);
 
     if (serialMonitor == null) {
       String board = port.getPrefs().get("board");

--- a/app/src/processing/app/EditorConsole.java
+++ b/app/src/processing/app/EditorConsole.java
@@ -26,6 +26,9 @@ import cc.arduino.ConsoleOutputStream;
 import javax.swing.*;
 import javax.swing.text.*;
 import java.awt.*;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseWheelEvent;
 import java.io.PrintStream;
 
 import static processing.app.Theme.scale;
@@ -61,7 +64,7 @@ public class EditorConsole extends JScrollPane {
   private SimpleAttributeSet stdOutStyle;
   private SimpleAttributeSet stdErrStyle;
 
-  public EditorConsole() {
+  public EditorConsole(final Base base) {
     document = new DefaultStyledDocument();
 
     consoleTextPane = new JTextPane(document);
@@ -110,6 +113,40 @@ public class EditorConsole extends JScrollPane {
     setMinimumSize(new Dimension(100, (height * lines)));
 
     EditorConsole.init(stdOutStyle, System.out, stdErrStyle, System.err);
+
+    // Add "CTRL scroll" hotkey for font size adjustment.
+    consoleTextPane.addMouseWheelListener((MouseWheelEvent e) -> {
+      if (e.isControlDown()) {
+        if (e.getWheelRotation() < 0) {
+          base.handleFontSizeChange(1);
+        } else {
+          base.handleFontSizeChange(-1);
+        }
+      } else {
+        e.getComponent().getParent().dispatchEvent(e);
+      }
+    });
+
+    // Add "CTRL (SHIFT) =/+" and "CTRL -" hotkeys for font size adjustment.
+    consoleTextPane.addKeyListener(new KeyAdapter() {
+      @Override
+      public void keyPressed(KeyEvent e) {
+        if (e.getModifiersEx() == KeyEvent.CTRL_DOWN_MASK
+            || e.getModifiersEx() == (KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK)) {
+          switch (e.getKeyCode()) {
+            case KeyEvent.VK_PLUS:
+            case KeyEvent.VK_EQUALS:
+              base.handleFontSizeChange(1);
+              break;
+            case KeyEvent.VK_MINUS:
+              if (!e.isShiftDown()) {
+                base.handleFontSizeChange(-1);
+              }
+              break;
+          }
+        }
+      }
+    });
   }
 
   public void applyPreferences() {

--- a/app/src/processing/app/EditorConsole.java
+++ b/app/src/processing/app/EditorConsole.java
@@ -26,9 +26,6 @@ import cc.arduino.ConsoleOutputStream;
 import javax.swing.*;
 import javax.swing.text.*;
 import java.awt.*;
-import java.awt.event.KeyAdapter;
-import java.awt.event.KeyEvent;
-import java.awt.event.MouseWheelEvent;
 import java.io.PrintStream;
 
 import static processing.app.Theme.scale;
@@ -64,7 +61,7 @@ public class EditorConsole extends JScrollPane {
   private SimpleAttributeSet stdOutStyle;
   private SimpleAttributeSet stdErrStyle;
 
-  public EditorConsole(final Base base) {
+  public EditorConsole(Base base) {
     document = new DefaultStyledDocument();
 
     consoleTextPane = new JTextPane(document);
@@ -114,39 +111,8 @@ public class EditorConsole extends JScrollPane {
 
     EditorConsole.init(stdOutStyle, System.out, stdErrStyle, System.err);
 
-    // Add "CTRL scroll" hotkey for font size adjustment.
-    consoleTextPane.addMouseWheelListener((MouseWheelEvent e) -> {
-      if (e.isControlDown()) {
-        if (e.getWheelRotation() < 0) {
-          base.handleFontSizeChange(1);
-        } else {
-          base.handleFontSizeChange(-1);
-        }
-      } else {
-        e.getComponent().getParent().dispatchEvent(e);
-      }
-    });
-
-    // Add "CTRL (SHIFT) =/+" and "CTRL -" hotkeys for font size adjustment.
-    consoleTextPane.addKeyListener(new KeyAdapter() {
-      @Override
-      public void keyPressed(KeyEvent e) {
-        if (e.getModifiersEx() == KeyEvent.CTRL_DOWN_MASK
-            || e.getModifiersEx() == (KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK)) {
-          switch (e.getKeyCode()) {
-            case KeyEvent.VK_PLUS:
-            case KeyEvent.VK_EQUALS:
-              base.handleFontSizeChange(1);
-              break;
-            case KeyEvent.VK_MINUS:
-              if (!e.isShiftDown()) {
-                base.handleFontSizeChange(-1);
-              }
-              break;
-          }
-        }
-      }
-    });
+    // Add font size adjustment listeners.
+    base.addEditorFontResizeListeners(consoleTextPane);
   }
 
   public void applyPreferences() {

--- a/app/src/processing/app/EditorTab.java
+++ b/app/src/processing/app/EditorTab.java
@@ -110,7 +110,7 @@ public class EditorTab extends JPanel implements SketchFile.TextStorage, MouseWh
     file.setStorage(this);
     applyPreferences();
     add(scrollPane, BorderLayout.CENTER);
-	textarea.addMouseWheelListener(this);
+    textarea.addMouseWheelListener(this);
   }
 
   private RSyntaxDocument createDocument(String contents) {

--- a/app/src/processing/app/EditorTab.java
+++ b/app/src/processing/app/EditorTab.java
@@ -68,7 +68,7 @@ import processing.app.tools.DiscourseFormat;
 /**
  * Single tab, editing a single file, in the main window.
  */
-public class EditorTab extends JPanel implements SketchFile.TextStorage, MouseWheelListener {
+public class EditorTab extends JPanel implements SketchFile.TextStorage {
   protected Editor editor;
   protected SketchTextArea textarea;
   protected RTextScrollPane scrollPane;
@@ -110,7 +110,7 @@ public class EditorTab extends JPanel implements SketchFile.TextStorage, MouseWh
     file.setStorage(this);
     applyPreferences();
     add(scrollPane, BorderLayout.CENTER);
-    textarea.addMouseWheelListener(this);
+    editor.base.addEditorFontResizeMouseWheelListener(textarea);
   }
 
   private RSyntaxDocument createDocument(String contents) {
@@ -181,18 +181,6 @@ public class EditorTab extends JPanel implements SketchFile.TextStorage, MouseWh
 
     configurePopupMenu(textArea);
     return textArea;
-  }
-  
-  public void mouseWheelMoved(MouseWheelEvent e) {
-    if (e.isControlDown()) {
-      if (e.getWheelRotation() < 0) {
-        editor.base.handleFontSizeChange(1);
-      } else {
-        editor.base.handleFontSizeChange(-1);
-      }
-    } else {
-      e.getComponent().getParent().dispatchEvent(e);
-    }
   }
 
   private void configurePopupMenu(final SketchTextArea textarea){

--- a/app/src/processing/app/NetworkMonitor.java
+++ b/app/src/processing/app/NetworkMonitor.java
@@ -31,8 +31,8 @@ public class NetworkMonitor extends AbstractTextMonitor implements MessageConsum
   private Channel channel;
   private int connectionAttempts;
 
-  public NetworkMonitor(BoardPort port) {
-    super(port);
+  public NetworkMonitor(Base base, BoardPort port) {
+    super(base, port);
 
     onSendCommand(new ActionListener() {
       public void actionPerformed(ActionEvent event) {

--- a/app/src/processing/app/SerialMonitor.java
+++ b/app/src/processing/app/SerialMonitor.java
@@ -21,9 +21,8 @@ package processing.app;
 import cc.arduino.packages.BoardPort;
 import processing.app.legacy.PApplet;
 
-import java.awt.*;
+import java.awt.Color;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 
 import static processing.app.I18n.tr;
 
@@ -38,36 +37,28 @@ public class SerialMonitor extends AbstractTextMonitor {
 
     serialRate = PreferencesData.getInteger("serial.debug_rate");
     serialRates.setSelectedItem(serialRate + " " + tr("baud"));
-    onSerialRateChange(new ActionListener() {
-      public void actionPerformed(ActionEvent event) {
-        String wholeString = (String) serialRates.getSelectedItem();
-        String rateString = wholeString.substring(0, wholeString.indexOf(' '));
-        serialRate = Integer.parseInt(rateString);
-        PreferencesData.set("serial.debug_rate", rateString);
-        try {
-          close();
-          Thread.sleep(100); // Wait for serial port to properly close
-          open();
-        } catch (InterruptedException e) {
-          // noop
-        } catch (Exception e) {
-          System.err.println(e);
-        }
+    onSerialRateChange((ActionEvent event) -> {
+      String wholeString = (String) serialRates.getSelectedItem();
+      String rateString = wholeString.substring(0, wholeString.indexOf(' '));
+      serialRate = Integer.parseInt(rateString);
+      PreferencesData.set("serial.debug_rate", rateString);
+      try {
+        close();
+        Thread.sleep(100); // Wait for serial port to properly close
+        open();
+      } catch (InterruptedException e) {
+        // noop
+      } catch (Exception e) {
+        System.err.println(e);
       }
     });
 
-    onSendCommand(new ActionListener() {
-      public void actionPerformed(ActionEvent e) {
-        send(textField.getText());
-        textField.setText("");
-      }
+    onSendCommand((ActionEvent event) -> {
+      send(textField.getText());
+      textField.setText("");
     });
     
-    onClearCommand(new ActionListener() {
-      public void actionPerformed(ActionEvent e) {
-        textArea.setText("");
-      }
-    });
+    onClearCommand((ActionEvent event) -> textArea.setText(""));
   }
 
   private void send(String s) {
@@ -93,6 +84,7 @@ public class SerialMonitor extends AbstractTextMonitor {
     }
   }
 
+  @Override
   public void open() throws Exception {
     super.open();
 
@@ -106,6 +98,7 @@ public class SerialMonitor extends AbstractTextMonitor {
     };
   }
 
+  @Override
   public void close() throws Exception {
     super.close();
     if (serial != null) {

--- a/app/src/processing/app/SerialMonitor.java
+++ b/app/src/processing/app/SerialMonitor.java
@@ -33,8 +33,8 @@ public class SerialMonitor extends AbstractTextMonitor {
   private Serial serial;
   private int serialRate;
 
-  public SerialMonitor(BoardPort port) {
-    super(port);
+  public SerialMonitor(Base base, BoardPort port) {
+    super(base, port);
 
     serialRate = PreferencesData.getInteger("serial.debug_rate");
     serialRates.setSelectedItem(serialRate + " " + tr("baud"));


### PR DESCRIPTION
- Add CTRL +/- and CTRL scroll shortcuts to increase/decrease the serial/network monitor and editor console text size in the same way the editor text can currently be adjusted.
- Make the serial/network monitor text size update when the editor font size is changed.
- Make the editor console text size update when the editor font size is changed. Before this, the size was already updated, but not applied to existing text in the editor. This lead to the following bug:
![afbeelding](https://user-images.githubusercontent.com/9693840/54962933-1095f680-4f67-11e9-962e-647bdda55aa0.png)

These changes combined cause the editor, editor console, serial monitor and network monitor to share their font in such a way that the font size can be updated using CTRL +/-/scroll in these elements and the new font size immediately applies to all these elements on change.

Fixes #8615.
Outdates https://github.com/arduino/Arduino/pull/8698 (this is added to this PR).