### PR TITLE
Handle CR without NL printed in EditorConsole

### DIFF
--- a/app/src/processing/app/EditorConsole.java
+++ b/app/src/processing/app/EditorConsole.java
@@ -186,7 +186,7 @@ public class EditorConsole extends JScrollPane {
   }
 
   public String getText() {
-    return consoleTextPane.getText().trim();
+    return consoleTextPane.getText();
   }
 
 }

--- a/app/src/processing/app/EditorConsole.java
+++ b/app/src/processing/app/EditorConsole.java
@@ -38,19 +38,15 @@ public class EditorConsole extends JScrollPane {
   private static ConsoleOutputStream out;
   private static ConsoleOutputStream err;
 
-  private static synchronized void init(SimpleAttributeSet outStyle, PrintStream outStream, SimpleAttributeSet errStyle, PrintStream errStream) {
-    if (out != null) {
-      return;
+  public static synchronized void setCurrentEditorConsole(EditorConsole console) {
+    if (out == null) {
+      out = new ConsoleOutputStream(console.stdOutStyle, System.out);
+      System.setOut(new PrintStream(out, true));
+
+      err = new ConsoleOutputStream(console.stdErrStyle, System.err);
+      System.setErr(new PrintStream(err, true));
     }
 
-    out = new ConsoleOutputStream(outStyle, outStream);
-    System.setOut(new PrintStream(out, true));
-
-    err = new ConsoleOutputStream(errStyle, errStream);
-    System.setErr(new PrintStream(err, true));
-  }
-
-  public static void setCurrentEditorConsole(EditorConsole console) {
     out.setCurrentEditorConsole(console);
     err.setCurrentEditorConsole(console);
   }
@@ -109,8 +105,6 @@ public class EditorConsole extends JScrollPane {
     setPreferredSize(new Dimension(100, (height * lines)));
     setMinimumSize(new Dimension(100, (height * lines)));
 
-    EditorConsole.init(stdOutStyle, System.out, stdErrStyle, System.err);
-
     // Add font size adjustment listeners.
     if (base != null)
       base.addEditorFontResizeListeners(consoleTextPane);
@@ -131,8 +125,10 @@ public class EditorConsole extends JScrollPane {
     // Re-insert console text with the new preferences if there were changes.
     // This assumes that the document has single-child paragraphs (default).
     if (!stdOutStyle.isEqual(stdOutStyleOld) || !stdErrStyle.isEqual(stdOutStyleOld)) {
-      out.setAttibutes(stdOutStyle);
-      err.setAttibutes(stdErrStyle);
+      if (out != null)
+        out.setAttibutes(stdOutStyle);
+      if (err != null)
+        err.setAttibutes(stdErrStyle);
 
       int start;
       for (int end = document.getLength() - 1; end >= 0; end = start - 1) {

--- a/app/src/processing/app/EditorConsole.java
+++ b/app/src/processing/app/EditorConsole.java
@@ -39,8 +39,11 @@ public class EditorConsole extends JScrollPane {
 
   private static ConsoleOutputStream out;
   private static ConsoleOutputStream err;
-  private static int startOfLine = 0;
-  private static int insertPosition = 0;
+  private int startOfLine = 0;
+  private int insertPosition = 0;
+
+  // Regex for linesplitting, see insertString for comments.
+  private static final Pattern newLinePattern = Pattern.compile("([^\r\n]*)([\r\n]*\n)?(\r+)?");
 
   public static synchronized void setCurrentEditorConsole(EditorConsole console) {
     if (out == null) {
@@ -186,17 +189,18 @@ public class EditorConsole extends JScrollPane {
     // Separate the string into content, newlines and lone carriage
     // returns.
     //
-    // Doing so allows lone CRs to return the insertPosition to the
+    // Doing so allows lone CRs to move the insertPosition back to the
     // start of the line to allow overwriting the most recent line (e.g.
     // for a progress bar). Any CR or NL that are immediately followed
     // by another NL are bunched together for efficiency, since these
     // can just be inserted into the document directly and still be
     // correct.
     //
-    // This regex is written so it will necessarily match any string
+    // The regex is written so it will necessarily match any string
     // completely if applied repeatedly. This is important because any
     // part not matched would be silently dropped.
-    Matcher m = Pattern.compile("([^\r\n]*)([\r\n]*\n)?(\r+)?").matcher(str);
+    Matcher m = newLinePattern.matcher(str);
+
     while (m.find()) {
       String content = m.group(1);
       String newlines = m.group(2);

--- a/app/src/processing/app/EditorConsole.java
+++ b/app/src/processing/app/EditorConsole.java
@@ -112,7 +112,8 @@ public class EditorConsole extends JScrollPane {
     EditorConsole.init(stdOutStyle, System.out, stdErrStyle, System.err);
 
     // Add font size adjustment listeners.
-    base.addEditorFontResizeListeners(consoleTextPane);
+    if (base != null)
+      base.addEditorFontResizeListeners(consoleTextPane);
   }
 
   public void applyPreferences() {

--- a/app/test/processing/app/EditorConsoleTest.java
+++ b/app/test/processing/app/EditorConsoleTest.java
@@ -1,0 +1,155 @@
+/*
+ * This file is part of Arduino.
+ *
+ * Copyright 2020 Arduino LLC (http://www.arduino.cc/)
+ *
+ * Arduino is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As a special exception, you may use this file as part of a free software
+ * library without restriction.  Specifically, if other files instantiate
+ * templates or use macros or inline functions from this file, or you compile
+ * this file and link it with other files to produce an executable, this
+ * file does not by itself cause the resulting executable to be covered by
+ * the GNU General Public License.  This exception does not however
+ * invalidate any other reasons why the executable file might be covered by
+ * the GNU General Public License.
+ */
+
+package processing.app;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class EditorConsoleTest extends AbstractWithPreferencesTest {
+  private EditorConsole console;
+
+  @Before
+  public void createConsole() {
+    console = new EditorConsole(null);
+  }
+
+  public String escapeString(String input) {
+    // This escapes backslashes, newlines and carriage returns, to get
+    // more readable assertion failures.
+    return input.replace("\\", "\\\\").replace("\n", "\\n").replace("\r", "\\r");
+  }
+
+  public void assertOutput(String output) {
+    assertEquals(escapeString(output), escapeString(console.getText()));
+  }
+
+  @Test
+  public void testHelloWorld() throws Exception {
+    console.insertString("Hello, world!", null);
+
+    assertOutput("Hello, world!");
+  }
+
+  @Test
+  public void testCrNlHandling() throws Exception {
+    // Do some basic tests with \r\n
+    console.insertString("abc\r\ndef", null);
+    assertOutput("abc\r\ndef");
+
+    console.insertString("xyz", null);
+    assertOutput("abc\r\ndefxyz");
+
+    console.insertString("000\r\n123", null);
+    assertOutput("abc\r\ndefxyz000\r\n123");
+
+    console.insertString("\r\n", null);
+    assertOutput("abc\r\ndefxyz000\r\n123\r\n");
+  }
+
+  @Test
+  public void testNlHandling() throws Exception {
+    // Basic tests, but with just \n
+    console.insertString("abc\ndef", null);
+    assertOutput("abc\ndef");
+
+    console.insertString("xyz", null);
+    assertOutput("abc\ndefxyz");
+
+    console.insertString("000\n123", null);
+    assertOutput("abc\ndefxyz000\n123");
+
+    console.insertString("\n", null);
+    assertOutput("abc\ndefxyz000\n123\n");
+  }
+
+  @Test
+  public void testCrHandling() throws Exception {
+    // Then test that single \r clears the current line
+    console.clear();
+    console.insertString("abc\rdef", null);
+    assertOutput("def");
+
+    // A single \r at the end is not added to the document
+    console.insertString("\r", null);
+    assertOutput("def");
+
+    // Nor are multiple \r at the end
+    console.insertString("\r\r\r", null);
+    assertOutput("def");
+
+    // But it does clear the line on the next write
+    console.insertString("123", null);
+    assertOutput("123");
+
+    // Same when combined with some data
+    console.insertString("\r456\r\r", null);
+    assertOutput("456");
+
+    console.insertString("000", null);
+    assertOutput("000");
+
+    // Then add a newline so preceding data is kept
+    console.insertString("\r\nxxx\r", null);
+    assertOutput("000\r\nxxx");
+
+    // But data after the newline is removed
+    console.insertString("yyy", null);
+    assertOutput("000\r\nyyy");
+
+    // When a \r\n is split across inserts, it becomes a lone \n
+    console.insertString("\r", null);
+    assertOutput("000\r\nyyy");
+    console.insertString("\n", null);
+    assertOutput("000\r\nyyy\n");
+  }
+
+  @Test
+  public void testCrPartialOverwrite() throws Exception {
+    console.insertString("abcdef\r", null);
+    assertOutput("abcdef");
+
+    console.insertString("123", null);
+    assertOutput("123def");
+
+    console.insertString("4", null);
+    assertOutput("1234ef");
+
+    console.insertString("\r\n56", null);
+    assertOutput("1234ef\r\n56");
+  }
+
+  @Test
+  public void testTogether() throws Exception {
+    console.insertString("abc\n123456\rdef\rx\r\nyyy\nzzz\r999", null);
+    assertOutput("abc\nxef456\r\nyyy\n999");
+  }
+}


### PR DESCRIPTION
When uploading a sketch using dfu-util (e.g. used by various STM32 cores), progress bar lines would be printed. However, each update would be printed on a new line, rather than overwriting the same line as intended. Even more, the console would not scroll when subsequent lines were added, which made it quite annoying to see the upload progress.

It turns out dfu-util uses lone `\r` to overwrite the previous line. However, `EditorConsole` would simply replace those with `\n` instead. But because `ConsoleOutputStream` only scrolled on `\n`, these extra lines would fall out of view on the bottom of the console.

I originally tried updating the scroll behaviour to include these lines, but then thought it would be even nicer to just properly handle `\r` characters instead. That took a bit more time than I had anticipated, but the result is fairly clean code, I think :-)

With this PR applied, the dfu-util now looks like this:

![Peek 2020-03-28 15-14](https://user-images.githubusercontent.com/194491/77827701-7f2c0800-7117-11ea-939f-a7135fcdc779.gif)

Without this PR, it was like this (note that most of the action happens *outside* of view below, until the upload is complete):

![Peek 2020-03-28 17-13](https://user-images.githubusercontent.com/194491/77827702-7fc49e80-7117-11ea-8569-5ebd4b06a049.gif)

As an additional test for partial line overwriting, I added this bit of shell script to a script that was used during upload:

```
echo -ne 'ABCDEF\r'
sleep 3;
echo -ne 'DEF\r'
sleep 3;
echo -ne 'X\n'
sleep 3;
echo -ne 'ZZZ\n'
```
Which works as expected:

![Peek 2020-03-28 15-13](https://user-images.githubusercontent.com/194491/77827700-7f2c0800-7117-11ea-9feb-956fd83c4603.gif)

Again, this would be a good candidate for some testcases. @cmaglie, do you have some notes you could share about how to run the testsuite in a meaningful way (especially just run a single testcase)?