### PR TITLE
Don't restore sketch location if last.sketch.location is out of display

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -621,7 +621,12 @@ public class Base {
         .get("last.sketch" + index + ".location");
     if (locationStr == null)
       return defaultEditorLocation();
-    return PApplet.parseInt(PApplet.split(locationStr, ','));
+
+    int location[] = PApplet.parseInt(PApplet.split(locationStr, ','));
+    if (location[0] > screen.width || location[1] > screen.height)
+      return defaultEditorLocation();
+
+    return location;
   }
 
   protected void storeRecentSketches(SketchController sketch) {


### PR DESCRIPTION
`if ((screen.width != screenW) || (screen.height != screenH))` in Base.java was making sure to reset every preference in case the display geometry changed.
Unfortunately, on Windows 10, `Toolkit.getDefaultToolkit().getScreenSize()` reports only the primary monitor either if external display is connected or not.

Fixes #9781

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes
