### PR TITLE
Fix condition when the file is not expire but the remote ETag is changed

### DIFF
--- a/arduino-core/src/cc/arduino/utils/network/FileDownloader.java
+++ b/arduino-core/src/cc/arduino/utils/network/FileDownloader.java
@@ -171,6 +171,7 @@ public class FileDownloader extends Observable {
         final Optional<File> fileFromCache = getFileCached(fileCached);
         if (fileCached.isNotChange() && fileFromCache.isPresent()) {
           // Copy the cached file in the destination file
+          log.info("The file will be taken from the cache {}", fileFromCache);
           FileUtils.copyFile(fileFromCache.get(), outputFile);
         } else {
           openConnectionAndFillTheFile(noResume);

--- a/arduino-core/src/cc/arduino/utils/network/FileDownloaderCache.java
+++ b/arduino-core/src/cc/arduino/utils/network/FileDownloaderCache.java
@@ -286,17 +286,19 @@ public class FileDownloaderCache {
     @JsonIgnore
     public boolean isChange() {
       // Check if the file is expire
-      if (!isExpire()) {
-        log.debug("The file \"{}\" is no expire, the eTag will not be checked. Expire time: {}", localPath,
+      boolean isChange = false;
+      if (isExpire()) {
+        log.debug("The file \"{}\" is expire. Expire time: {}", localPath,
           this.getExpiresTime().format(DateTimeFormatter.ISO_DATE_TIME));
-        return false;
+        isChange = true;
       }
 
-      if (lastETag != null) {
+      if (lastETag != null && !lastETag.equals(eTag)) {
         // If are different means that the file is change
-        return !lastETag.equals(eTag);
+        log.debug("The file \"{}\" is changed last ETag != now Etag ({}!={})", localPath, lastETag, eTag);
+        isChange = true;
       }
-      return true;
+      return isChange;
     }
 
     @JsonIgnore

--- a/arduino-core/src/cc/arduino/utils/network/FileDownloaderCache.java
+++ b/arduino-core/src/cc/arduino/utils/network/FileDownloaderCache.java
@@ -146,6 +146,7 @@ public class FileDownloaderCache {
       .orElseGet(() -> new FileCached(remoteURL.toString(), cacheFilePath.toString()));
 
     // If the file is change of the cache is disable run the HEAD request to check if the file is changed
+    log.info("Get file cached is expire {}, exist {}, info {} ", fileCached.isExpire(), fileCached.exists(), fileCached);
     if (fileCached.isExpire() || !fileCached.exists()) {
       // Update remote etag and cache control header
       final Optional<FileCached> fileCachedInfoUpdated =


### PR DESCRIPTION
When the file is not expired but the remote ETag is changed, It must trigger an update download. At this moment the function `isChange()` does the priority to the file expiration, not to the remote ETag