### PR TITLE
Cleanup board/library manager color setting and somewhat support dark themes

### DIFF
--- a/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryTableCellEditor.java
+++ b/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryTableCellEditor.java
@@ -125,6 +125,7 @@ public class ContributedLibraryTableCellEditor extends InstallerTableCell {
     editorCell.versionToInstallChooser
         .setVisible(!mayInstalled.isPresent() && notInstalled.size() > 1);
 
+    editorCell.setForeground(Color.BLACK);
     editorCell.setBackground(new Color(218, 227, 227)); // #dae3e3
     return editorCell;
   }

--- a/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryTableCellJPanel.java
+++ b/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryTableCellJPanel.java
@@ -42,6 +42,7 @@ public class ContributedLibraryTableCellJPanel extends JPanel {
   final JPanel buttonsPanel;
   final JPanel inactiveButtonsPanel;
   final JLabel statusLabel;
+  final JTextPane description;
   private final String moreInfoLbl = tr("More info");
 
   public ContributedLibraryTableCellJPanel(JTable parentTable, Object value,
@@ -77,7 +78,8 @@ public class ContributedLibraryTableCellJPanel extends JPanel {
     versionToInstallChooser
         .setMinimumSize(new Dimension((int)versionToInstallChooser.getPreferredSize().getWidth() + 50, (int)versionToInstallChooser.getPreferredSize().getHeight()));
 
-    makeNewDescription();
+    description = makeNewDescription();
+    add(description);
 
     buttonsPanel = new JPanel();
     buttonsPanel.setLayout(new BoxLayout(buttonsPanel, BoxLayout.X_AXIS));
@@ -121,7 +123,6 @@ public class ContributedLibraryTableCellJPanel extends JPanel {
     add(Box.createVerticalStrut(15));
 
     ContributedLibraryReleases releases = (ContributedLibraryReleases) value;
-    JTextPane description = makeNewDescription();
 
     // FIXME: happens on macosx, don't know why
     if (releases == null)
@@ -237,9 +238,6 @@ public class ContributedLibraryTableCellJPanel extends JPanel {
 
   // TODO Make this a method of Theme
   private JTextPane makeNewDescription() {
-    if (getComponentCount() > 0) {
-      remove(0);
-    }
     JTextPane description = new JTextPane();
     description.setInheritsPopupMenu(true);
     Insets margin = description.getMargin();
@@ -265,7 +263,6 @@ public class ContributedLibraryTableCellJPanel extends JPanel {
       }
     });
     // description.addKeyListener(new DelegatingKeyListener(parentTable));
-    add(description, 0);
     return description;
   }
 

--- a/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryTableCellJPanel.java
+++ b/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryTableCellJPanel.java
@@ -271,4 +271,11 @@ public class ContributedLibraryTableCellJPanel extends JPanel {
     buttonsPanel.setVisible(enabled);
     inactiveButtonsPanel.setVisible(!enabled);
   }
+
+  public void setForeground(Color c) {
+    super.setForeground(c);
+    // The description is not opaque, so copy our foreground color to it.
+    if (description != null)
+      description.setForeground(c);
+  }
 }

--- a/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryTableCellJPanel.java
+++ b/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryTableCellJPanel.java
@@ -205,7 +205,6 @@ public class ContributedLibraryTableCellJPanel extends JPanel {
     description.setText(desc);
     // copy description to accessibility context for screen readers to use
     description.getAccessibleContext().setAccessibleDescription(desc);
-    description.setBackground(Color.WHITE);
 
     // for modelToView to work, the text area has to be sized. It doesn't
     // matter if it's visible or not.
@@ -215,14 +214,6 @@ public class ContributedLibraryTableCellJPanel extends JPanel {
     InstallerTableCell
         .setJTextPaneDimensionToFitContainedText(description,
                                                  parentTable.getBounds().width);
-
-    if (isSelected) {
-      setBackground(parentTable.getSelectionBackground());
-      setForeground(parentTable.getSelectionForeground());
-    } else {
-      setBackground(parentTable.getBackground());
-      setForeground(parentTable.getForeground());
-    }
   }
 
   // same function as in ContributedPlatformTableCellJPanel - is there a utils file this can move to?

--- a/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryTableCellRenderer.java
+++ b/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryTableCellRenderer.java
@@ -46,6 +46,7 @@ public class ContributedLibraryTableCellRenderer implements TableCellRenderer {
         value, isSelected);
     cell.setButtonsVisible(false);
 
+    cell.setForeground(Color.BLACK);
     if (row % 2 == 0) {
       cell.setBackground(new Color(236, 241, 241)); // #ecf1f1
     } else {

--- a/app/src/cc/arduino/contributions/packages/ui/ContributedPlatformTableCellEditor.java
+++ b/app/src/cc/arduino/contributions/packages/ui/ContributedPlatformTableCellEditor.java
@@ -130,6 +130,7 @@ public class ContributedPlatformTableCellEditor extends InstallerTableCell {
         .setVisible(installed == null && uninstalledReleases.size() > 1);
 
     cell.update(table, _value, !installedBuiltIn.isEmpty());
+    cell.setForeground(Color.BLACK);
     cell.setBackground(new Color(218, 227, 227)); // #dae3e3
     return cell;
   }

--- a/app/src/cc/arduino/contributions/packages/ui/ContributedPlatformTableCellEditor.java
+++ b/app/src/cc/arduino/contributions/packages/ui/ContributedPlatformTableCellEditor.java
@@ -129,7 +129,7 @@ public class ContributedPlatformTableCellEditor extends InstallerTableCell {
     cell.versionToInstallChooser
         .setVisible(installed == null && uninstalledReleases.size() > 1);
 
-    cell.update(table, _value, true, !installedBuiltIn.isEmpty());
+    cell.update(table, _value, !installedBuiltIn.isEmpty());
     cell.setBackground(new Color(218, 227, 227)); // #dae3e3
     return cell;
   }

--- a/app/src/cc/arduino/contributions/packages/ui/ContributedPlatformTableCellJPanel.java
+++ b/app/src/cc/arduino/contributions/packages/ui/ContributedPlatformTableCellJPanel.java
@@ -184,8 +184,7 @@ public class ContributedPlatformTableCellJPanel extends JPanel {
     return retString;
   }
 
-  void update(JTable parentTable, Object value, boolean isSelected,
-              boolean hasBuiltInRelease) {
+  void update(JTable parentTable, Object value, boolean hasBuiltInRelease) {
     ContributedPlatformReleases releases = (ContributedPlatformReleases) value;
 
     JTextPane description = makeNewDescription();
@@ -268,7 +267,6 @@ public class ContributedPlatformTableCellJPanel extends JPanel {
     description.setText(desc);
     // copy description to accessibility context for screen readers to use
     description.getAccessibleContext().setAccessibleDescription(desc);
-    description.setBackground(Color.WHITE);
 
     // for modelToView to work, the text area has to be sized. It doesn't
     // matter if it's visible or not.
@@ -278,14 +276,6 @@ public class ContributedPlatformTableCellJPanel extends JPanel {
     int width = parentTable.getBounds().width;
     InstallerTableCell.setJTextPaneDimensionToFitContainedText(description,
                                                                width);
-
-    if (isSelected) {
-      setBackground(parentTable.getSelectionBackground());
-      setForeground(parentTable.getSelectionForeground());
-    } else {
-      setBackground(parentTable.getBackground());
-      setForeground(parentTable.getForeground());
-    }
   }
 
   private JTextPane makeNewDescription() {

--- a/app/src/cc/arduino/contributions/packages/ui/ContributedPlatformTableCellJPanel.java
+++ b/app/src/cc/arduino/contributions/packages/ui/ContributedPlatformTableCellJPanel.java
@@ -312,4 +312,10 @@ public class ContributedPlatformTableCellJPanel extends JPanel {
     inactiveButtonsPanel.setVisible(!enabled);
   }
 
+  public void setForeground(Color c) {
+    super.setForeground(c);
+    // The description is not opaque, so copy our foreground color to it.
+    if (description != null)
+      description.setForeground(c);
+  }
 }

--- a/app/src/cc/arduino/contributions/packages/ui/ContributedPlatformTableCellJPanel.java
+++ b/app/src/cc/arduino/contributions/packages/ui/ContributedPlatformTableCellJPanel.java
@@ -75,6 +75,7 @@ public class ContributedPlatformTableCellJPanel extends JPanel {
   final JPanel buttonsPanel;
   final JPanel inactiveButtonsPanel;
   final JLabel statusLabel;
+  final JTextPane description;
   private final String moreInfoLbl = tr("More Info");
   private final String onlineHelpLbl = tr("Online Help");
 
@@ -117,7 +118,8 @@ public class ContributedPlatformTableCellJPanel extends JPanel {
     versionToInstallChooser
         .setMaximumSize(versionToInstallChooser.getPreferredSize());
 
-    makeNewDescription();
+    description = makeNewDescription();
+    add(description);
 
     buttonsPanel = new JPanel();
     buttonsPanel.setLayout(new BoxLayout(buttonsPanel, BoxLayout.X_AXIS));
@@ -186,8 +188,6 @@ public class ContributedPlatformTableCellJPanel extends JPanel {
 
   void update(JTable parentTable, Object value, boolean hasBuiltInRelease) {
     ContributedPlatformReleases releases = (ContributedPlatformReleases) value;
-
-    JTextPane description = makeNewDescription();
 
     // FIXME: happens on macosx, don't know why
     if (releases == null) {
@@ -279,9 +279,6 @@ public class ContributedPlatformTableCellJPanel extends JPanel {
   }
 
   private JTextPane makeNewDescription() {
-    if (getComponentCount() > 0) {
-      remove(0);
-    }
     JTextPane description = new JTextPane();
     description.setInheritsPopupMenu(true);
     Insets margin = description.getMargin();
@@ -305,7 +302,6 @@ public class ContributedPlatformTableCellJPanel extends JPanel {
         Base.openURL(e.getDescription());
       }
     });
-    add(description, 0);
     return description;
   }
 

--- a/app/src/cc/arduino/contributions/packages/ui/ContributedPlatformTableCellRenderer.java
+++ b/app/src/cc/arduino/contributions/packages/ui/ContributedPlatformTableCellRenderer.java
@@ -46,6 +46,7 @@ public class ContributedPlatformTableCellRenderer implements TableCellRenderer {
     cell.setButtonsVisible(false);
     cell.update(table, value, false);
 
+    cell.setForeground(Color.BLACK);
     if (row % 2 == 0) {
       cell.setBackground(new Color(236, 241, 241)); // #ecf1f1
     } else {

--- a/app/src/cc/arduino/contributions/packages/ui/ContributedPlatformTableCellRenderer.java
+++ b/app/src/cc/arduino/contributions/packages/ui/ContributedPlatformTableCellRenderer.java
@@ -44,7 +44,7 @@ public class ContributedPlatformTableCellRenderer implements TableCellRenderer {
                                                  int column) {
     ContributedPlatformTableCellJPanel cell = new ContributedPlatformTableCellJPanel();
     cell.setButtonsVisible(false);
-    cell.update(table, value, isSelected, false);
+    cell.update(table, value, false);
 
     if (row % 2 == 0) {
       cell.setBackground(new Color(236, 241, 241)); // #ecf1f1

--- a/app/src/cc/arduino/contributions/ui/InstallerJDialog.java
+++ b/app/src/cc/arduino/contributions/ui/InstallerJDialog.java
@@ -180,7 +180,6 @@ public abstract class InstallerJDialog<T> extends JDialog {
     contribTable.setDragEnabled(false);
     contribTable.setIntercellSpacing(new Dimension(0, 1));
     contribTable.setShowVerticalLines(false);
-    contribTable.setSelectionBackground(Theme.getColor("status.notice.bgcolor"));
     contribTable.addKeyListener(new AbstractKeyListener() {
 
       @Override


### PR DESCRIPTION
I'm running with a dark system theme, which defaults interfaces to have white/light grey on black/dark grey coloring. This works pretty well in the Arduino IDE, except for the library and board managers.

As an example, here's how the board manager looks using the default Gnome light theme (adwaita):

![Default theme](https://user-images.githubusercontent.com/194491/65968224-1c58fd00-e463-11e9-99be-ce5c3f4be941.png)


However, when switching to a dark theme, adwaita-dark (can be done using the gnome-tweaks command), the background colors change but the foreground color stays at the (now) default light color:

![Dark theme](https://user-images.githubusercontent.com/194491/65967723-64c3eb00-e462-11e9-8173-f26fa32caffa.png)

While investigating, I also found that there is a lot of color-setting code that is not actually effective (because the colors are set on the wrong component, or are overwritten by other code). The first commit removes this useless code. See the commit message for a detailed analysis of how the code paths run.

The second commit does a bit of cleanup and refactoring needed for the last commit, which also sets the foreground color to black to match the background color. This results in a usable interface again:

![Dark theme fixed](https://user-images.githubusercontent.com/194491/65967724-64c3eb00-e462-11e9-89d6-f22b13893c4b.png)

With the default light theme, the interface is unchanged. All of the above also applies to the library manager, which is fixed in the same way.

Note that this essentially forces a light theme for the board and library manager, but leaves the dropdowns and buttons unchanged (since it is probably tricky to completely undo the dark them for those).

An alternative solution would be only use the default colors, which would actually preserve the dark theme colors in these managers as well (rather than forcing black-on-white/grey as now). There are default colors for selected and non-selected table cells that could be used, but these are different from the current colors. Additionally, the current odd/even alternating colors are then also no longer available.

For completeness, here's how that would look in a light theme:

![image](https://user-images.githubusercontent.com/194491/65968702-dbadb380-e463-11e9-8107-428a7e73fe83.png)

And in a dark theme:

![image](https://user-images.githubusercontent.com/194491/65968798-00099000-e464-11e9-9c60-1191fe9b6f1e.png)
