### PR TITLE
Force System font settings on Windows

### DIFF
--- a/build/windows/launcher/arduino.l4j.ini
+++ b/build/windows/launcher/arduino.l4j.ini
@@ -1,3 +1,4 @@
 -Xms128M
 -Xmx512M
 -Dfile.encoding=UTF8
+-Dawt.useSystemAAFontSettings=on


### PR DESCRIPTION
If Cleartype and nonstandard fonts are being used, the IDE menus are rendered terribly. This patch should not affect people with standard configurations but must be tested on all possible OS/fonts combinations

Fixes #6170
Fixes #7839