### PR TITLE
Add Buttons in Library and Boards managers

### DIFF
--- a/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryTableCellJPanel.java
+++ b/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryTableCellJPanel.java
@@ -28,10 +28,12 @@ import cc.arduino.contributions.libraries.ContributedLibrary;
 import cc.arduino.contributions.libraries.ContributedLibraryReleases;
 import cc.arduino.contributions.ui.InstallerTableCell;
 import processing.app.Base;
+import processing.app.PreferencesData;
 import processing.app.Theme;
 
 public class ContributedLibraryTableCellJPanel extends JPanel {
 
+  final JButton moreInfoButton;
   final JButton installButton;
   final Component installButtonPlaceholder;
   final JComboBox downgradeChooser;
@@ -40,12 +42,15 @@ public class ContributedLibraryTableCellJPanel extends JPanel {
   final JPanel buttonsPanel;
   final JPanel inactiveButtonsPanel;
   final JLabel statusLabel;
+  private final String moreInfoLbl = tr("More info");
 
   public ContributedLibraryTableCellJPanel(JTable parentTable, Object value,
                                            boolean isSelected) {
     super();
     setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
 
+    moreInfoButton = new JButton(moreInfoLbl);
+    moreInfoButton.setVisible(false);
     installButton = new JButton(tr("Install"));
     int width = installButton.getPreferredSize().width;
     installButtonPlaceholder = Box.createRigidArea(new Dimension(width, 1));
@@ -79,6 +84,11 @@ public class ContributedLibraryTableCellJPanel extends JPanel {
     buttonsPanel.setOpaque(false);
 
     buttonsPanel.add(Box.createHorizontalStrut(7));
+    if (PreferencesData.getBoolean("ide.accessible")) {
+      buttonsPanel.add(moreInfoButton);
+      buttonsPanel.add(Box.createHorizontalStrut(5));
+      buttonsPanel.add(Box.createHorizontalStrut(15));
+    }
     buttonsPanel.add(downgradeChooser);
     buttonsPanel.add(Box.createHorizontalStrut(5));
     buttonsPanel.add(downgradeButton);
@@ -141,7 +151,7 @@ public class ContributedLibraryTableCellJPanel extends JPanel {
     String name = selected.getName();
     String author = selected.getAuthor();
     // String maintainer = selectedLib.getMaintainer();
-    String website = selected.getWebsite();
+    final String website = selected.getWebsite();
     String sentence = selected.getSentence();
     String paragraph = selected.getParagraph();
     // String availableVer = selectedLib.getVersion();
@@ -188,7 +198,7 @@ public class ContributedLibraryTableCellJPanel extends JPanel {
       desc += "<br />";
     }
     if (author != null && !author.isEmpty()) {
-      desc += format("<a href=\"{0}\">More info</a>", website);
+      desc = setButtonOrLink(moreInfoButton, desc, moreInfoLbl, website);
     }
 
     desc += "</body></html>";
@@ -213,6 +223,25 @@ public class ContributedLibraryTableCellJPanel extends JPanel {
       setBackground(parentTable.getBackground());
       setForeground(parentTable.getForeground());
     }
+  }
+
+  // same function as in ContributedPlatformTableCellJPanel - is there a utils file this can move to?
+  private String setButtonOrLink(JButton button, String desc, String label, String url) {
+    boolean accessibleIDE = PreferencesData.getBoolean("ide.accessible");
+    String retString = desc;
+
+    if (accessibleIDE) {
+      button.setVisible(true);
+      button.addActionListener(e -> {
+        Base.openURL(url);
+      });
+    }
+    else {
+      // if not accessible IDE, keep link the same EXCEPT that now the link text is translated!
+      retString += format("<a href=\"{0}\">{1}</a><br/>", url, label);
+    }
+
+    return retString;
   }
 
   // TODO Make this a method of Theme

--- a/app/src/cc/arduino/contributions/packages/ui/ContributedPlatformTableCellJPanel.java
+++ b/app/src/cc/arduino/contributions/packages/ui/ContributedPlatformTableCellJPanel.java
@@ -57,11 +57,14 @@ import cc.arduino.contributions.packages.ContributedHelp;
 import cc.arduino.contributions.packages.ContributedPlatform;
 import cc.arduino.contributions.ui.InstallerTableCell;
 import processing.app.Base;
+import processing.app.PreferencesData;
 import processing.app.Theme;
 
 @SuppressWarnings("serial")
 public class ContributedPlatformTableCellJPanel extends JPanel {
 
+  final JButton moreInfoButton;
+  final JButton onlineHelpButton;
   final JButton installButton;
   final JButton removeButton;
   final Component removeButtonPlaceholder;
@@ -72,6 +75,8 @@ public class ContributedPlatformTableCellJPanel extends JPanel {
   final JPanel buttonsPanel;
   final JPanel inactiveButtonsPanel;
   final JLabel statusLabel;
+  private final String moreInfoLbl = tr("More Info");
+  private final String onlineHelpLbl = tr("Online Help");
 
   public ContributedPlatformTableCellJPanel() {
     super();
@@ -79,6 +84,10 @@ public class ContributedPlatformTableCellJPanel extends JPanel {
 
     {
       installButton = new JButton(tr("Install"));
+      moreInfoButton = new JButton(moreInfoLbl);
+      moreInfoButton.setVisible(false);
+      onlineHelpButton = new JButton(onlineHelpLbl);
+      onlineHelpButton.setVisible(false);
       int width = installButton.getPreferredSize().width;
       installButtonPlaceholder = Box.createRigidArea(new Dimension(width, 1));
     }
@@ -115,6 +124,13 @@ public class ContributedPlatformTableCellJPanel extends JPanel {
     buttonsPanel.setOpaque(false);
 
     buttonsPanel.add(Box.createHorizontalStrut(7));
+    if (PreferencesData.getBoolean("ide.accessible")) { // only add the buttons if needed
+      buttonsPanel.add(onlineHelpButton);
+      buttonsPanel.add(Box.createHorizontalStrut(5));
+      buttonsPanel.add(moreInfoButton);
+      buttonsPanel.add(Box.createHorizontalStrut(5));
+      buttonsPanel.add(Box.createHorizontalStrut(15));
+    }
     buttonsPanel.add(downgradeChooser);
     buttonsPanel.add(Box.createHorizontalStrut(5));
     buttonsPanel.add(downgradeButton);
@@ -147,6 +163,25 @@ public class ContributedPlatformTableCellJPanel extends JPanel {
     add(inactiveButtonsPanel);
 
     add(Box.createVerticalStrut(15));
+  }
+
+  // same function as in ContributedLibraryTableCellJPanel - is there a utils file this can move to?
+  private String setButtonOrLink(JButton button, String desc, String label, String url) {
+    boolean accessibleIDE = PreferencesData.getBoolean("ide.accessible");
+    String retString = desc;
+
+    if (accessibleIDE) {
+      button.setVisible(true);
+      button.addActionListener(e -> {
+        Base.openURL(url);
+      });
+    }
+    else {
+      // if not accessible IDE, keep link the same EXCEPT that now the link text is translated!
+      retString += " " + format("<a href=\"{0}\">{1}</a><br/>", url, label);
+    }
+
+    return retString;
   }
 
   void update(JTable parentTable, Object value, boolean isSelected,
@@ -216,16 +251,17 @@ public class ContributedPlatformTableCellJPanel extends JPanel {
     } else if (selected.getParentPackage().getHelp() != null) {
       help = selected.getParentPackage().getHelp();
     }
+
     if (help != null) {
       String url = help.getOnline();
       if (url != null && !url.isEmpty()) {
-        desc += " " + format("<a href=\"{0}\">Online help</a><br/>", url);
+        desc = setButtonOrLink(onlineHelpButton, desc, onlineHelpLbl, url);
       }
     }
 
     String url = selected.getParentPackage().getWebsiteURL();
     if (url != null && !url.isEmpty()) {
-      desc += " " + format("<a href=\"{0}\">More info</a>", url);
+      desc = setButtonOrLink(moreInfoButton, desc, moreInfoLbl, url);
     }
 
     desc += "</body></html>";

--- a/app/src/cc/arduino/contributions/ui/InstallerJDialog.java
+++ b/app/src/cc/arduino/contributions/ui/InstallerJDialog.java
@@ -133,6 +133,7 @@ public abstract class InstallerJDialog<T> extends JDialog {
           updateIndexFilter(filters, categoryFilter);
         }
       };
+      filterField.getAccessibleContext().setAccessibleDescription(tr("Search Filter"));
 
       // Add cut/copy/paste contextual menu to the search filter input field.
       JPopupMenu menu = new JPopupMenu();


### PR DESCRIPTION
Using the new "use accessibility features" settings option, when the option is selected then instead of more info and online help links in the description there are now buttons for these features that do the same thing as the links.

As a side note, when the option is not selected, the links will now include translated strings for the links.  This made coding the buttons easier, and imo makes the links better.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes

Tested in Windows with NVDA.