### PR TITLE
Serial Plotter Plotting Bug #9946

### DIFF
--- a/app/src/processing/app/SerialPlotter.java
+++ b/app/src/processing/app/SerialPlotter.java
@@ -406,7 +406,7 @@ public class SerialPlotter extends AbstractMonitor {
         continue;
       }
 	
-	  if(line.equals("<CLEAR>"){
+	  if(line.equals("<CLEAR>")){
 			graphs.clear();//clear the graphs points in the array
 			xCount = 0;//reset the count of data point
 	  }

--- a/app/src/processing/app/SerialPlotter.java
+++ b/app/src/processing/app/SerialPlotter.java
@@ -406,7 +406,7 @@ public class SerialPlotter extends AbstractMonitor {
         continue;
       }
 	
-	  if(line.equals("<CLEAR>")){
+	  if("<CLEAR>".equals(line)){
 			graphs.clear();//clear the graphs points in the array
 			xCount = 0;//reset the count of data point
 	  }

--- a/app/src/processing/app/SerialPlotter.java
+++ b/app/src/processing/app/SerialPlotter.java
@@ -405,6 +405,12 @@ public class SerialPlotter extends AbstractMonitor {
         // the line only contained trimmable characters
         continue;
       }
+	
+	  if(line.equals("<CLEAR>"){
+			graphs.clear();//clear the graphs points in the array
+			xCount = 0;//reset the count of data point
+	  }
+
       String[] parts = line.split("[, \t]+");
       if(parts.length == 0) {
         continue;


### PR DESCRIPTION
Changes tested on Linux and Windows.
Introduced  <CLEAR> as a command to delete all current graph points in and reset data count to 0, in order to try and solve bug [#9946](https://github.com/arduino/Arduino/issues/9946). No other changes to program were made. Linux and Windows users shouldn't be affected by this change. I have no guarantee this command solves the problem mentioned as I can't reproduce the conditions.