### PR TITLE
Fixed user/pass preferences save for "manual" proxy settings.

### DIFF
--- a/app/src/cc/arduino/view/preferences/Preferences.java
+++ b/app/src/cc/arduino/view/preferences/Preferences.java
@@ -840,10 +840,14 @@ public class Preferences extends javax.swing.JDialog {
     PreferencesData.set(Constants.PREF_PROXY_MANUAL_TYPE, manualProxyTypeButtonGroup.getSelection().getActionCommand());
     PreferencesData.set(Constants.PREF_PROXY_MANUAL_HOSTNAME, manualProxyHostName.getText());
     PreferencesData.set(Constants.PREF_PROXY_MANUAL_PORT, manualProxyPort.getText());
-    PreferencesData.set(Constants.PREF_PROXY_MANUAL_USERNAME, manualProxyUsername.getText());
-    PreferencesData.set(Constants.PREF_PROXY_MANUAL_PASSWORD, String.valueOf(manualProxyPassword.getPassword()));
-    PreferencesData.set(Constants.PREF_PROXY_AUTO_USERNAME, autoProxyUsername.getText());
-    PreferencesData.set(Constants.PREF_PROXY_AUTO_PASSWORD, String.valueOf(autoProxyPassword.getPassword()));
+    if (PreferencesData.get(Constants.PREF_PROXY_TYPE).equals(Constants.PROXY_TYPE_MANUAL)) {
+      PreferencesData.set(Constants.PREF_PROXY_USERNAME, manualProxyUsername.getText());
+      PreferencesData.set(Constants.PREF_PROXY_PASSWORD, String.valueOf(manualProxyPassword.getPassword()));
+    }
+    if (PreferencesData.get(Constants.PREF_PROXY_TYPE).equals(Constants.PROXY_TYPE_AUTO)) {
+      PreferencesData.set(Constants.PREF_PROXY_USERNAME, autoProxyUsername.getText());
+      PreferencesData.set(Constants.PREF_PROXY_PASSWORD, String.valueOf(autoProxyPassword.getPassword()));
+    }
   }
 
   private void showPreferencesData() {
@@ -924,16 +928,16 @@ public class Preferences extends javax.swing.JDialog {
       if (!PreferencesData.get(Constants.PREF_PROXY_PAC_URL, "").isEmpty()) {
         autoProxyUsePAC.setSelected(true);
         autoProxyPACURL.setText(PreferencesData.get(Constants.PREF_PROXY_PAC_URL));
-        autoProxyUsername.setText(PreferencesData.get(Constants.PREF_PROXY_AUTO_USERNAME));
-        autoProxyPassword.setText(PreferencesData.get(Constants.PREF_PROXY_AUTO_PASSWORD));
+        autoProxyUsername.setText(PreferencesData.get(Constants.PREF_PROXY_USERNAME));
+        autoProxyPassword.setText(PreferencesData.get(Constants.PREF_PROXY_PASSWORD));
       }
     } else {
       manualProxy.setSelected(true);
       manualProxyFieldsSetEnabled(true);
       manualProxyHostName.setText(PreferencesData.get(Constants.PREF_PROXY_MANUAL_HOSTNAME));
       manualProxyPort.setText(PreferencesData.get(Constants.PREF_PROXY_MANUAL_PORT));
-      manualProxyUsername.setText(PreferencesData.get(Constants.PREF_PROXY_MANUAL_USERNAME));
-      manualProxyPassword.setText(PreferencesData.get(Constants.PREF_PROXY_MANUAL_PASSWORD));
+      manualProxyUsername.setText(PreferencesData.get(Constants.PREF_PROXY_USERNAME));
+      manualProxyPassword.setText(PreferencesData.get(Constants.PREF_PROXY_PASSWORD));
     }
 
     String selectedManualProxyType = PreferencesData.get(Constants.PREF_PROXY_MANUAL_TYPE, Constants.PROXY_MANUAL_TYPE_HTTP);

--- a/app/test/cc/arduino/net/CustomProxySelectorTest.java
+++ b/app/test/cc/arduino/net/CustomProxySelectorTest.java
@@ -83,8 +83,8 @@ public class CustomProxySelectorTest {
   public void testProxyPACHTTPWithLogin() throws Exception {
     preferences.put(Constants.PREF_PROXY_TYPE, Constants.PROXY_TYPE_AUTO);
     preferences.put(Constants.PREF_PROXY_PAC_URL, CustomProxySelectorTest.class.getResource("proxy_http.pac").toExternalForm());
-    preferences.put(Constants.PREF_PROXY_AUTO_USERNAME, "auto");
-    preferences.put(Constants.PREF_PROXY_AUTO_PASSWORD, "autopassword");
+    preferences.put(Constants.PREF_PROXY_USERNAME, "auto");
+    preferences.put(Constants.PREF_PROXY_PASSWORD, "autopassword");
     CustomProxySelector proxySelector = new CustomProxySelector(preferences);
     Proxy proxy = proxySelector.getProxyFor(uri);
 
@@ -154,8 +154,8 @@ public class CustomProxySelectorTest {
     preferences.put(Constants.PREF_PROXY_MANUAL_TYPE, Constants.PROXY_MANUAL_TYPE_HTTP);
     preferences.put(Constants.PREF_PROXY_MANUAL_HOSTNAME, "localhost");
     preferences.put(Constants.PREF_PROXY_MANUAL_PORT, "8080");
-    preferences.put(Constants.PREF_PROXY_MANUAL_USERNAME, "username");
-    preferences.put(Constants.PREF_PROXY_MANUAL_PASSWORD, "pwd");
+    preferences.put(Constants.PREF_PROXY_USERNAME, "username");
+    preferences.put(Constants.PREF_PROXY_PASSWORD, "pwd");
 
     CustomProxySelector proxySelector = new CustomProxySelector(preferences);
     Proxy proxy = proxySelector.getProxyFor(uri);

--- a/arduino-core/src/cc/arduino/Constants.java
+++ b/arduino-core/src/cc/arduino/Constants.java
@@ -58,10 +58,8 @@ public class Constants {
   public static final String PREF_PROXY_PAC_URL = "proxy.pac.url";
   public static final String PREF_PROXY_MANUAL_HOSTNAME = "proxy.manual.hostname";
   public static final String PREF_PROXY_MANUAL_PORT = "proxy.manual.port";
-  public static final String PREF_PROXY_MANUAL_USERNAME = "proxy.manual.username";
-  public static final String PREF_PROXY_MANUAL_PASSWORD = "proxy.manual.password";
-  public static final String PREF_PROXY_AUTO_USERNAME = "proxy.manual.username";
-  public static final String PREF_PROXY_AUTO_PASSWORD = "proxy.manual.password";
+  public static final String PREF_PROXY_USERNAME = "proxy.manual.username";
+  public static final String PREF_PROXY_PASSWORD = "proxy.manual.password";
 
   public static final String PACKAGE_INDEX_URL;
   public static final String LIBRARY_INDEX_URL;

--- a/arduino-core/src/cc/arduino/net/CustomProxySelector.java
+++ b/arduino-core/src/cc/arduino/net/CustomProxySelector.java
@@ -75,7 +75,7 @@ public class CustomProxySelector {
   }
 
   private Proxy pacProxy(String pac, URI uri) throws IOException, ScriptException, NoSuchMethodException {
-    setAuthenticator(preferences.get(Constants.PREF_PROXY_AUTO_USERNAME), preferences.get(Constants.PREF_PROXY_AUTO_PASSWORD));
+    setAuthenticator(preferences.get(Constants.PREF_PROXY_USERNAME), preferences.get(Constants.PREF_PROXY_PASSWORD));
 
     URLConnection urlConnection = new URL(pac).openConnection();
     urlConnection.connect();
@@ -141,7 +141,7 @@ public class CustomProxySelector {
   }
 
   private Proxy manualProxy() {
-    setAuthenticator(preferences.get(Constants.PREF_PROXY_MANUAL_USERNAME), preferences.get(Constants.PREF_PROXY_MANUAL_PASSWORD));
+    setAuthenticator(preferences.get(Constants.PREF_PROXY_USERNAME), preferences.get(Constants.PREF_PROXY_PASSWORD));
     Proxy.Type type = Proxy.Type.valueOf(preferences.get(Constants.PREF_PROXY_MANUAL_TYPE));
     return new Proxy(type, new InetSocketAddress(preferences.get(Constants.PREF_PROXY_MANUAL_HOSTNAME), Integer.valueOf(preferences.get(Constants.PREF_PROXY_MANUAL_PORT))));
   }


### PR DESCRIPTION
The network proxy user/pass in "manual" mode are not saved. This PR fixes the problem.

There was an error in the following constants:
```
  PREF_PROXY_AUTO_USERNAME = "proxy.manual.username"
  PREF_PROXY_AUTO_PASSWORD = "proxy.manual.password"
```

they should be set to "auto" and not "manual":

```
  PREF_PROXY_AUTO_USERNAME = "proxy.auto.username"
  PREF_PROXY_AUTO_PASSWORD = "proxy.auto.password"
```

BTW changing the constants to the correct value now will fix the problem for future installations of the IDE but will produce an annoying side-effect for users upgrading from previous version of the IDE: they will lose their saved user and pass (because it was saved as "proxy.manual.*") and the IDE will suddenly stop working without any clear reason.

To avoid this I've left the value to "proxy.manual.*" and removed the distinction from AUTO and MANUAL, so now we have only:

```
  PREF_PROXY_USERNAME = "proxy.manual.username"
  PREF_PROXY_PASSWORD = "proxy.manual.password"
```

The corresponding textbox in the preference dialog will be filled based on the PROXY_TYPE selection.

