### PR TITLE
Fix libraries comparator logic in library manager

### DIFF
--- a/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryReleasesComparator.java
+++ b/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryReleasesComparator.java
@@ -32,7 +32,9 @@ package cc.arduino.contributions.libraries.ui;
 import cc.arduino.contributions.libraries.ContributedLibrary;
 import cc.arduino.contributions.libraries.ContributedLibraryReleases;
 
+import java.util.Arrays;
 import java.util.Comparator;
+import java.util.List;
 
 public class ContributedLibraryReleasesComparator implements Comparator<ContributedLibraryReleases> {
 
@@ -47,9 +49,11 @@ public class ContributedLibraryReleasesComparator implements Comparator<Contribu
     ContributedLibrary lib1 = o1.getLatest();
     ContributedLibrary lib2 = o2.getLatest();
 
-    if (lib1.getTypes() == null || lib2.getTypes() == null) {
-      return compareName(lib1, lib2);
-    }
+    List<String> types1 = lib1.getTypes();
+    List<String> types2 = lib2.getTypes();
+    if (types1 == null) types1 = Arrays.asList();
+    if (types2 == null) types2 = Arrays.asList();
+
     if (lib1.getTypes().contains(firstType) && lib2.getTypes().contains(firstType)) {
       return compareName(lib1, lib2);
     }


### PR DESCRIPTION
Previously it could lead to "contract violations", for example consider this:

A = Library{ Name:"A", Types: ["Sensors"] }
B = Library{ Name:"B", Types: null        }
C = Library{ Name:"C", Types: ["Arduino"] }

it results in:

A<B (because B has Types==null and compareName("A","B")<0)
B<C (because B has Types==null and compareName("B","C")<0)
C<A (becuase C has Types=="Arduino" and the comparator returns -1 directly)

This commit fix this behavior.

Fix #9738 