### PR TITLE
Tools Boards menu scroll updates for accessibility

### DIFF
--- a/app/src/processing/app/tools/MenuScroller.java
+++ b/app/src/processing/app/tools/MenuScroller.java
@@ -280,9 +280,6 @@ public class MenuScroller {
       scrollCount = autoSizeScrollCount;
     }
 
-//    if (PreferencesData.getBoolean("ide.accessible")) {
-//      interval = 1000;
-//    }
     if (scrollCount <= 0 || interval <= 0) {
       throw new IllegalArgumentException("scrollCount and interval must be greater than 0");
     }
@@ -573,8 +570,21 @@ public class MenuScroller {
           firstIndex += increment * accelerator;
           refreshMenu();
           if (PreferencesData.getBoolean("ide.accessible")) {
+            //    If the user has chosen to use accessibility features, it means that they are using a screen reader
+            // to assist them in development of their project.  This scroller is very unfriendly toward screen readers
+            // because it does not tell the user that it is scrolling through the board options, and it does not read
+            // the name of the boards as they scroll by.  It is possible that the desired board will never become
+            // accessible.
+            //    Because this scroller is quite nice for the sighted user, the idea here is to continue to use the
+            // scroller, but to fool it into scrolling one item at a time for accessible features users so that the
+            // screen readers work well, too.
+            //    It's not the prettiest of code, but it works.
             String    itemClassName;
             int keyEvent;
+
+            // The blind user likely used an arrow key to get to the scroller.  Determine which arrow key
+            // so we can send an event for the opposite arrow key.  This fools the scroller into scrolling
+            // a single item.  Get the class name of the new item while we're here
             if (increment > 0) {
               itemClassName = menuItems[firstIndex + scrollCount - 1].getClass().getName();
               keyEvent = KeyEvent.VK_UP;
@@ -584,8 +594,9 @@ public class MenuScroller {
               keyEvent = KeyEvent.VK_DOWN;
             }
 
-            // if next item is a separator just go on like normal, otherwise move the cursor back to that item is read
-            // by a screen reader and the user can continue to use their arrow keys to navigate the list
+            // Use the class name to check if the next item is a separator.  If it is, just let it scroll on like
+            // normal, otherwise move the cursor back with the opposite key event to the new item so that item is read
+            // by a screen reader and the user can use their arrow keys to navigate the list one item at a time
             if (!itemClassName.equals(JSeparator.class.getName()) ) {
               KeyboardFocusManager manager = KeyboardFocusManager.getCurrentKeyboardFocusManager();
               Component comp = manager.getFocusOwner();

--- a/app/src/processing/app/tools/MenuScroller.java
+++ b/app/src/processing/app/tools/MenuScroller.java
@@ -3,6 +3,8 @@
  */
 package processing.app.tools;
 
+import processing.app.PreferencesData;
+
 import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
@@ -278,6 +280,9 @@ public class MenuScroller {
       scrollCount = autoSizeScrollCount;
     }
 
+//    if (PreferencesData.getBoolean("ide.accessible")) {
+//      interval = 1000;
+//    }
     if (scrollCount <= 0 || interval <= 0) {
       throw new IllegalArgumentException("scrollCount and interval must be greater than 0");
     }
@@ -567,6 +572,29 @@ public class MenuScroller {
         public void actionPerformed(ActionEvent e) {
           firstIndex += increment * accelerator;
           refreshMenu();
+          if (PreferencesData.getBoolean("ide.accessible")) {
+            String    itemClassName;
+            int keyEvent;
+            if (increment > 0) {
+              itemClassName = menuItems[firstIndex + scrollCount - 1].getClass().getName();
+              keyEvent = KeyEvent.VK_UP;
+            }
+            else {
+              itemClassName = menuItems[firstIndex].getClass().getName();
+              keyEvent = KeyEvent.VK_DOWN;
+            }
+
+            // if next item is a separator just go on like normal, otherwise move the cursor back to that item is read
+            // by a screen reader and the user can continue to use their arrow keys to navigate the list
+            if (!itemClassName.equals(JSeparator.class.getName()) ) {
+              KeyboardFocusManager manager = KeyboardFocusManager.getCurrentKeyboardFocusManager();
+              Component comp = manager.getFocusOwner();
+              KeyEvent event = new KeyEvent(comp,
+                KeyEvent.KEY_PRESSED, System.currentTimeMillis(), 0,
+                keyEvent, KeyEvent.CHAR_UNDEFINED);
+              comp.dispatchEvent(event);
+            }
+          }
         }
       });
     }


### PR DESCRIPTION
When a user uses the keyboard to navigate the menu, when you arrow up or down onto the scroll arrows, the scroll just starts scrolling the menu, scrolling a new board every 150 ms.  The board names don’t get read by the screen reader as they scroll by.  So the screen reader user has no idea what’s going on.  They are just on a menu item that says “menu item” at the screen reader.  If they hit the same arrow key again, they get to the Boards Manager… menu item, either by scrolling up or by scrolling down and wrapping around.  The wrapping around isn’t an issue – the user at least now knows where they are again because it says more than “menu item”
 
A big issue is that if they have a small screen and a very large number of board installed, it is possible that the board that they are looking for would scroll onto the visible part of the menu and then back off the visible part as the scroll continues.  After a bit of wondering what’s going on, because “screen item” made no sense, they may arrow back the other way to try to figure out what is going on.  Going the other way they might notice that the boards had changed, and they would think that that is odd.   And name of the board they want would never be read to them – it scrolled into and out of the visible area.  They know their board is installed, but they just can’t get to it.
 
Ideally, the menu wouldn’t scroll continuously.  Instead when they get to the end of the visible area and hit arrow again, only the next item would appear.   And I could easily make that happed by just removing the scroll – then the screen reader just keeps going through the list, but they end up scrolling off of the screen.  But for the low vision user that’s no good – they use both the screen reader and what they can see on the screen. Or if the person who is blind asks for sighted person’s help, the sighted person would want to see what’s going on.
 
So the problems isn’t that it goes back to the head of the list.  The problem is that the scroll doesn’t tell the user that it’s scrolling.  And as it scrolls it doesn’t tell the user WHAT is scrolling.  So this is intended to scroll the list one item at a time AND read that item name.  While still maintaining usability for low vision and sighted users.  
 
I hope that made sense.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes
