### PR TITLE
Allow config changes and clear in disabled serial monitor and plotter

### DIFF
--- a/app/src/processing/app/AbstractTextMonitor.java
+++ b/app/src/processing/app/AbstractTextMonitor.java
@@ -190,14 +190,9 @@ public abstract class AbstractTextMonitor extends AbstractMonitor {
       textArea.setBackground(new Color(238, 238, 238));
     }
     textArea.invalidate();
-    clearButton.setEnabled(enable);
     scrollPane.setEnabled(enable);
     textField.setEnabled(enable);
     sendButton.setEnabled(enable);
-    autoscrollBox.setEnabled(enable);
-    addTimeStampBox.setEnabled(enable);
-    lineEndings.setEnabled(enable);
-    serialRates.setEnabled(enable);
   }
 
   public void onSendCommand(ActionListener listener) {

--- a/app/src/processing/app/SerialMonitor.java
+++ b/app/src/processing/app/SerialMonitor.java
@@ -48,14 +48,16 @@ public class SerialMonitor extends AbstractTextMonitor {
       String rateString = wholeString.substring(0, wholeString.indexOf(' '));
       serialRate = Integer.parseInt(rateString);
       PreferencesData.set("serial.debug_rate", rateString);
-      try {
-        close();
-        Thread.sleep(100); // Wait for serial port to properly close
-        open();
-      } catch (InterruptedException e) {
-        // noop
-      } catch (Exception e) {
-        System.err.println(e);
+      if (serial != null) {
+        try {
+          close();
+          Thread.sleep(100); // Wait for serial port to properly close
+          open();
+        } catch (InterruptedException e) {
+          // noop
+        } catch (Exception e) {
+          System.err.println(e);
+        }
       }
     });
 

--- a/app/src/processing/app/SerialPlotter.java
+++ b/app/src/processing/app/SerialPlotter.java
@@ -242,12 +242,14 @@ public class SerialPlotter extends AbstractMonitor {
       String rateString = wholeString.substring(0, wholeString.indexOf(' '));
       serialRate = Integer.parseInt(rateString);
       PreferencesData.set("serial.debug_rate", rateString);
-      try {
-        close();
-        Thread.sleep(100); // Wait for serial port to properly close
-        open();
-      } catch (Exception e) {
-        // ignore
+      if (serial != null) {
+        try {
+          close();
+          Thread.sleep(100); // Wait for serial port to properly close
+          open();
+        } catch (Exception e) {
+          // ignore
+        }
       }
     });
 
@@ -379,10 +381,8 @@ public class SerialPlotter extends AbstractMonitor {
   }
 
   protected void onEnableWindow(boolean enable) {
-    serialRates.setEnabled(enable);
     textField.setEnabled(enable);
     sendButton.setEnabled(enable);
-    lineEndings.setEnabled(enable);
   }
 
   private void onSerialRateChange(ActionListener listener) {


### PR DESCRIPTION
When the serial device disconnects, the serial monitor and plotter are
disabled. Previously, the window would be completely disabled. Now, the
configuration controls (autoscroll, add timestamp, baudrate, line
endings) can still be changed while the window is disconnected. These
settings will not take effect immediately, but will be used when the
port is next opened.

Also, the clear output button can now also be used when the port is
disconnected, which makes it easy to get a clean start when reconnecting
the serial port.