### PR TITLE
[IDE] Title of sketch is misaligned on Linux FIX #10209

### DIFF
--- a/app/src/processing/app/EditorHeader.java
+++ b/app/src/processing/app/EditorHeader.java
@@ -270,12 +270,8 @@ public class EditorHeader extends JComponent {
       int textLeft = contentLeft + (pieceWidth - textWidth) / 2;
 
       g.setColor(textColor[state]);
-      int baseline = (sizeH + fontAscent) / 2;
-      
-      // FIX for OpenJDK 8 and 11 on Linux (GNOME/KDE) (https://github.com/arduino/Arduino/issues/10209)
-      if (OSUtils.isLinux()) {
-        baseline = baseline + 2;
-      }
+      int baseline = (sizeH + fontAscent + metrics.getDescent()) / 2;
+
       //g.drawString(sketch.code[i].name, textLeft, baseline);
       g.drawString(text, textLeft, baseline);
 

--- a/app/src/processing/app/EditorHeader.java
+++ b/app/src/processing/app/EditorHeader.java
@@ -271,6 +271,11 @@ public class EditorHeader extends JComponent {
 
       g.setColor(textColor[state]);
       int baseline = (sizeH + fontAscent) / 2;
+      
+      // FIX for OpenJDK 8 and 11 on Linux (GNOME/KDE) (https://github.com/arduino/Arduino/issues/10209)
+      if (OSUtils.isLinux()) {
+        baseline = baseline - 2;
+      }
       //g.drawString(sketch.code[i].name, textLeft, baseline);
       g.drawString(text, textLeft, baseline);
 

--- a/app/src/processing/app/EditorHeader.java
+++ b/app/src/processing/app/EditorHeader.java
@@ -274,7 +274,7 @@ public class EditorHeader extends JComponent {
       
       // FIX for OpenJDK 8 and 11 on Linux (GNOME/KDE) (https://github.com/arduino/Arduino/issues/10209)
       if (OSUtils.isLinux()) {
-        baseline = baseline - 2;
+        baseline = baseline + 2;
       }
       //g.drawString(sketch.code[i].name, textLeft, baseline);
       g.drawString(text, textLeft, baseline);

--- a/app/src/processing/app/EditorHeader.java
+++ b/app/src/processing/app/EditorHeader.java
@@ -73,6 +73,7 @@ public class EditorHeader extends JComponent {
 
   static final int PIECE_WIDTH = scale(4);
   static final int PIECE_HEIGHT = scale(33);
+  static final int TAB_HEIGHT = scale(27);
 
   // value for the size bars, buttons, etc
   // TODO: Should be a Theme value?
@@ -270,9 +271,8 @@ public class EditorHeader extends JComponent {
       int textLeft = contentLeft + (pieceWidth - textWidth) / 2;
 
       g.setColor(textColor[state]);
-      int baseline = (sizeH + fontAscent + metrics.getDescent()) / 2;
-
-      //g.drawString(sketch.code[i].name, textLeft, baseline);
+      int tabMarginTop = sizeH - TAB_HEIGHT;
+      int baseline = tabMarginTop + ((TAB_HEIGHT + fontAscent) / 2) ; 
       g.drawString(text, textLeft, baseline);
 
       g.drawImage(pieces[state][RIGHT], x, 0, null);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?

### Details

For a long time I always found the linux icon out of alignment, I attribute this problem that was perhaps related to my system fonts. But I think that need a HACK for Linux / Ubuntu

Tests:
Os: Kubuntu / KDE
JDK: OpenJDK 7 and 11

But I decided to investigate further, and looking at some prints on the internet I see that it is really out of alignment.

http://dexvils.blogspot.com/2015/06/install-arduino-ide-16x-on-ubuntu.html
https://websiteforstudents.com/how-to-install-arduino-ide-on-ubuntu-18-04-16-04/

![image](https://user-images.githubusercontent.com/515675/82015239-aea9bc00-9654-11ea-80f8-41b3054cd1ea.png)
