### PR TITLE
Fix bogus port disconnection during serial event

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -2091,6 +2091,11 @@ public class Editor extends JFrame implements RunnerListener {
   private void resumeOrCloseSerialMonitor() {
     // Return the serial monitor window to its initial state
     if (serialMonitor != null) {
+      try {
+        Thread.sleep(200);
+      } catch (InterruptedException e) {
+          // noop
+      }
       BoardPort boardPort = BaseNoGui.getDiscoveryManager().find(PreferencesData.get("serial.port"));
       long sleptFor = 0;
       while (boardPort == null && sleptFor < MAX_TIME_AWAITING_FOR_RESUMING_SERIAL_MONITOR) {

--- a/arduino-core/src/cc/arduino/packages/BoardPort.java
+++ b/arduino-core/src/cc/arduino/packages/BoardPort.java
@@ -122,6 +122,10 @@ public class BoardPort {
     return this.address;
   }
 
+  public String toCompleteString() {
+    return this.address + "_" + this.getPrefs().get("vid") + "_" + this.getPrefs().get("pid");
+  }
+
   // Search for the board which matches identificationPrefs.
   // If found, boardName is set to the name from boards.txt
   // and the board is returned.  If not found, null is returned.

--- a/arduino-core/src/processing/app/Platform.java
+++ b/arduino-core/src/processing/app/Platform.java
@@ -202,8 +202,9 @@ public class Platform {
                 }
                 Map<String, Object> boardData = new HashMap<>();
                 boardData.put("board", board);
-                boardData.put("vid", vids.get(i));
-                boardData.put("pid", pids.get(i));
+                // remove 0x from VID / PID to keep them as reported by liblistserial
+                boardData.put("vid", vids.get(i).replaceAll("0x", ""));
+                boardData.put("pid", pids.get(i).replaceAll("0x", ""));
                 String extrafields = vid_pid_iSerial.substring(vidPid.length() + 1);
                 String[] parts = extrafields.split("_");
                 boardData.put("iserial", parts[0]);


### PR DESCRIPTION
Fixes #9785 and probably many others

This commit strongly simplifies the serial list code

Pluggable discovery introduced a bug since `BoardPort.toString()` started reporting only the name of the port, not the complete `name_vid_pid` needed to match `liblistserial` output.
Adding `.toCompleteString()` almost solves the bogus disconnection part alone, but `resolveDeviceByVendorIdProductId()` uses "0x" prefixes VID/PID, breaking it again.

In addition, all the logic used to match a board with its bootloader (to obtain a serial number on 32u4 boards) has been completely removed since it is currently useless (and unused).

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes
