### PR TITLE
Prevent testsuite from reading user settings and data

### DIFF
--- a/app/test/processing/app/AbstractGUITest.java
+++ b/app/test/processing/app/AbstractGUITest.java
@@ -41,25 +41,21 @@ import processing.app.helpers.FileUtils;
 import javax.swing.*;
 import java.util.Random;
 
-public abstract class AbstractGUITest {
+public abstract class AbstractGUITest extends AbstractWithPreferencesTest {
 
   protected ArduinoFrameFixture window;
 
   @Before
   public void startUpTheIDE() throws Exception {
+    // This relies on AbstractWithPreferencesTest to set up the
+    // non-gui-specific stuff.
+
     System.setProperty("mrj.version", "whynot"); //makes sense only on osx. See https://github.com/alexruiz/fest-swing-1.x/issues/2#issuecomment-86532042
-    Runtime.getRuntime().addShutdownHook(new Thread(DeleteFilesOnShutdown.INSTANCE));
 
     FailOnThreadViolationRepaintManager.install();
 
-    BaseNoGui.initPlatform();
-    BaseNoGui.getPlatform().init();
-    PreferencesData.init(null);
     JPopupMenu.setDefaultLightWeightPopupEnabled(false);
-    Theme.init();
     BaseNoGui.getPlatform().setLookAndFeel();
-    Base.untitledFolder = FileUtils.createTempFolder("untitled" + new Random().nextInt(Integer.MAX_VALUE), ".tmp");
-    DeleteFilesOnShutdown.add(Base.untitledFolder);
 
     window = GuiActionRunner.execute(new GuiQuery<ArduinoFrameFixture>() {
       @Override

--- a/app/test/processing/app/AbstractGUITest.java
+++ b/app/test/processing/app/AbstractGUITest.java
@@ -60,7 +60,7 @@ public abstract class AbstractGUITest extends AbstractWithPreferencesTest {
     window = GuiActionRunner.execute(new GuiQuery<ArduinoFrameFixture>() {
       @Override
       protected ArduinoFrameFixture executeInEDT() throws Throwable {
-        return new ArduinoFrameFixture(new Base(new String[0]).editors.get(0));
+        return new ArduinoFrameFixture(createBase().editors.get(0));
       }
     });
   }

--- a/app/test/processing/app/AbstractWithPreferencesTest.java
+++ b/app/test/processing/app/AbstractWithPreferencesTest.java
@@ -67,6 +67,8 @@ public abstract class AbstractWithPreferencesTest {
     PreferencesData.set("settings.path", settingsDir.toString());
     // Do not read or write the default ~/Arduino sketchbook
     PreferencesData.set("sketchbook.path", sketchbookDir.toString());
+    // Do not perform any update checks
+    PreferencesData.set("update.check", sketchbookDir.toString());
     // Write the defaults, with these changes to file. This allows them
     // to be reloaded when creating a Base instance (see getBaseArgs()
     // below).

--- a/app/test/processing/app/AbstractWithPreferencesTest.java
+++ b/app/test/processing/app/AbstractWithPreferencesTest.java
@@ -29,17 +29,27 @@
 
 package processing.app;
 
-import cc.arduino.files.DeleteFilesOnShutdown;
 import org.junit.Before;
+import org.junit.After;
+
 import processing.app.helpers.FileUtils;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Random;
+import java.util.List;
+import java.util.LinkedList;
 
 public abstract class AbstractWithPreferencesTest {
+  /**
+   * Files or directories that will be deleted after each test.
+   * Subclasses can add files here in @Test or @Before functions.
+   */
+  protected List<File> deleteAfter = new LinkedList<File>();
 
   @Before
   public void init() throws Exception {
-    Runtime.getRuntime().addShutdownHook(new Thread(DeleteFilesOnShutdown.INSTANCE));
     BaseNoGui.initPlatform();
     BaseNoGui.getPlatform().init();
     PreferencesData.init(null);
@@ -48,7 +58,13 @@ public abstract class AbstractWithPreferencesTest {
     BaseNoGui.initPackages();
 
     Base.untitledFolder = FileUtils.createTempFolder("untitled" + new Random().nextInt(Integer.MAX_VALUE), ".tmp");
-    DeleteFilesOnShutdown.add(Base.untitledFolder);
+    deleteAfter.add(Base.untitledFolder);
   }
 
+  @After
+  public void cleanup() throws IOException {
+    for (File f : deleteAfter)
+      FileUtils.recursiveDelete(f);
+    deleteAfter = new LinkedList<File>();
+  }
 }

--- a/app/test/processing/app/CommandLineTest.java
+++ b/app/test/processing/app/CommandLineTest.java
@@ -32,6 +32,10 @@ package processing.app;
 import static org.junit.Assert.*;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 import org.apache.commons.compress.utils.IOUtils;
 import org.fest.assertions.Assertions;
@@ -72,58 +76,57 @@ public class CommandLineTest {
     System.out.println("found arduino: " + arduinoPath);
   }
 
+  public Process runArduino(boolean output, boolean success, File wd, String[] extraArgs) throws IOException, InterruptedException {
+    Runtime rt = Runtime.getRuntime();
+
+    List<String> args = new ArrayList<String>();
+    args.add(arduinoPath.getAbsolutePath());
+    args.addAll(Arrays.asList(extraArgs));
+
+    Process pr = rt.exec(args.toArray(new String[0]), null, wd);
+    if (output) {
+      IOUtils.copy(pr.getInputStream(), System.out);
+      IOUtils.copy(pr.getErrorStream(), System.out);
+    }
+    pr.waitFor();
+    if (success)
+      assertEquals(0, pr.exitValue());
+    return pr;
+  }
+
   @Test
   public void testCommandLineBuildWithRelativePath() throws Exception {
-    Runtime rt = Runtime.getRuntime();
     File wd = new File(buildPath, "build/shared/examples/01.Basics/Blink/");
-    Process pr = rt
-        .exec(arduinoPath + " --board arduino:avr:uno --verify Blink.ino", null,
-              wd);
-    IOUtils.copy(pr.getInputStream(), System.out);
-    pr.waitFor();
-    assertEquals(0, pr.exitValue());
+    runArduino(true, true, wd, new String[] {
+        "--board", "arduino:avr:uno",
+        "--verify", "Blink.ino",
+    });
   }
 
   @Test
   public void testCommandLinePreferencesSave() throws Exception {
-    Runtime rt = Runtime.getRuntime();
     File prefFile = File.createTempFile("test_pref", ".txt");
     prefFile.deleteOnExit();
 
-    Process pr = rt.exec(new String[] {
-        arduinoPath.getAbsolutePath(),
+    runArduino(true, true, null, new String[] {
         "--save-prefs",
         "--preferences-file", prefFile.getAbsolutePath(),
         "--get-pref", // avoids starting the GUI
     });
-    IOUtils.copy(pr.getInputStream(), System.out);
-    IOUtils.copy(pr.getErrorStream(), System.out);
-    pr.waitFor();
-    assertEquals(0, pr.exitValue());
 
-    pr = rt.exec(new String[] {
-        arduinoPath.getAbsolutePath(),
+    runArduino(true, true, null, new String[] {
         "--pref", "test_pref=xxx",
         "--preferences-file", prefFile.getAbsolutePath(),
     });
-    IOUtils.copy(pr.getInputStream(), System.out);
-    IOUtils.copy(pr.getErrorStream(), System.out);
-    pr.waitFor();
-    assertEquals(0, pr.exitValue());
 
     PreferencesMap prefs = new PreferencesMap(prefFile);
     assertNull("preference should not be saved", prefs.get("test_pref"));
 
-    pr = rt.exec(new String[] {
-        arduinoPath.getAbsolutePath(),
+    runArduino(true, true, null, new String[] {
         "--pref", "test_pref=xxx",
         "--preferences-file", prefFile.getAbsolutePath(),
         "--save-prefs",
     });
-    IOUtils.copy(pr.getInputStream(), System.out);
-    IOUtils.copy(pr.getErrorStream(), System.out);
-    pr.waitFor();
-    assertEquals(0, pr.exitValue());
 
     prefs = new PreferencesMap(prefFile);
     assertEquals("preference should be saved", "xxx", prefs.get("test_pref"));
@@ -131,29 +134,20 @@ public class CommandLineTest {
 
   @Test
   public void testCommandLineVersion() throws Exception {
-    Runtime rt = Runtime.getRuntime();
-    Process pr = rt.exec(new String[]{
-      arduinoPath.getAbsolutePath(),
+    Process pr = runArduino(false, true, null, new String[] {
       "--version",
     });
-    pr.waitFor();
 
-    Assertions.assertThat(pr.exitValue())
-        .as("Process will finish with exit code 0 in --version")
-        .isEqualTo(0);
     Assertions.assertThat(new String(IOUtils.toByteArray(pr.getInputStream())))
         .matches("Arduino: \\d+\\.\\d+\\.\\d+.*\r?\n");
   }
 
   @Test
   public void testCommandLineMultipleAction() throws Exception {
-    Runtime rt = Runtime.getRuntime();
-    Process pr = rt.exec(new String[]{
-      arduinoPath.getAbsolutePath(),
+    Process pr = runArduino(true, false, null, new String[] {
       "--version",
       "--verify",
     });
-    pr.waitFor();
 
     Assertions.assertThat(pr.exitValue())
         .as("Multiple Action will be rejected")

--- a/app/test/processing/app/CommandLineTest.java
+++ b/app/test/processing/app/CommandLineTest.java
@@ -83,6 +83,8 @@ public class CommandLineTest {
     args.add(arduinoPath.getAbsolutePath());
     args.addAll(Arrays.asList(extraArgs));
 
+    System.out.println("Running: " + String.join(" ", args));
+
     Process pr = rt.exec(args.toArray(new String[0]), null, wd);
     if (output) {
       IOUtils.copy(pr.getInputStream(), System.out);

--- a/app/test/processing/app/CommandLineTest.java
+++ b/app/test/processing/app/CommandLineTest.java
@@ -45,7 +45,13 @@ import org.junit.Test;
 import processing.app.helpers.OSUtils;
 import processing.app.helpers.PreferencesMap;
 
-public class CommandLineTest {
+/**
+ * This extends AbstractWithPreferencesTest which initializes part of
+ * the internal Arduino structures. Most of that is not required, but it
+ * also conveniently sets up a settings directory and preferences file,
+ * which we can use here (through getBaseArgs()).
+ */
+public class CommandLineTest extends AbstractWithPreferencesTest {
 
   private static File buildPath;
   private static File arduinoPath;
@@ -81,6 +87,7 @@ public class CommandLineTest {
 
     List<String> args = new ArrayList<String>();
     args.add(arduinoPath.getAbsolutePath());
+    args.addAll(Arrays.asList(getBaseArgs()));
     args.addAll(Arrays.asList(extraArgs));
 
     System.out.println("Running: " + String.join(" ", args));

--- a/app/test/processing/app/CommandLineTest.java
+++ b/app/test/processing/app/CommandLineTest.java
@@ -35,7 +35,7 @@ import java.io.File;
 
 import org.apache.commons.compress.utils.IOUtils;
 import org.fest.assertions.Assertions;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import processing.app.helpers.OSUtils;
@@ -43,11 +43,11 @@ import processing.app.helpers.PreferencesMap;
 
 public class CommandLineTest {
 
-  File buildPath;
-  File arduinoPath;
+  private static File buildPath;
+  private static File arduinoPath;
 
-  @Before
-  public void findBuildPaths() throws Exception {
+  @BeforeClass
+  public static void findBuildPaths() throws Exception {
     buildPath = new File(System.getProperty("user.dir"));
     while (!new File(buildPath, "build").isDirectory()) {
       buildPath = buildPath.getParentFile();

--- a/app/test/processing/app/CommandLineTest.java
+++ b/app/test/processing/app/CommandLineTest.java
@@ -111,7 +111,7 @@ public class CommandLineTest {
     runArduino(true, true, null, new String[] {
         "--save-prefs",
         "--preferences-file", prefFile.getAbsolutePath(),
-        "--get-pref", // avoids starting the GUI
+        "--version", // avoids starting the GUI
     });
 
     runArduino(true, true, null, new String[] {

--- a/app/test/processing/app/DefaultTargetTest.java
+++ b/app/test/processing/app/DefaultTargetTest.java
@@ -57,7 +57,7 @@ public class DefaultTargetTest extends AbstractWithPreferencesTest {
     PreferencesData.set("board", "unreal_board");
 
     // should not raise an exception
-    new Base(new String[0]);
+    createBase();
 
     // skip test if no target platforms are available
     Assume.assumeNotNull(BaseNoGui.getTargetPlatform());

--- a/app/test/processing/app/HittingEscapeOnCloseConfirmationDialogTest.java
+++ b/app/test/processing/app/HittingEscapeOnCloseConfirmationDialogTest.java
@@ -30,6 +30,7 @@
 package processing.app;
 
 import org.fest.swing.core.KeyPressInfo;
+import org.fest.swing.core.matcher.DialogMatcher;
 import org.fest.swing.finder.WindowFinder;
 import org.fest.swing.fixture.DialogFixture;
 import org.junit.Test;
@@ -39,6 +40,7 @@ import javax.swing.*;
 import java.awt.event.KeyEvent;
 
 import static org.junit.Assert.assertEquals;
+import static processing.app.I18n.tr;
 
 public class HittingEscapeOnCloseConfirmationDialogTest extends AbstractGUITest {
 
@@ -49,7 +51,8 @@ public class HittingEscapeOnCloseConfirmationDialogTest extends AbstractGUITest 
 
     window.close();
 
-    DialogFixture dialog = WindowFinder.findDialog(JDialog.class).using(window.robot);
+    DialogMatcher matcher = DialogMatcher.withTitle(tr("Close")).andShowing();
+    DialogFixture dialog = WindowFinder.findDialog(matcher).using(window.robot);
     dialog.pressAndReleaseKey(KeyPressInfo.keyCode(KeyEvent.VK_ESCAPE));
 
     EditorConsole console = (EditorConsole) window.scrollPane("console").component();

--- a/arduino-core/src/processing/app/PreferencesData.java
+++ b/arduino-core/src/processing/app/PreferencesData.java
@@ -50,6 +50,9 @@ public class PreferencesData {
       //ignore
     }
 
+    // Start with a clean slate
+    prefs = new PreferencesMap();
+
     // start by loading the defaults, in case something
     // important was deleted from the user prefs
     try {


### PR DESCRIPTION
While trying to add a testcase for #9954, I noticed that some tests were failing on my system. I also noticed that the tests were reading my regular preferences, `~/.arduino15` directory and sketchbook. This resulted in test failures, since that caused some "Invalid library" messages to be printed and I had "external editor" set making the IDE editor read-only. But also, this is generally a bad idea, since it makes tests unreliable and might even end up messing with a user's settings and data.

Most of this PR are small fixes and refactors, working up to the "Tests: Do not read system user's data" commit that fixes this particular problem. There are also a few commits with small unrelated fixes (which were enabled by these refactorings).

With this PR applied, the testsuite ran correctly, except for the issues caused by #10168.