### PR TITLE
Support .tar.xz for ArchiveExtractor to make download more fast

### DIFF
--- a/arduino-core/src/cc/arduino/utils/ArchiveExtractor.java
+++ b/arduino-core/src/cc/arduino/utils/ArchiveExtractor.java
@@ -36,6 +36,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.apache.commons.compress.compressors.xz.XZCompressorInputStream;
 import org.apache.commons.compress.utils.IOUtils;
 import processing.app.I18n;
 import processing.app.Platform;
@@ -98,6 +99,8 @@ public class ArchiveExtractor {
         in = new ZipArchiveInputStream(new FileInputStream(archiveFile));
       } else if (archiveFile.getName().endsWith("tar.gz")) {
         in = new TarArchiveInputStream(new GzipCompressorInputStream(new FileInputStream(archiveFile)));
+      } else if (archiveFile.getName().endsWith("tar.xz")) {
+        in = new TarArchiveInputStream(new XZCompressorInputStream(new FileInputStream(archiveFile)));
       } else if (archiveFile.getName().endsWith("tar")) {
         in = new TarArchiveInputStream(new FileInputStream(archiveFile));
       } else {


### PR DESCRIPTION
Now ```tar.xz``` format is widely used, and the official arduino
IDE download URL also shows that arduino uses ```tar.xz``` format.
(https://downloads.arduino.cc/arduino-1.8.9-linux64.tar.xz).

As we all know, the tar.xz format has the optimal size compared to tar,
tar.gz, tar.bz2, and zip.
(https://www.rootusers.com/gzip-vs-bzip2-vs-xz-performance-comparison/)

Therefore, it is very unreasonable not to support tar.xz.

Supporting this format can save almost half of the bandwidth resources
and download time when compressing the gcc toolchain,
making users more comfortable.

![Screenshot from 2019-04-12 12-00-59](https://user-images.githubusercontent.com/394260/56011539-ad53e480-5d1a-11e9-89ac-d4f9926f0f10.png)
