### PR TITLE
Fix serial monitor output cut short with multibyte (UTF-8) data

### DIFF
--- a/app/test/processing/app/SerialTest.java
+++ b/app/test/processing/app/SerialTest.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of Arduino.
+ *
+ * Copyright 2020 Arduino LLC (http://www.arduino.cc/)
+ *
+ * Arduino is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As a special exception, you may use this file as part of a free software
+ * library without restriction.  Specifically, if other files instantiate
+ * templates or use macros or inline functions from this file, or you compile
+ * this file and link it with other files to produce an executable, this
+ * file does not by itself cause the resulting executable to be covered by
+ * the GNU General Public License.  This exception does not however
+ * invalidate any other reasons why the executable file might be covered by
+ * the GNU General Public License.
+ */
+
+package processing.app;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class SerialTest {
+  class NullSerial extends Serial {
+    public NullSerial() throws SerialException {
+      super("none", 0, 'n', 0, 0, false, false);
+    }
+
+    @Override
+    protected void message(char[] chars, int length) {
+      output += new String(chars, 0, length);
+    }
+
+    String output = "";
+  }
+
+  @Test
+  public void testSerialUTF8Decoder() throws Exception {
+    NullSerial s = new NullSerial();
+    // https://github.com/arduino/Arduino/issues/9808
+    String testdata = "012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789°0123456789";
+    s.processSerialEvent(testdata.getBytes());
+    assertEquals(s.output, testdata);
+  }
+}

--- a/arduino-core/src/processing/app/Serial.java
+++ b/arduino-core/src/processing/app/Serial.java
@@ -191,8 +191,7 @@ public class Serial implements SerialPortEventListener {
     int next = 0;
     while(next < buf.length) {
       while(next < buf.length && outToMessage.hasRemaining()) {
-        int spaceInIn = inFromSerial.remaining();
-        int copyNow = buf.length - next < spaceInIn ? buf.length - next : spaceInIn;
+        int copyNow = Math.min(buf.length - next, inFromSerial.remaining());
         inFromSerial.put(buf, next, copyNow);
         next += copyNow;
         inFromSerial.flip();


### PR DESCRIPTION
This fixes #9808, detailed description in the commit messages.

This seems like a class that could use some automated testing, but I did not see any existing tests (none at all in arduino-core, only in app), nor did I find any meaningful documentation about how to run tests (I only found "ant test", which runs *all* tests and does not show a useful summary to tell if any tests failed AFAICS). Hence, no tests.