### PR TITLE
Divide board menu into submenus

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1493,7 +1493,7 @@ public class Base {
         if (platformLabel == null)
           platformLabel = targetPackage.getId() + "-" + targetPlatform.getId();
 
-        JMenu platformBoardsMenu = new JMenu(tr(platformLabel));
+        JMenu platformBoardsMenu = new JMenu(platformLabel);
         MenuScroller.setScrollerFor(platformBoardsMenu);
         platformMenus.add(platformBoardsMenu);
 

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1510,6 +1510,8 @@ public class Base {
       }
     }
 
+    platformMenus.sort((x,y) -> x.getText().compareToIgnoreCase(y.getText()));
+
     JMenuItem firstBoardItem = null;
     if (platformMenus.size() == 1) {
       // When just one platform exists, add the board items directly,

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1511,10 +1511,21 @@ public class Base {
     }
 
     JMenuItem firstBoardItem = null;
-    for (JMenu platformMenu : platformMenus) {
-      if (firstBoardItem == null && platformMenu.getItemCount() > 0)
-        firstBoardItem = platformMenu.getItem(0);
-      boardMenu.add(platformMenu);
+    if (platformMenus.size() == 1) {
+      // When just one platform exists, add the board items directly,
+      // rather than using a submenu
+      for (Component boardItem : platformMenus.get(0).getMenuComponents()) {
+        boardMenu.add(boardItem);
+        if (firstBoardItem == null)
+          firstBoardItem = (JMenuItem)boardItem;
+      }
+    } else {
+      // For multiple platforms, use submenus
+      for (JMenu platformMenu : platformMenus) {
+        if (firstBoardItem == null && platformMenu.getItemCount() > 0)
+          firstBoardItem = platformMenu.getItem(0);
+        boardMenu.add(platformMenu);
+      }
     }
 
     if (firstBoardItem == null) {

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -999,9 +999,9 @@ public class Base {
     // kill uploader (if still alive)
     UploaderUtils uploaderInstance = new UploaderUtils();
     Uploader uploader = uploaderInstance.getUploaderByPreferences(false);
-    if (uploader != null && uploader.programmerPid != null && uploader.programmerPid.isAlive()) {
+    if (uploader != null && Uploader.programmerPid != null && Uploader.programmerPid.isAlive()) {
         // kill the stuck programmer
-        uploader.programmerPid.destroyForcibly();
+        Uploader.programmerPid.destroyForcibly();
     }
 
     if (handleQuitEach()) {
@@ -1444,8 +1444,9 @@ public class Base {
         String filterText = "";
         String dropdownItem = "";
         if (actionevent instanceof Event) {
-          filterText = ((Event) actionevent).getPayload().get("filterText").toString();
-          dropdownItem = ((Event) actionevent).getPayload().get("dropdownItem").toString();
+          Event e = ((Event) actionevent);
+          filterText = e.getPayload().get("filterText").toString();
+          dropdownItem = e.getPayload().get("dropdownItem").toString();
         }
         try {
           openBoardsManager(filterText, dropdownItem);
@@ -1481,7 +1482,7 @@ public class Base {
     ButtonGroup boardsButtonGroup = new ButtonGroup();
     Map<String, ButtonGroup> buttonGroupsMap = new HashMap<>();
 
-    List<JMenu> platformMenus = new ArrayList<JMenu>();
+    List<JMenu> platformMenus = new ArrayList<>();
 
     // Cycle through all packages
     for (TargetPackage targetPackage : BaseNoGui.packages.values()) {
@@ -1602,7 +1603,7 @@ public class Base {
           };
           List<TargetBoard> boards = (List<TargetBoard>) subAction.getValue("board");
           if (boards == null) {
-            boards = new ArrayList<TargetBoard>();
+            boards = new ArrayList<>();
           }
           boards.add(board);
           subAction.putValue("board", boards);
@@ -2003,6 +2004,7 @@ public class Base {
               Base.this.handleFontSizeChange(-1);
             }
             break;
+          default:
           }
         }
       }

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -761,6 +761,20 @@ public class Editor extends JFrame implements RunnerListener {
     toolsMenu.add(item);
 
     toolsMenu.addMenuListener(new StubMenuListener() {
+      public JMenuItem getSelectedItemRecursive(JMenu menu) {
+        int count = menu.getItemCount();
+        for (int i=0; i < count; i++) {
+          JMenuItem item = menu.getItem(i);
+
+          if ((item instanceof JMenu))
+            item = getSelectedItemRecursive((JMenu)item);
+
+          if (item != null && item.isSelected())
+            return item;
+        }
+        return null;
+      }
+
       public void menuSelected(MenuEvent e) {
         //System.out.println("Tools menu selected.");
         populatePortMenu();
@@ -772,15 +786,9 @@ public class Editor extends JFrame implements RunnerListener {
             String basename = name;
             int index = name.indexOf(':');
             if (index > 0) basename = name.substring(0, index);
-            String sel = null;
-            int count = menu.getItemCount();
-            for (int i=0; i < count; i++) {
-              JMenuItem item = menu.getItem(i);
-              if (item != null && item.isSelected()) {
-                sel = item.getText();
-                if (sel != null) break;
-              }
-            }
+
+            JMenuItem item = getSelectedItemRecursive(menu);
+            String sel = item != null ? item.getText() : null;
             if (sel == null) {
               if (!name.equals(basename)) menu.setText(basename);
             } else {

--- a/arduino-core/src/processing/app/I18n.java
+++ b/arduino-core/src/processing/app/I18n.java
@@ -106,10 +106,6 @@ public class I18n {
    * This method is an hack to extract words with gettext tool.
    */
   protected static void unusedStrings() {
-    // These phrases are defined in the "platform.txt".
-    tr("Arduino AVR Boards");
-    tr("Arduino ARM (32-bits) Boards");
-
     // This word is defined in the "boards.txt".
     tr("Processor");
   }


### PR DESCRIPTION
When multiple platforms (board packages) are installed, the boards menu quickly becomes very long and hard to use. This PR changes the menu to have a single submenu for each installed platform, under which the boards for that platform are listed. This makes the list a lot faster to navigate:

![Screenshot from 2019-09-19 17-00-33](https://user-images.githubusercontent.com/194491/65256954-b1bdce00-db00-11e9-9d3f-781615265ba6.png)

When there is just a single platform installed (e.g. on the default install), submenus do not really add anything, so the board menu still lists the boards directly as before (the only change is that the platform name is no longer shown at the top of the menu):

![Screenshot from 2019-09-19 16-56-58](https://user-images.githubusercontent.com/194491/65257071-e9c51100-db00-11e9-8a92-b92a86a158d0.png)

I think there has been some discussion about this in the past (see #8858, #1986 is also somewhat related). This also relates to keeping a recently-used-boards list (PR at #8607), either that or this PR might need some refactoring if both will be merged (but I needed this feature myself, so I thought I might as well share it here as well).
