### PR TITLE
Never leave programmers menu empty

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1696,6 +1696,12 @@ public class Base {
     addProgrammersForPlatform(boardPlatform, programmerMenus, group);
     if (corePlatform != null)
       addProgrammersForPlatform(corePlatform, programmerMenus, group);
+
+    if (programmerMenus.isEmpty()) {
+      JMenuItem item = new JMenuItem(tr("No programmers available for this board"));
+      item.setEnabled(false);
+      programmerMenus.add(item);
+    }
   }
 
   public void addProgrammersForPlatform(TargetPlatform platform, List<JMenuItem> menus, ButtonGroup group) {


### PR DESCRIPTION
This is a followup for PR #9900 that was just merged.

When there are no programmers available for the current board, the
programmers menu would remain empty, which would prevent it from
unfolding and could make users think there was something wrong with the
menu.

Now, a disabled item with a message is added if no programmers are
available, which should make it more clear what is going on.


I also think that a similar approach might be useful for the Ports menu (now every now and then users think there is something broken when the ports menu is grayed out), but I noticed that there is some serial port selection popup code (never knew that existed, hm) that checks for empty-ness of the menu, so that needs a bit more though (and I have no time for that right now).