### PR TITLE
Moving shebang at the top of the file

### DIFF
--- a/build/linux/dist/arduino-linux-setup.sh
+++ b/build/linux/dist/arduino-linux-setup.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # arduino-linux-setup.sh : A simple Arduino setup script for Linux systems
 # Copyright (C) 2015 Arduino Srl
 #
@@ -60,8 +61,6 @@
 #
 #	+ now the script checks for SUDO permissions
 #
-
-#!/bin/bash
 
 # if [[ $EUID != 0 ]] ; then
 #   echo This must be run as root!


### PR DESCRIPTION
Shebang changes how Unix-like OS run scripts, ensuring the script is run with the specified interpreter. In this case as the line was not the first in the file, users without bash as their default shell would experience issues running the script.

Fixes #9281
More details on shebang usage here https://en.wikipedia.org/wiki/Shebang_(Unix)

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
