### PR TITLE
Compiler errors without column

### DIFF
--- a/arduino-core/src/cc/arduino/Compiler.java
+++ b/arduino-core/src/cc/arduino/Compiler.java
@@ -516,16 +516,13 @@ public class Compiler implements MessageConsumer {
 
     if (pieces != null) {
       String msg = "";
-      int errorIdx = pieces.length - 1;
-      String error = pieces[errorIdx];
       String filename = pieces[1];
       int line = PApplet.parseInt(pieces[2]);
-      int col;
-      if (errorIdx > 3) {
+      int col = -1;
+      if (pieces[3] != null) {
         col = PApplet.parseInt(pieces[3].substring(1));
-      } else {
-        col = -1;
       }
+      String error = pieces[5];
 
       if (error.trim().equals("SPI.h: No such file or directory")) {
         error = tr("Please import the SPI library from the Sketch > Import Library menu.");

--- a/arduino-core/src/cc/arduino/Compiler.java
+++ b/arduino-core/src/cc/arduino/Compiler.java
@@ -582,11 +582,8 @@ public class Compiler implements MessageConsumer {
         String fileName = ex.getCodeFile().getPrettyName();
         int lineNum = ex.getCodeLine() + 1;
         int colNum = ex.getCodeColumn();
-        if (colNum != -1) {
-          s = fileName + ":" + lineNum + ":" + colNum + ": error: " + error + msg;
-        } else {
-          s = fileName + ":" + lineNum + ": error: " + error + msg;
-        }
+        String column = (colNum != -1) ? (":" + colNum) : "";
+        s = fileName + ":" + lineNum + column + ": error: " + error + msg;
       }
 
       if (ex != null) {

--- a/arduino-core/src/cc/arduino/Compiler.java
+++ b/arduino-core/src/cc/arduino/Compiler.java
@@ -134,7 +134,7 @@ public class Compiler implements MessageConsumer {
     }
   }
 
-  private static final Pattern ERROR_FORMAT = Pattern.compile("(.+\\.\\w+):(\\d+)(:\\d+)*:\\s*(fatal)?\\s*error:\\s*(.*)\\s*", Pattern.MULTILINE | Pattern.DOTALL);
+  private static final Pattern ERROR_FORMAT = Pattern.compile("(.+\\.\\w+):(\\d+)(:\\d+)*:\\s*((fatal)?\\s*error:\\s*)(.*)\\s*", Pattern.MULTILINE | Pattern.DOTALL);
 
   private final File pathToSketch;
   private final Sketch sketch;
@@ -522,7 +522,8 @@ public class Compiler implements MessageConsumer {
       if (pieces[3] != null) {
         col = PApplet.parseInt(pieces[3].substring(1));
       }
-      String error = pieces[5];
+      String errorPrefix = pieces[4];
+      String error = pieces[6];
 
       if (error.trim().equals("SPI.h: No such file or directory")) {
         error = tr("Please import the SPI library from the Sketch > Import Library menu.");
@@ -583,7 +584,7 @@ public class Compiler implements MessageConsumer {
         int lineNum = ex.getCodeLine() + 1;
         int colNum = ex.getCodeColumn();
         String column = (colNum != -1) ? (":" + colNum) : "";
-        s = fileName + ":" + lineNum + column + ": error: " + error + msg;
+        s = fileName + ":" + lineNum + column + ": " + errorPrefix + error + msg;
       }
 
       if (ex != null) {


### PR DESCRIPTION
Error messages are detected and parsed using a regex. Part of this regex
matches the optional column number.

The code that handled this assumed that a missing column would result in
less elements in the matches array, but a regex always results in one
element per set of parenthesis in the regex, which will be null if no
capture was made for that element.

In practice, this meant that if no column was present in the error
message, a NullPointerException would be raised. Furthermore, gcc 9
seems to have started outputting omitting column numbers (instead of
printing 0) for some errors (such as unterminated #ifdef), which exposed
this problem.

To reproduce, install a core that uses gcc 9, such as [Arduino_Core_STM32](https://github.com/stm32duino/Arduino_Core_STM32/), select a board from that core and compile any sketch that contains in unterminated ifdef, e.g.:

```
#ifdef FOO
void setup() { }
void loop() { }
```

On AVR, this results in:
```
sketch_jan29a:1:0: error: unterminated #ifdef
 #ifdef FOO
 ^
exit status 1
unterminated #ifdef
```

On STM32, I get:

```
    1 | #ifdef FOO
      | 
Using library SrcWrapper at version 1.0.1 in folder: /home/matthijs/.arduino15/packages/STM32/hardware/stm32/1.8.0/libraries/SrcWrapper 
exit status 1
processing.app.debug.RunnerException
	at cc.arduino.Compiler.lambda$callArduinoBuilder$3(Compiler.java:309)
	at processing.app.debug.MessageSiphon.run(MessageSiphon.java:96)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.NullPointerException
	at cc.arduino.Compiler.message(Compiler.java:525)
	at cc.arduino.i18n.I18NAwareMessageConsumer.message(I18NAwareMessageConsumer.java:80)
	at cc.arduino.MessageConsumerOutputStream.flush(MessageConsumerOutputStream.java:71)
	at cc.arduino.MessageConsumerOutputStream.write(MessageConsumerOutputStream.java:54)
	at java.base/java.io.OutputStream.write(OutputStream.java:122)
	at cc.arduino.Compiler.lambda$callArduinoBuilder$3(Compiler.java:307)
	... 2 more
```

Note the missing error message, only the quoted source lines for the error are present. gcc-9 also changed the way it indicates source lines using a `|` prefix, but that is handled just fine.

A second problem is that "fatal" would be stripped from error messages. e.g. 

```
matthijs@grubby:~$ cat foo.cpp 
#include <asdf.h>
matthijs@grubby:~$ gcc foo.cpp 
foo.cpp:1:10: fatal error: asdf: No such file or directory
 #include <asdf.h>
          ^~~~~~
compilation terminated.
```

But compiling the same line in the IDE (using the AVR core) gives:

```
sketch_jan29a:1:10: error: asdf.h: No such file or directoryAlternatives for asdf.h: []
 #include <asdf.h>
          ^~~~~~~~
compilation terminated.
```
Note the missing "fatal". There is also some intermixing of stdout and stderr, but that is a separate issue.

This PR fixes both problems by improving the compiler error message parsing. See the commit messages for implementation details.

With this PR, columless error message are shown properly (below with the STM32 core):
```
sketch_jan29a:1: error: unterminated #ifdef
    1 | #ifdef FOO
      | 
```

Also, fatal errors are now again shown as such (below uses the AVR core again):
```
sketch_jan29a:1:10: fatal error: asdf.h: No such file or directory
 #include <asdf.h>
          ^~~~~~~~
compilation terminated.
```
