### PR TITLE
Dynamic splash image

### DIFF
--- a/app/src/cc/arduino/view/SplashScreenHelper.java
+++ b/app/src/cc/arduino/view/SplashScreenHelper.java
@@ -33,6 +33,8 @@ package cc.arduino.view;
 
 import java.awt.*;
 import java.awt.geom.Rectangle2D;
+import java.io.IOException;
+import java.net.URL;
 import java.util.Map;
 
 import processing.app.Theme;
@@ -78,6 +80,10 @@ public class SplashScreenHelper {
     drawText(text);
 
     ensureTextIsDiplayed();
+  }
+
+  public void setImageURL(URL imageURL) throws NullPointerException, IOException, IllegalStateException {
+    splash.setImageURL(imageURL);
   }
 
   private void ensureTextIsDiplayed() {

--- a/app/src/cc/arduino/view/SplashScreenHelper.java
+++ b/app/src/cc/arduino/view/SplashScreenHelper.java
@@ -33,7 +33,6 @@ package cc.arduino.view;
 
 import java.awt.*;
 import java.awt.geom.Rectangle2D;
-import java.io.IOException;
 import java.net.URL;
 import java.util.Map;
 
@@ -82,8 +81,10 @@ public class SplashScreenHelper {
     ensureTextIsDiplayed();
   }
 
-  public void setImageURL(URL imageURL) throws NullPointerException, IOException, IllegalStateException {
-    splash.setImageURL(imageURL);
+  public void setImageURL(URL imageURL) {
+    try {
+      splash.setImageURL(imageURL);
+    } catch(Exception e) {}
   }
 
   private void ensureTextIsDiplayed() {

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -66,6 +66,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.*;
 import java.io.*;
+import java.net.URL;
 import java.util.List;
 import java.util.Timer;
 import java.util.*;
@@ -237,6 +238,10 @@ public class Base {
 
     SplashScreenHelper splash;
     if (parser.isGuiMode()) {
+      splash = new SplashScreenHelper(SplashScreen.getSplashScreen());
+      if (PreferencesData.has("update.splashImage"))
+        splash.setImageURL(new URL(PreferencesData.get("update.splashImage")));
+
       // Setup all notification widgets
       splash = new SplashScreenHelper(SplashScreen.getSplashScreen());
       BaseNoGui.notifier = new GUIUserNotifier(this);


### PR DESCRIPTION
This PR allows to display dynamic splash images according to an URL returned by the server polled for version check. Such behavior can be used to inform users about news in the Arduino world.

To trigger this feature, one more line can be added to the `https://www.arduino.cc/latest.txt` file:

```
10812
splashImage=https://www.arduino.cc/foo-bar.png
```

(This does not break version check by current versions of the IDE, as they only read the first line.)

The `splashImage` URL, if any, is stored in the application preferences and used at the next run (version check is performed _after_ the splash screen disappears).

As of now, no caching mechanism is in place: the remote image is loaded from remote at launch time. Loading is pretty quick, so users see the default image for a bit, and then it gets replaced by the new one.

I also tried to implement a click handler in order to open a URL when user clicks on the splash screen, but it seems that this is not possible with `java.awt.SplashScreen` and we would need to reimplement the splash screen as a `JPanel`.

**Note:** this is just a proof-of-concept. We might want to add signature verification. Do not merge for now :)

![Screenshot 2020-03-02 at 18 01 58](https://user-images.githubusercontent.com/594957/75704355-864b2c00-5cb9-11ea-9baf-b724ed9ad05f.png)
