### PR TITLE
Fix wrong bracket match rectangle on auto format

### DIFF
--- a/app/src/processing/app/EditorTab.java
+++ b/app/src/processing/app/EditorTab.java
@@ -442,6 +442,9 @@ public class EditorTab extends JPanel implements SketchFile.TextStorage {
     } finally {
       caret.setUpdatePolicy(policy);
     }
+    // A trick to force textarea to recalculate the bracket matching rectangle.
+    // In the worst case scenario, this should be ineffective.
+    textarea.setLineWrap(textarea.getLineWrap());
   }
 
   /**


### PR DESCRIPTION
This commit fixes #9544 
When setText is called on editorTab the rectangle that highlights
the bracket match becomes incorrect.
This is because text is inserted to the document without notifying the textarea.
Calling setLineWrap internally fires an event that recalculates the bracket 
match rectangle and thus solves the problem.
A more straightforward way would have been calling the function 
"doBracketMatching" on textarea but the function is protected. 
Actually setLineWrap is the only public function that I am able to find 
that internally (eventually) calls doBracketMatching.
I am not familiar with your testing framework and couldn't find any
information about it to run the tests so I only tested the changes manually.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully ran tests with your changes
