### PR TITLE
GSOC2020: Ctrl-shift-U does not work work when editor is focused #9895

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -169,6 +169,9 @@ public class Editor extends JFrame implements RunnerListener {
   /** Command-Option on Mac OS X, Ctrl-Alt on Windows and Linux */
   static final int SHORTCUT_ALT_KEY_MASK = ActionEvent.ALT_MASK |
     Toolkit.getDefaultToolkit().getMenuShortcutKeyMask();
+  /** Command-Option on Mac OS X, Ctrl-Shift on Windows and Linux */
+  static final int SHORTCUT_SHIFT_KEY_MASK = ActionEvent.SHIFT_MASK |
+    Toolkit.getDefaultToolkit().getMenuShortcutKeyMask();
 
   /**
    * true if this file has not yet been given a name by the user
@@ -670,9 +673,22 @@ public class Editor extends JFrame implements RunnerListener {
     item.addActionListener(event -> handleExport(false));
     sketchMenu.add(item);
 
-    item = newJMenuItemShift(tr("Upload Using Programmer"), 'U');
-    item.addActionListener(event -> handleExport(true));
-    sketchMenu.add(item);
+    // Since CTRL+SHIFT+U is not working on iBus keyboard input method
+    // Lets redirect the shorcut for Linux to CTRL+ALT+U
+    // Leaving the preexisting behaviour for Windows & Mac OS
+    String OS = System.getProperty("os.name").toLowerCase();
+    if (OS.indexOf("nix") >= 0 || OS.indexOf("nux") >= 0 || OS.indexOf("aix") > 0)
+    {
+      item = newJMenuItemAlt(tr("Upload Using Programmer"), 'U');
+      item.addActionListener(event -> handleExport(true));
+      sketchMenu.add(item);
+    }
+    else
+    {
+      item = newJMenuItemShift(tr("Upload Using Programmer"), 'U');
+      item.addActionListener(event -> handleExport(true));
+      sketchMenu.add(item);
+    }
 
     item = newJMenuItemAlt(tr("Export compiled Binary"), 'S');
     item.addActionListener(event -> {
@@ -1350,7 +1366,7 @@ public class Editor extends JFrame implements RunnerListener {
   // Control + Shift + K seems to not be working on linux (Xubuntu 17.04, 2017-08-19)
   static public JMenuItem newJMenuItemShift(String title, int what) {
     JMenuItem menuItem = new JMenuItem(title);
-    menuItem.setAccelerator(KeyStroke.getKeyStroke(what, SHORTCUT_KEY_MASK | ActionEvent.SHIFT_MASK));
+    menuItem.setAccelerator(KeyStroke.getKeyStroke(what, SHORTCUT_SHIFT_KEY_MASK));
     return menuItem;
   }
 

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -677,18 +677,14 @@ public class Editor extends JFrame implements RunnerListener {
     // Lets redirect the shorcut for Linux to CTRL+ALT+U
     // Leaving the preexisting behaviour for Windows & Mac OS
     String OS = System.getProperty("os.name").toLowerCase();
-    if (OS.indexOf("nix") >= 0 || OS.indexOf("nux") >= 0 || OS.indexOf("aix") > 0)
+    if (OS.indexOf("nix") >= 0 || OS.indexOf("nux") >= 0 || OS.indexOf("aix") >= 0)
     {
       item = newJMenuItemAlt(tr("Upload Using Programmer"), 'U');
-      item.addActionListener(event -> handleExport(true));
-      sketchMenu.add(item);
-    }
-    else
-    {
+    } else {
       item = newJMenuItemShift(tr("Upload Using Programmer"), 'U');
-      item.addActionListener(event -> handleExport(true));
-      sketchMenu.add(item);
     }
+    item.addActionListener(event -> handleExport(true));
+    sketchMenu.add(item);
 
     item = newJMenuItemAlt(tr("Export compiled Binary"), 'S');
     item.addActionListener(event -> {

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -169,9 +169,6 @@ public class Editor extends JFrame implements RunnerListener {
   /** Command-Option on Mac OS X, Ctrl-Alt on Windows and Linux */
   static final int SHORTCUT_ALT_KEY_MASK = ActionEvent.ALT_MASK |
     Toolkit.getDefaultToolkit().getMenuShortcutKeyMask();
-  /** Command-Option on Mac OS X, Ctrl-Shift on Windows and Linux */
-  static final int SHORTCUT_SHIFT_KEY_MASK = ActionEvent.SHIFT_MASK |
-    Toolkit.getDefaultToolkit().getMenuShortcutKeyMask();
 
   /**
    * true if this file has not yet been given a name by the user
@@ -677,8 +674,7 @@ public class Editor extends JFrame implements RunnerListener {
     // Lets redirect the shorcut for Linux to CTRL+ALT+U
     // Leaving the preexisting behaviour for Windows & Mac OS
     String OS = System.getProperty("os.name").toLowerCase();
-    if (OS.indexOf("nix") >= 0 || OS.indexOf("nux") >= 0 || OS.indexOf("aix") >= 0)
-    {
+    if (OS.indexOf("nix") >= 0 || OS.indexOf("nux") >= 0 || OS.indexOf("aix") >= 0)    {
       item = newJMenuItemAlt(tr("Upload Using Programmer"), 'U');
     } else {
       item = newJMenuItemShift(tr("Upload Using Programmer"), 'U');
@@ -1362,7 +1358,7 @@ public class Editor extends JFrame implements RunnerListener {
   // Control + Shift + K seems to not be working on linux (Xubuntu 17.04, 2017-08-19)
   static public JMenuItem newJMenuItemShift(String title, int what) {
     JMenuItem menuItem = new JMenuItem(title);
-    menuItem.setAccelerator(KeyStroke.getKeyStroke(what, SHORTCUT_SHIFT_KEY_MASK));
+    menuItem.setAccelerator(KeyStroke.getKeyStroke(what, SHORTCUT_KEY_MASK | ActionEvent.SHIFT_MASK));
     return menuItem;
   }
 


### PR DESCRIPTION
**GSOC2020: Ctrl-shift-U does not work work when editor is focused #9895**

1. I have tested the changes on Windows, Linux & Mac
2. I was following the existing style of the code. I noticed that SHORTCUT_SHIFT_KEY_MASK was missing and replaced with identical logic on line 1353. Therefore, I decided to create the variable.
3. According to [1] iBus is not supporting CTRL+SHIFT+U. Modified to use CTRL+ALT+U for Linux. 
    a) No users were affected on Windows and Mac OS, because preexisting behaviour is the same for Windows and Mac OS.
    b) Users with Linux XIM/None settings are affected, because the hotkeys were changed.
4. Tested with XIM/None CTRL+SHIFT+U was working fine.
5. Tested with iBus/XIM/None CTRL+ALT+U is working on Linux.

[1] https://superuser.com/questions/358749/how-to-disable-ctrlshiftu-in-ubuntu-linux