### PR TITLE
SerialUpload: skip first sleep on MacOS Catalina

### DIFF
--- a/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
+++ b/arduino-core/src/cc/arduino/packages/uploaders/SerialUploader.java
@@ -35,11 +35,13 @@
 package cc.arduino.packages.uploaders;
 
 import cc.arduino.LoadVIDPIDSpecificPreferences;
+import cc.arduino.contributions.VersionComparator;
 import cc.arduino.packages.Uploader;
 import processing.app.*;
 import cc.arduino.packages.BoardPort;
 import processing.app.debug.RunnerException;
 import processing.app.debug.TargetPlatform;
+import processing.app.helpers.OSUtils;
 import processing.app.helpers.PreferencesMap;
 import processing.app.helpers.PreferencesMapException;
 import processing.app.helpers.StringReplacer;
@@ -135,7 +137,11 @@ public class SerialUploader extends Uploader {
               I18n.format(tr("Forcing reset using 1200bps open/close on port {0}"), userSelectedUploadPort));
           Serial.touchForCDCReset(userSelectedUploadPort);
         }
-        Thread.sleep(400);
+        // It looks like MacOS Catalina (10.15) is too fast enumerating the bootloader port
+        // Let's skip the initial sleep to get a faster response and eventually an enumeration
+        if (!(OSUtils.isMacOS() && VersionComparator.greaterThanOrEqual(OSUtils.version(), "10.15"))) {
+          Thread.sleep(400);
+        }
         if (waitForUploadPort) {
           // Scanning for available ports seems to open the port or
           // otherwise assert DTR, which would cancel the WDT reset if


### PR DESCRIPTION
From log analysis (I don't have a Mac with Catalina yet for testing in real life) is appears that:
- bootloader is triggered via 1200bps touch
- the bootloader portname is the same as sketch one
- the transition is very fast (if it exist at all)

Removing the first sleep after the touch could allow the IDE to recognize port disappearance .

Could fix #9290 and #8626

@gvarisco 