### PR TITLE
GSOC 2020: [Preferences] Button problem in Preferences #9185

### DIFF
--- a/app/src/cc/arduino/view/preferences/Preferences.java
+++ b/app/src/cc/arduino/view/preferences/Preferences.java
@@ -218,6 +218,7 @@ public class Preferences extends javax.swing.JDialog {
     additionalBoardsManagerField.setToolTipText(tr("Enter a comma separated list of urls"));
 
     extendedAdditionalUrlFieldWindow.setIcon(new ImageIcon(Theme.getThemeImage("newwindow", this, Theme.scale(16), Theme.scale(14))));
+    extendedAdditionalUrlFieldWindow.setToolTipText(tr("Enter additional URLs, one for each row"));
     extendedAdditionalUrlFieldWindow.setMargin(new java.awt.Insets(1, 1, 1, 1));
     extendedAdditionalUrlFieldWindow.addActionListener(new java.awt.event.ActionListener() {
       public void actionPerformed(java.awt.event.ActionEvent evt) {

--- a/app/src/cc/arduino/view/preferences/Preferences.java
+++ b/app/src/cc/arduino/view/preferences/Preferences.java
@@ -218,7 +218,6 @@ public class Preferences extends javax.swing.JDialog {
     additionalBoardsManagerField.setToolTipText(tr("Enter a comma separated list of urls"));
 
     extendedAdditionalUrlFieldWindow.setIcon(new ImageIcon(Theme.getThemeImage("newwindow", this, Theme.scale(16), Theme.scale(14))));
-    extendedAdditionalUrlFieldWindow.setToolTipText(tr("Enter additional URLs, one for each row"));
     extendedAdditionalUrlFieldWindow.setMargin(new java.awt.Insets(1, 1, 1, 1));
     extendedAdditionalUrlFieldWindow.addActionListener(new java.awt.event.ActionListener() {
       public void actionPerformed(java.awt.event.ActionEvent evt) {

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -169,6 +169,9 @@ public class Editor extends JFrame implements RunnerListener {
   /** Command-Option on Mac OS X, Ctrl-Alt on Windows and Linux */
   static final int SHORTCUT_ALT_KEY_MASK = ActionEvent.ALT_MASK |
     Toolkit.getDefaultToolkit().getMenuShortcutKeyMask();
+  /** Command-Option on Mac OS X, Ctrl-Shift on Windows and Linux */
+  static final int SHORTCUT_SHIFT_KEY_MASK = ActionEvent.SHIFT_MASK |
+    Toolkit.getDefaultToolkit().getMenuShortcutKeyMask();
 
   /**
    * true if this file has not yet been given a name by the user
@@ -670,9 +673,22 @@ public class Editor extends JFrame implements RunnerListener {
     item.addActionListener(event -> handleExport(false));
     sketchMenu.add(item);
 
-    item = newJMenuItemShift(tr("Upload Using Programmer"), 'U');
-    item.addActionListener(event -> handleExport(true));
-    sketchMenu.add(item);
+    // Since CTRL+SHIFT+U is not working on iBus keyboard input method
+    // Lets redirect the shorcut for Linux to CTRL+ALT+U
+    // Leaving the preexisting behaviour for Windows & Mac OS
+    String OS = System.getProperty("os.name").toLowerCase();
+    if (OS.indexOf("nix") >= 0 || OS.indexOf("nux") >= 0 || OS.indexOf("aix") > 0)
+    {
+      item = newJMenuItemAlt(tr("Upload Using Programmer"), 'U');
+      item.addActionListener(event -> handleExport(true));
+      sketchMenu.add(item);
+    }
+    else
+    {
+      item = newJMenuItemShift(tr("Upload Using Programmer"), 'U');
+      item.addActionListener(event -> handleExport(true));
+      sketchMenu.add(item);
+    }
 
     item = newJMenuItemAlt(tr("Export compiled Binary"), 'S');
     item.addActionListener(event -> {
@@ -1350,7 +1366,7 @@ public class Editor extends JFrame implements RunnerListener {
   // Control + Shift + K seems to not be working on linux (Xubuntu 17.04, 2017-08-19)
   static public JMenuItem newJMenuItemShift(String title, int what) {
     JMenuItem menuItem = new JMenuItem(title);
-    menuItem.setAccelerator(KeyStroke.getKeyStroke(what, SHORTCUT_KEY_MASK | ActionEvent.SHIFT_MASK));
+    menuItem.setAccelerator(KeyStroke.getKeyStroke(what, SHORTCUT_SHIFT_KEY_MASK));
     return menuItem;
   }
 

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -169,9 +169,6 @@ public class Editor extends JFrame implements RunnerListener {
   /** Command-Option on Mac OS X, Ctrl-Alt on Windows and Linux */
   static final int SHORTCUT_ALT_KEY_MASK = ActionEvent.ALT_MASK |
     Toolkit.getDefaultToolkit().getMenuShortcutKeyMask();
-  /** Command-Option on Mac OS X, Ctrl-Shift on Windows and Linux */
-  static final int SHORTCUT_SHIFT_KEY_MASK = ActionEvent.SHIFT_MASK |
-    Toolkit.getDefaultToolkit().getMenuShortcutKeyMask();
 
   /**
    * true if this file has not yet been given a name by the user
@@ -673,22 +670,9 @@ public class Editor extends JFrame implements RunnerListener {
     item.addActionListener(event -> handleExport(false));
     sketchMenu.add(item);
 
-    // Since CTRL+SHIFT+U is not working on iBus keyboard input method
-    // Lets redirect the shorcut for Linux to CTRL+ALT+U
-    // Leaving the preexisting behaviour for Windows & Mac OS
-    String OS = System.getProperty("os.name").toLowerCase();
-    if (OS.indexOf("nix") >= 0 || OS.indexOf("nux") >= 0 || OS.indexOf("aix") > 0)
-    {
-      item = newJMenuItemAlt(tr("Upload Using Programmer"), 'U');
-      item.addActionListener(event -> handleExport(true));
-      sketchMenu.add(item);
-    }
-    else
-    {
-      item = newJMenuItemShift(tr("Upload Using Programmer"), 'U');
-      item.addActionListener(event -> handleExport(true));
-      sketchMenu.add(item);
-    }
+    item = newJMenuItemShift(tr("Upload Using Programmer"), 'U');
+    item.addActionListener(event -> handleExport(true));
+    sketchMenu.add(item);
 
     item = newJMenuItemAlt(tr("Export compiled Binary"), 'S');
     item.addActionListener(event -> {
@@ -1366,7 +1350,7 @@ public class Editor extends JFrame implements RunnerListener {
   // Control + Shift + K seems to not be working on linux (Xubuntu 17.04, 2017-08-19)
   static public JMenuItem newJMenuItemShift(String title, int what) {
     JMenuItem menuItem = new JMenuItem(title);
-    menuItem.setAccelerator(KeyStroke.getKeyStroke(what, SHORTCUT_SHIFT_KEY_MASK));
+    menuItem.setAccelerator(KeyStroke.getKeyStroke(what, SHORTCUT_KEY_MASK | ActionEvent.SHIFT_MASK));
     return menuItem;
   }
 


### PR DESCRIPTION
**[Preferences] Button problem in Preferences #9185**

1) The following fix adds a tool-tip to the "new Window" button in preferences.
The tool tip uses an existing sentence, which explains what the new pop-up window is used for.

It is less descriptive, but it requires no changes in reference files => no translation needed

I will create another pull request with more descriptive pop-up, but which will require translation to be done.

Tested on Linux & Windows