### PR TITLE
Remove Java version evaluation

### DIFF
--- a/arduino-core/src/processing/app/legacy/PApplet.java
+++ b/arduino-core/src/processing/app/legacy/PApplet.java
@@ -17,27 +17,6 @@ public class PApplet {
   public String sketchPath; //folder;
 
   /**
-   * Full name of the Java version (i.e. 1.5.0_11).
-   * Prior to 0125, this was only the first three digits.
-   */
-  public static final String javaVersionName =
-    System.getProperty("java.version");
-
-  /**
-   * Version of Java that's in use, whether 1.1 or 1.3 or whatever,
-   * stored as a float.
-   * <P>
-   * Note that because this is stored as a float, the values may
-   * not be <EM>exactly</EM> 1.3 or 1.4. Instead, make sure you're
-   * comparing against 1.3f or 1.4f, which will have the same amount
-   * of error (i.e. 1.40000001). This could just be a double, but
-   * since Processing only uses floats, it's safer for this to be a float
-   * because there's no good way to specify a double with the preproc.
-   */
-  public static final float javaVersion =
-    new Float(javaVersionName.substring(0, 3)).floatValue();
-
-  /**
    * Current platform in use, one of the
    * PConstants WINDOWS, MACOSX, MACOS9, LINUX or OTHER.
    */


### PR DESCRIPTION
According to JEP223, Java versions do not include trailing zero
elements. This means that e.g. Java 14.0.0 reports its version just as
"14". The changed code part expected at least three characters, so it
failed to start on such "zero-zero" Java releases. The evaluated java
version was not used anywhere, so the code block was removed.

For example, my machine is running Java 14 (openjdk version "14" 2020-03-17). When I start the IDE, the following exception is reported and the IDE won't start:

```
java.lang.ExceptionInInitializerError
	at processing.app.helpers.PreferencesMap.load(PreferencesMap.java:100)
	at processing.app.helpers.PreferencesMap.load(PreferencesMap.java:74)
	at processing.app.PreferencesData.init(PreferencesData.java:53)
	at processing.app.BaseNoGui.initParameters(BaseNoGui.java:856)
	at processing.app.Base.<init>(Base.java:197)
	at processing.app.Base.main(Base.java:135)
Caused by: java.lang.StringIndexOutOfBoundsException: begin 0, end 3, length 2
	at java.base/java.lang.String.checkBoundsBeginEnd(String.java:3756)
	at java.base/java.lang.String.substring(String.java:1902)
	at processing.app.legacy.PApplet.<clinit>(PApplet.java:38)
	... 6 more
```

This patch fixes the problem.