### PR TITLE
Boards Menu: add hint if core lives in sketchbook

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1494,6 +1494,10 @@ public class Base {
         if (platformLabel == null)
           platformLabel = targetPackage.getId() + "-" + targetPlatform.getId();
 
+        // add an hint that this core lives in sketchbook
+        if (targetPlatform.isInSketchbook())
+          platformLabel += " (in sketchbook)";
+
         JMenu platformBoardsMenu = new JMenu(platformLabel);
         MenuScroller.setScrollerFor(platformBoardsMenu);
         platformMenus.add(platformBoardsMenu);

--- a/app/test/processing/app/debug/TargetPlatformStub.java
+++ b/app/test/processing/app/debug/TargetPlatformStub.java
@@ -99,4 +99,10 @@ public class TargetPlatformStub implements TargetPlatform {
   public TargetPackage getContainerPackage() {
     return targetPackage;
   }
+
+  @Override
+  public boolean isInSketchbook() {
+    // TODO Auto-generated method stub
+    return false;
+  }
 }

--- a/arduino-core/src/processing/app/debug/LegacyTargetPlatform.java
+++ b/arduino-core/src/processing/app/debug/LegacyTargetPlatform.java
@@ -245,4 +245,9 @@ public class LegacyTargetPlatform implements TargetPlatform {
       res += "  " + boardId + " = " + boards.get(boardId) + "\n";
     return res + "}";
   }
+
+  @Override
+  public boolean isInSketchbook() {
+	return getFolder().getAbsolutePath().startsWith(BaseNoGui.getDefaultSketchbookFolder().getAbsolutePath());
+  }
 }

--- a/arduino-core/src/processing/app/debug/LegacyTargetPlatform.java
+++ b/arduino-core/src/processing/app/debug/LegacyTargetPlatform.java
@@ -248,6 +248,6 @@ public class LegacyTargetPlatform implements TargetPlatform {
 
   @Override
   public boolean isInSketchbook() {
-	return getFolder().getAbsolutePath().startsWith(BaseNoGui.getDefaultSketchbookFolder().getAbsolutePath());
+	return getFolder().getAbsolutePath().startsWith(BaseNoGui.getSketchbookHardwareFolder().getAbsolutePath());
   }
 }

--- a/arduino-core/src/processing/app/debug/TargetPlatform.java
+++ b/arduino-core/src/processing/app/debug/TargetPlatform.java
@@ -94,4 +94,10 @@ public interface TargetPlatform {
    */
   public TargetPackage getContainerPackage();
 
+  /**
+   * Returns true if the platform is installed in a subfolder of the sketchbook
+   *
+   * @return
+   */
+  public boolean isInSketchbook();
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?

For core development the recommended methods is to clone the core repo in `$sketchbook/hardware`. Before https://github.com/arduino/Arduino/commit/9b48e8d0475d11ea2bb2c883a00ad629207d6d09 these cores were listed after all Board Manager cores; now they are interleaved and quite difficult to spot immediately.
This patch adds the `(sketchbook)` label to cores living in sketchbook, using `getAbsolutePath` so symlinked cores can be spotted too).