### PR TITLE
Set foreground color on board/library titles in managers

### DIFF
--- a/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryTableCellJPanel.java
+++ b/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryTableCellJPanel.java
@@ -34,12 +34,18 @@ public class ContributedLibraryTableCellJPanel extends JPanel {
   final JPanel inactiveButtonsPanel;
   final JLabel statusLabel;
   final JTextPane description;
+  final TitledBorder titledBorder;
   private final String moreInfoLbl = tr("More info");
 
   public ContributedLibraryTableCellJPanel(JTable parentTable, Object value,
                                            boolean isSelected) {
     super();
     setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+
+    // Actual title set below
+    titledBorder = BorderFactory.createTitledBorder("");
+    titledBorder.setTitleFont(getFont().deriveFont(Font.BOLD));
+    setBorder(titledBorder);
 
     moreInfoButton = new JButton(moreInfoLbl);
     moreInfoButton.setVisible(false);
@@ -120,9 +126,7 @@ public class ContributedLibraryTableCellJPanel extends JPanel {
       return;
 
     ContributedLibrary selected = releases.getSelected();
-    TitledBorder titledBorder = BorderFactory.createTitledBorder(selected.getName());
-    titledBorder.setTitleFont(getFont().deriveFont(Font.BOLD));
-    setBorder(titledBorder);
+    titledBorder.setTitle(selected.getName());
     Optional<ContributedLibrary> mayInstalled = releases.getInstalled();
 
     boolean installable, upgradable;
@@ -271,5 +275,7 @@ public class ContributedLibraryTableCellJPanel extends JPanel {
     // The description is not opaque, so copy our foreground color to it.
     if (description != null)
       description.setForeground(c);
+    if (titledBorder != null)
+      titledBorder.setTitleColor(c);
   }
 }

--- a/app/src/cc/arduino/contributions/packages/ui/ContributedPlatformTableCellJPanel.java
+++ b/app/src/cc/arduino/contributions/packages/ui/ContributedPlatformTableCellJPanel.java
@@ -67,12 +67,18 @@ public class ContributedPlatformTableCellJPanel extends JPanel {
   final JPanel inactiveButtonsPanel;
   final JLabel statusLabel;
   final JTextPane description;
+  final TitledBorder titledBorder;
   private final String moreInfoLbl = tr("More Info");
   private final String onlineHelpLbl = tr("Online Help");
 
   public ContributedPlatformTableCellJPanel() {
     super();
     setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+
+    // Actual title set by update()
+    titledBorder = BorderFactory.createTitledBorder("");
+    titledBorder.setTitleFont(getFont().deriveFont(Font.BOLD));
+    setBorder(titledBorder);
 
     {
       installButton = new JButton(tr("Install"));
@@ -186,9 +192,7 @@ public class ContributedPlatformTableCellJPanel extends JPanel {
     }
 
     ContributedPlatform selected = releases.getSelected();
-    TitledBorder titledBorder = BorderFactory.createTitledBorder(selected.getName());
-    titledBorder.setTitleFont(getFont().deriveFont(Font.BOLD));
-    setBorder(titledBorder);
+    titledBorder.setTitle(selected.getName());
     ContributedPlatform installed = releases.getInstalled();
 
     boolean removable, installable, upgradable;
@@ -311,5 +315,7 @@ public class ContributedPlatformTableCellJPanel extends JPanel {
     // The description is not opaque, so copy our foreground color to it.
     if (description != null)
       description.setForeground(c);
+    if (titledBorder != null)
+      titledBorder.setTitleColor(c);
   }
 }


### PR DESCRIPTION
In commit 93581b03d (Set foreground color in library/board manager), the
foreground color was set in addition to the background color, to make
sure that the library and board manager would remain readable even with
a non-standard color scheme (e.g. a dark theme).

When that commit was created, this worked properly. However, between
creating that commit and merging it as part of #9272, the title
rendering was changed from being part of the description (which had its
color set up properly) to being part of the title border (which used
default colors) in #9262.

This commit fixes this again by applying the foreground color also to
the TitledBorder component.

In ContributedPlatformTableCellJPanel this also moves the creation of
the TitledBorder into the constructor, and for
ContributedLibraryTableCellJPanel upwards in the constructor (where it
is run unconditionally), so the property can be final.

Before:

![image](https://user-images.githubusercontent.com/194491/76681417-c7650980-65f2-11ea-9ef4-221869452682.png)

After:

![image](https://user-images.githubusercontent.com/194491/76681571-b4533900-65f4-11ea-82dc-e3f6f16d865c.png)
