### PR TITLE
Treat JUnit errors as failures to increase visibility

### DIFF
--- a/app/build.xml
+++ b/app/build.xml
@@ -109,7 +109,7 @@
       <fileset dir="test" includes="**/*.pac" />
     </copy>
 
-    <junit printsummary="yes" dir="${work.dir}" fork="true">
+    <junit printsummary="yes" dir="${work.dir}" fork="true" showoutput="yes" failureproperty="test.failed">
       <jvmarg value="-Djava.library.path=${java.additional.library.path}"/>
       <jvmarg value="-DWORK_DIR=."/>
       <jvmarg value="-ea"/>
@@ -131,6 +131,7 @@
       </batchtest>
     </junit>
 
+    <fail if="test.failed"/>
   </target>
 
   <target name="build" depends="compile" description="Build PDE">


### PR DESCRIPTION
Before this change `cd app; ant test` would return "BUILD SUCCESS"
even when unit tests were returning errors.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes

Please note: **this change will make (already) failing tests break the "ant test" target.**
