### PR TITLE
Fix log path when you run `ant run`

### DIFF
--- a/app/src/log4j2.xml
+++ b/app/src/log4j2.xml
@@ -8,8 +8,8 @@
     </Console>
 
     <!-- Rolling File Appender -->
-    <RollingFile name="RollingFile" fileName="${sys:log4j.saveDirectory}/logs/application.log"
-                 filePattern="${sys:log4j.saveDirectory}/logs/application-%d{MM-dd-yyyy}-%i.log.gz"
+    <RollingFile name="RollingFile" fileName="${sys:log4j.dir}/logs/application.log"
+                 filePattern="${sys:log4j.dir}/logs/application-%d{MM-dd-yyyy}-%i.log.gz"
                  ignoreExceptions="false">
       <PatternLayout>
         <Pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX}{UTC} %p %c{1.}:%L [%t] %m%n</Pattern>

--- a/app/src/log4j2.xml
+++ b/app/src/log4j2.xml
@@ -4,7 +4,7 @@
 
     <!-- Console Appender -->
     <Console name="Console" target="SYSTEM_ERR">
-      <PatternLayout pattern="%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX}{UTC} %p %c{1.} [%t] %m%n" />
+      <PatternLayout pattern="%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX}{UTC} %p %c{1.}:%L [%t] %m%n"/>
     </Console>
 
     <!-- Rolling File Appender -->
@@ -12,7 +12,7 @@
                  filePattern="${sys:log4j.saveDirectory}/logs/application-%d{MM-dd-yyyy}-%i.log.gz"
                  ignoreExceptions="false">
       <PatternLayout>
-        <Pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX}{UTC} %p %c{1.} [%t] %m%n</Pattern>
+        <Pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX}{UTC} %p %c{1.}:%L [%t] %m%n</Pattern>
       </PatternLayout>
       <Policies>
         <SizeBasedTriggeringPolicy size="50 MB"/>

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -208,7 +208,8 @@ public class Base {
 
     BaseNoGui.initPortableFolder();
     // This configure the logs root folder
-    System.setProperty("log4j.saveDirectory", BaseNoGui.getSettingsFolder().getAbsolutePath());
+    System.out.println("Set log4j store directory " + BaseNoGui.getSettingsFolder().getAbsolutePath());
+    System.setProperty("log4j.dir", BaseNoGui.getSettingsFolder().getAbsolutePath());
 
     // Look for a possible "--preferences-file" parameter and load preferences
     BaseNoGui.initParameters(args);

--- a/arduino-core/src/cc/arduino/packages/discoverers/serial/SerialDiscovery.java
+++ b/arduino-core/src/cc/arduino/packages/discoverers/serial/SerialDiscovery.java
@@ -29,17 +29,14 @@
 
 package cc.arduino.packages.discoverers.serial;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Timer;
-import java.util.TimerTask;
-
 import cc.arduino.packages.BoardPort;
 import cc.arduino.packages.Discovery;
 import processing.app.BaseNoGui;
 import processing.app.Platform;
 import processing.app.debug.TargetBoard;
+import processing.app.helpers.BoardCloudResolver;
+
+import java.util.*;
 
 public class SerialDiscovery implements Discovery, Runnable {
 
@@ -50,6 +47,7 @@ public class SerialDiscovery implements Discovery, Runnable {
   public boolean uploadInProgress = false;
   public boolean pausePolling = false;
   private BoardPort oldUploadBoardPort = null;
+  private final BoardCloudResolver boardCloudResolver = new BoardCloudResolver();
 
 
   @Override
@@ -203,7 +201,7 @@ public class SerialDiscovery implements Discovery, Runnable {
           boardPort.getPrefs().put("vid", parts[1]);
           boardPort.getPrefs().put("pid", parts[2]);
           // ask Cloud API to match the board with known VID/PID pair
-          platform.getBoardWithMatchingVidPidFromCloud(parts[1], parts[2]);
+          boardCloudResolver.getBoardBy(parts[1], parts[2]);
         } else {
           boardPort.getPrefs().put("vid", "0000");
           boardPort.getPrefs().put("pid", "0000");

--- a/arduino-core/src/processing/app/Platform.java
+++ b/arduino-core/src/processing/app/Platform.java
@@ -23,11 +23,6 @@
 package processing.app;
 
 import cc.arduino.packages.BoardPort;
-import cc.arduino.utils.network.HttpConnectionManager;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import processing.app.debug.TargetBoard;
 import processing.app.debug.TargetPackage;
 import processing.app.debug.TargetPlatform;
@@ -36,9 +31,6 @@ import processing.app.legacy.PConstants;
 import javax.swing.*;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
 import java.util.*;
 
 import static processing.app.I18n.tr;
@@ -60,8 +52,7 @@ import static processing.app.I18n.tr;
  * know if name is proper Java package syntax.)
  */
 public class Platform {
-  private static Logger log = LogManager.getLogger(Platform.class);
-
+  // DO NOT USE log4j here otherwise the root path of the logs will no be initialize correctly
   /**
    * Set the default L & F. While I enjoy the bounty of the sixteen possible
    * exception types that this UIManager method might throw, I feel that in
@@ -185,36 +176,6 @@ public class Platform {
     return list;
   }
 
-  public synchronized void getBoardWithMatchingVidPidFromCloud(String vid, String pid) {
-    // this method is less useful in Windows < WIN10 since you need drivers to be already installed
-    ObjectMapper mapper = new ObjectMapper();
-    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    try {
-      URL jsonUrl = new URL(String.format("https://builder.arduino.cc/builder/v1/boards/0x%s/0x%s", vid, pid));
-
-      final HttpURLConnection httpConnection = new HttpConnectionManager(jsonUrl)
-        .makeConnection();
-      int code = httpConnection.getResponseCode();
-      if (code == 404) {
-        log.warn("Fail to get the Vid Pid information from the builder response code={}", code);
-        return;
-      }
-      InputStream is = httpConnection.getInputStream();
-      BoardCloudAPIid board = mapper.readValue(is, BoardCloudAPIid.class);
-      log.info("Board info from the cloud {}", board);
-      // Launch a popup with a link to boardmanager#board.getName()
-      // replace spaces with &
-      String realBoardName = board.getName().replaceAll("\\(.*?\\)", "").trim();
-      String boardNameReplaced = realBoardName.replaceAll(" ", "&");
-      String message = I18n.format(tr("{0}Install this package{1} to use your {2} board"), "<a href=\"http://boardsmanager/all#" + boardNameReplaced + "\">", "</a>", realBoardName);
-      BaseNoGui.setBoardManagerLink(message);
-    } catch (Exception e) {
-      // No connection no problem, fail silently
-      //e.printStackTrace();
-
-    }
-  }
-
   public synchronized Map<String, Object> resolveDeviceByVendorIdProductId(String serial, Map<String, TargetPackage> packages) {
     String vid_pid_iSerial = resolveDeviceAttachedToNative(serial);
     for (TargetPackage targetPackage : packages.values()) {
@@ -254,56 +215,6 @@ public class Platform {
       }
     }
     return null;
-  }
-
-  public static class BoardCloudAPIid {
-
-    private String fqbn;
-    private String name;
-    private String architecture;
-    private String id;
-
-    public String getName() {
-      return name;
-    }
-
-    public String getFqbn() {
-      return fqbn;
-    }
-
-    public String getArchitecture() {
-      return architecture;
-    }
-
-    public String getId() {
-      return id;
-    }
-
-    public void setName(String tmp) {
-      name = tmp;
-    }
-
-    public void setFqbn(String fqbn) {
-      this.fqbn = fqbn;
-    }
-
-    public void setArchitecture(String tmp) {
-      architecture = tmp;
-    }
-
-    public void setId(String tmp) {
-      id = tmp;
-    }
-
-    @Override
-    public String toString() {
-      return "BoardCloudAPIid{" +
-        "name='" + name + '\'' +
-        ", fqbn='" + fqbn + '\'' +
-        ", architecture='" + architecture + '\'' +
-        ", id='" + id + '\'' +
-        '}';
-    }
   }
 
   public String resolveDeviceByBoardID(Map<String, TargetPackage> packages, String boardId) {

--- a/arduino-core/src/processing/app/helpers/BoardCloudResolver.java
+++ b/arduino-core/src/processing/app/helpers/BoardCloudResolver.java
@@ -1,0 +1,151 @@
+/*
+ *
+ *  * This file is part of Arduino.
+ *  *
+ *  * Copyright 2015 Arduino LLC (http://www.arduino.cc/)
+ *  *
+ *  * Arduino is free software; you can redistribute it and/or modify
+ *  * it under the terms of the GNU General Public License as published by
+ *  * the Free Software Foundation; either version 2 of the License, or
+ *  * (at your option) any later version.
+ *  *
+ *  * This program is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  * GNU General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU General Public License
+ *  * along with this program; if not, write to the Free Software
+ *  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *  *
+ *  * As a special exception, you may use this file as part of a free software
+ *  * library without restriction.  Specifically, if other files instantiate
+ *  * templates or use macros or inline functions from this file, or you compile
+ *  * this file and link it with other files to produce an executable, this
+ *  * file does not by itself cause the resulting executable to be covered by
+ *  * the GNU General Public License.  This exception does not however
+ *  * invalidate any other reasons why the executable file might be covered by
+ *  * the GNU General Public License.
+ *
+ */
+
+package processing.app.helpers;
+
+import cc.arduino.utils.network.HttpConnectionManager;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import processing.app.BaseNoGui;
+import processing.app.I18n;
+import processing.app.debug.TargetBoard;
+import processing.app.debug.TargetPackage;
+import processing.app.debug.TargetPlatform;
+
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Map;
+
+import static processing.app.I18n.tr;
+
+public class BoardCloudResolver {
+  private static Logger log = LogManager.getLogger(BoardCloudResolver.class);
+
+  public synchronized void getBoardBy(String vid, String pid) {
+    // this method is less useful in Windows < WIN10 since you need drivers to be already installed
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    try {
+      URL jsonUrl = new URL(String.format("https://builder.arduino.cc/builder/v1/boards/0x%s/0x%s", vid, pid));
+
+      final HttpURLConnection httpConnection = new HttpConnectionManager(jsonUrl)
+        .makeConnection();
+      int code = httpConnection.getResponseCode();
+      if (code == 404) {
+        log.warn("Fail to get the Vid Pid information from the builder response code={}", code);
+        return;
+      }
+      InputStream is = httpConnection.getInputStream();
+      BoardCloudAPIid board = mapper.readValue(is, BoardCloudAPIid.class);
+      log.info("Board info from the cloud {}", board);
+      // Launch a popup with a link to boardmanager#board.getName()
+      // replace spaces with &
+      String realBoardName = board.getName().replaceAll("\\(.*?\\)", "").trim();
+      String boardNameReplaced = realBoardName.replaceAll(" ", "&");
+      String message = I18n.format(tr("{0}Install this package{1} to use your {2} board"), "<a href=\"http://boardsmanager/all#" + boardNameReplaced + "\">", "</a>", realBoardName);
+      BaseNoGui.setBoardManagerLink(message);
+    } catch (Exception e) {
+      // No connection no problem, fail silently
+      //e.printStackTrace();
+      log.warn("Error during get board information by vid, pid", e);
+
+    }
+  }
+
+  public String resolveDeviceByBoardID(Map<String, TargetPackage> packages, String boardId) {
+    assert packages != null;
+    assert boardId != null;
+    for (TargetPackage targetPackage : packages.values()) {
+      for (TargetPlatform targetPlatform : targetPackage.getPlatforms().values()) {
+        for (TargetBoard board : targetPlatform.getBoards().values()) {
+          if (boardId.equals(board.getId())) {
+            return board.getName();
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  private static class BoardCloudAPIid {
+
+    private String fqbn;
+    private String name;
+    private String architecture;
+    private String id;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String tmp) {
+      name = tmp;
+    }
+
+    public String getFqbn() {
+      return fqbn;
+    }
+
+    public void setFqbn(String fqbn) {
+      this.fqbn = fqbn;
+    }
+
+    public String getArchitecture() {
+      return architecture;
+    }
+
+    public void setArchitecture(String tmp) {
+      architecture = tmp;
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(String tmp) {
+      id = tmp;
+    }
+
+    @Override
+    public String toString() {
+      return "BoardCloudAPIid{" +
+        "name='" + name + '\'' +
+        ", fqbn='" + fqbn + '\'' +
+        ", architecture='" + architecture + '\'' +
+        ", id='" + id + '\'' +
+        '}';
+    }
+  }
+
+}


### PR DESCRIPTION
When the IDE was started with `ant run` the log folder was wrong due to a premature initialization of the logging environment before set the log directory path.