### PR TITLE
Only show programmers for current board

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1540,6 +1540,7 @@ public class Base {
         onBoardOrPortChange();
         rebuildImportMenu(Editor.importMenu);
         rebuildExamplesMenu(Editor.examplesMenu);
+        rebuildProgrammerMenu();
       }
     };
     action.putValue("b", board);
@@ -1670,28 +1671,40 @@ public class Base {
 
   public void rebuildProgrammerMenu() {
     programmerMenus = new LinkedList<>();
-
     ButtonGroup group = new ButtonGroup();
-    for (TargetPackage targetPackage : BaseNoGui.packages.values()) {
-      for (TargetPlatform targetPlatform : targetPackage.platforms()) {
-        for (String programmer : targetPlatform.getProgrammers().keySet()) {
-          String id = targetPackage.getId() + ":" + programmer;
 
-          @SuppressWarnings("serial")
-          AbstractAction action = new AbstractAction(targetPlatform.getProgrammer(programmer).get("name")) {
-            public void actionPerformed(ActionEvent actionevent) {
-              PreferencesData.set("programmer", "" + getValue("id"));
-            }
-          };
-          action.putValue("id", id);
-          JMenuItem item = new JRadioButtonMenuItem(action);
-          if (PreferencesData.get("programmer").equals(id)) {
-            item.setSelected(true);
-          }
-          group.add(item);
-          programmerMenus.add(item);
+    TargetBoard board = BaseNoGui.getTargetBoard();
+    TargetPlatform boardPlatform = board.getContainerPlatform();
+    TargetPlatform corePlatform = null;
+
+    String core = board.getPreferences().get("build.core");
+    if (core.contains(":")) {
+      String[] split = core.split(":", 2);
+      corePlatform = BaseNoGui.getCurrentTargetPlatformFromPackage(split[0]);
+    }
+
+    addProgrammersForPlatform(boardPlatform, programmerMenus, group);
+    if (corePlatform != null)
+      addProgrammersForPlatform(corePlatform, programmerMenus, group);
+  }
+
+  public void addProgrammersForPlatform(TargetPlatform platform, List<JMenuItem> menus, ButtonGroup group) {
+    for (String programmer : platform.getProgrammers().keySet()) {
+      String id = platform.getContainerPackage().getId() + ":" + programmer;
+
+      @SuppressWarnings("serial")
+      AbstractAction action = new AbstractAction(platform.getProgrammer(programmer).get("name")) {
+        public void actionPerformed(ActionEvent actionevent) {
+          PreferencesData.set("programmer", "" + getValue("id"));
         }
+      };
+      action.putValue("id", id);
+      JMenuItem item = new JRadioButtonMenuItem(action);
+      if (PreferencesData.get("programmer").equals(id)) {
+        item.setSelected(true);
       }
+      group.add(item);
+      menus.add(item);
     }
   }
 


### PR DESCRIPTION
Previously, the programmers menu always showed *all* programmers of
*all* platforms. This made it hard to find the programmer you need.

When selecting a programmer from another platform, it would typically
not work, since the tool definitions rely on specific variables to be
defined by the board, or files available in the variant directory, which
are typically platform-dependent. Also, some programmers might be
defined in multiple platforms, but there is currently no way to tell
which one is for the current platform an will work, and which is for
another platform and will break.

This commit changes the programmer menu to only show programmers from
the platforms that define the board and the core used. The latter is
only used when boar definition refers a core in another platform, in
which case the core and variant already have a strong coupling (the
variant must offer the right variables for the core to work), so that
would also apply to the programmer, so programmers from the referenced
core's platform can be expected to work.

When a board is selected, the menu of available programmers is
refreshed, but the currently selected programmer preference is
untouched. This might mean that a programmer is selected that is invalid
for the current board and will not actually work. This could be fixed by
clearing the current programmer when it becomes invalid, but that would
mean that changing to another platform and back would always require
reselecting the programmer to use, which seems counter-productive. An
alternative fix would be to check the programmer against the board and
throw an error, but that would require duplicating some code, which did
not seem worthwile (ideally, all this code will be moved to arduino-cli
anyway in the future).

This fixes #9373.