### PR TITLE
Update issue template to reflect change in the GitHub issue creation page

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,1 +1,1 @@
-Read the Issues section of the Contributing Rules at the "contributing guidelines" link above before submitting an issue report.
+Please read the Issues section of the Contributing Rules at the "Contributing" link to the right before submitting an issue report.


### PR DESCRIPTION
At the time the original issue template was created, GitHub always displayed a reminder to read CONTRIBUTING.md with a link above the new issue creation field:
![old](https://user-images.githubusercontent.com/8572152/59012705-09a02580-87ed-11e9-9693-5c8481e5956e.png)

Unfortunately, this has since been changed so that a prominent reminder is now shown on the right side of the field only for new contributors or if CONTRIBUTING.md has changed since the user's last contribution:
![new](https://user-images.githubusercontent.com/8572152/59012797-453aef80-87ed-11e9-9edc-c2f3c582959c.png)

And a less prominent link otherwise:
![new2](https://user-images.githubusercontent.com/8572152/59020257-77a11880-87fe-11e9-9190-133cfed712d9.png)


So the template text must be updated to reflect the new position of the link on the page.