### PR TITLE
Build Arduino IDE and run tests on GitHub-hosted runners

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -1,0 +1,21 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build with Ant
+      working-directory: ./build
+      run: ant clean dist
+    - name: Run tests
+      working-directory: ./app
+      run: ant test

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -15,7 +15,9 @@ jobs:
         java-version: 1.8
     - name: Build with Ant
       working-directory: ./build
-      run: ant clean dist
+      run: |
+        sed -i 's#<input .*/>##' build.xml
+        ant clean dist
     - name: Run tests
       working-directory: ./app
       run: ant test

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -18,6 +18,10 @@ jobs:
       run: |
         sed -i 's#<input .*/>##' build.xml
         ant clean dist
+    - name: Install X virtual framebuffer
+      run: sudo apt-get install -y xvfb
     - name: Run tests
       working-directory: ./app
-      run: ant test
+      run: xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" ant test
+    - name: Cleanup xvfb
+      uses: bcomnes/cleanup-xvfb@v1


### PR DESCRIPTION
I noticed some Arduino IDE tests were failing when I ran them (fx #9695).

This PR increases visibility of existing tests by building the Arduino IDE and running Arduino IDE tests automatically on the GitHub platform.


Background: A GitHub-hosted runner is a virtual machine hosted by GitHub with the GitHub Actions runner application installed. This makes it possible to build and run Arduino tests automatically.

https://help.github.com/en/actions/automating-your-workflow-with-github-actions/virtual-environments-for-github-hosted-runners