### PR TITLE
GSOC 2020: [Preferences] Button problem in Preferences #9185 requires translation

### DIFF
--- a/app/src/cc/arduino/view/preferences/Preferences.form
+++ b/app/src/cc/arduino/view/preferences/Preferences.form
@@ -346,7 +346,7 @@
                       <Connection code="tr(&quot;Additional Boards Manager URLs: &quot;)" type="code"/>
                     </Property>
                     <Property name="toolTipText" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                      <Connection code="tr(&quot;Enter a comma separated list of urls&quot;)" type="code"/>
+                      <Connection code="tr(&quot;Enter a comma separated list of urls or use a pop-up window on the right&quot;)" type="code"/>
                     </Property>
                   </Properties>
                   <AuxValues>
@@ -357,7 +357,7 @@
                 <Component class="javax.swing.JTextField" name="additionalBoardsManagerField">
                   <Properties>
                     <Property name="toolTipText" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                      <Connection code="tr(&quot;Enter a comma separated list of urls&quot;)" type="code"/>
+                      <Connection code="tr(&quot;Enter a comma separated list of urls or use a pop-up window on the right&quot;)" type="code"/>
                     </Property>
                   </Properties>
                 </Component>

--- a/app/src/cc/arduino/view/preferences/Preferences.java
+++ b/app/src/cc/arduino/view/preferences/Preferences.java
@@ -212,12 +212,13 @@ public class Preferences extends javax.swing.JDialog {
     comboWarningsLabel.setLabelFor(comboWarnings);
 
     additionalBoardsManagerLabel.setText(tr("Additional Boards Manager URLs: "));
-    additionalBoardsManagerLabel.setToolTipText(tr("Enter a comma separated list of urls"));
+    additionalBoardsManagerLabel.setToolTipText(tr("Enter a comma separated list of urls or use a pop-up window on the right"));
     additionalBoardsManagerLabel.setLabelFor(additionalBoardsManagerField);
 
-    additionalBoardsManagerField.setToolTipText(tr("Enter a comma separated list of urls"));
+    additionalBoardsManagerField.setToolTipText(tr("Enter a comma separated list of urls or use a pop-up window on the right"));
 
     extendedAdditionalUrlFieldWindow.setIcon(new ImageIcon(Theme.getThemeImage("newwindow", this, Theme.scale(16), Theme.scale(14))));
+    extendedAdditionalUrlFieldWindow.setToolTipText(tr("Opens a window to enter additional URLs, one for each row"));
     extendedAdditionalUrlFieldWindow.setMargin(new java.awt.Insets(1, 1, 1, 1));
     extendedAdditionalUrlFieldWindow.addActionListener(new java.awt.event.ActionListener() {
       public void actionPerformed(java.awt.event.ActionEvent evt) {


### PR DESCRIPTION
**[Preferences] Button problem in Preferences #9185 requires translation**

This pull request is more descriptive than #9945, but it requires translation in resource files.
Not sure about necessary workflows.
Tested Windows, Linux. 

Tool Tip still pops up for different languages, but on English. I can help with Russian/Ukrainian if needed.