### PR TITLE
Hide splash screen asap if not using gui

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -208,7 +208,6 @@ public class Base {
 
     BaseNoGui.initPortableFolder();
     // This configure the logs root folder
-    System.out.println("Set log4j store directory " + BaseNoGui.getSettingsFolder().getAbsolutePath());
     System.setProperty("log4j.dir", BaseNoGui.getSettingsFolder().getAbsolutePath());
 
     // Look for a possible "--preferences-file" parameter and load preferences
@@ -217,6 +216,17 @@ public class Base {
     CommandlineParser parser = new CommandlineParser(args);
     parser.parseArgumentsPhase1();
     commandLine = !parser.isGuiMode();
+
+    if (!parser.isGuiMode()) {
+      try {
+        // This can return null or raise an exception
+        SplashScreen s = SplashScreen.getSplashScreen();
+        if (s != null) {
+          s.close();
+        }
+      } catch (UnsupportedOperationException e) {
+      }
+    }
 
     BaseNoGui.checkInstallationFolder();
 


### PR DESCRIPTION
Fixes #1970

On macOS, when running,

    Arduino.app/Contents/MacOS/Arduino --upload sketch.ino

a splash screen is visible the entire time the upload is running.

This PR hides that splash screen as soon as it’s known for sure that the
GUI should not be displayed. This makes for a slightly better user
experience: there’s still a splash screen, but it only appears briefly at
launch time.

The [SplashScreen docs][] explain:

> The splash screen can be displayed at application startup, before the
> Java Virtual Machine (JVM) starts. ... is closed automatically as soon as
> the first window is displayed by Swing/AWT (may be also closed manually
> using the Java API, see below)

[SplashScreen docs]: https://docs.oracle.com/javase/7/docs/api/java/awt/SplashScreen.html

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes
