### PR TITLE
Fix NPEs if no hardware core is installed

### DIFF
--- a/arduino-core/src/cc/arduino/contributions/packages/ContributionsIndexer.java
+++ b/arduino-core/src/cc/arduino/contributions/packages/ContributionsIndexer.java
@@ -215,7 +215,7 @@ public class ContributionsIndexer {
   }
 
   private void syncBuiltInHardware() throws IOException {
-    if (index == null) {
+    if (index == null || builtInHardwareFolder == null) {
       return;
     }
     for (File folder : builtInHardwareFolder.listFiles(ONLY_DIRS)) {

--- a/arduino-core/src/processing/app/BaseNoGui.java
+++ b/arduino-core/src/processing/app/BaseNoGui.java
@@ -676,7 +676,9 @@ public class BaseNoGui {
     // Libraries located in the latest folders on the list can override
     // other libraries with the same name.
     librariesIndexer.setLibrariesFolders(librariesFolders);
-    librariesIndexer.setArchitecturePriority(getTargetPlatform().getId());
+    if (getTargetPlatform() != null) {
+      librariesIndexer.setArchitecturePriority(getTargetPlatform().getId());
+    }
     librariesIndexer.rescanLibraries();
 
     populateImportToLibraryTable();


### PR DESCRIPTION
Fixes #8229

@NicoHood can you check if this solves the (non-hard) dependency on `arduinocore-avr` with your build scripts?