### PR TITLE
Replace hardcoded pin numbers with variables

### DIFF
--- a/build/shared/examples/09.USB/Mouse/JoystickMouseControl/JoystickMouseControl.ino
+++ b/build/shared/examples/09.USB/Mouse/JoystickMouseControl/JoystickMouseControl.ino
@@ -69,8 +69,8 @@ void loop() {
   lastSwitchState = switchState;
 
   // read and scale the two axes:
-  int xReading = readAxis(A0);
-  int yReading = readAxis(A1);
+  int xReading = readAxis(xAxis);
+  int yReading = readAxis(yAxis);
 
   // if the mouse control state is active, move the mouse:
   if (mouseIsActive) {


### PR DESCRIPTION
Replace pin numbers "A0" and "A1" with variables "xAxis" and "yAxis".

Variables "xAxis" and "yAxis" were created, but never used. I changed the hardcoded pin numbers to these variables to avoid confusion and to make the code more consistent.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?