### PR TITLE
Improve LibraryManager Dialog rendering

### DIFF
--- a/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryTableCellEditor.java
+++ b/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryTableCellEditor.java
@@ -52,7 +52,7 @@ import cc.arduino.utils.ReverseComparator;
 public class ContributedLibraryTableCellEditor extends InstallerTableCell {
 
   private ContributedLibraryReleases editorValue;
-  private ContributedLibraryTableCellJPanel editorCell;
+  private ContributedLibraryTableCellJPanel editorCell = new ContributedLibraryTableCellJPanel();
 
   @Override
   public Object getCellEditorValue() {
@@ -64,8 +64,8 @@ public class ContributedLibraryTableCellEditor extends InstallerTableCell {
                                                boolean isSelected, int row,
                                                int column) {
     editorValue = (ContributedLibraryReleases) value;
-
-    editorCell = new ContributedLibraryTableCellJPanel(table, value, true);
+    
+    editorCell.update(table, value, isSelected);
     editorCell.installButton
         .addActionListener(e -> onInstall(editorValue.getSelected(),
                                           editorValue.getInstalled()));

--- a/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryTableCellJPanel.java
+++ b/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryTableCellJPanel.java
@@ -24,22 +24,25 @@ import processing.app.Theme;
 
 public class ContributedLibraryTableCellJPanel extends JPanel {
 
-  final JButton moreInfoButton;
-  final JButton installButton;
-  final Component installButtonPlaceholder;
-  final JComboBox downgradeChooser;
-  final JComboBox versionToInstallChooser;
-  final JButton downgradeButton;
-  final JPanel buttonsPanel;
-  final JPanel inactiveButtonsPanel;
-  final JLabel statusLabel;
-  final JTextPane description;
-  final TitledBorder titledBorder;
+  protected JButton moreInfoButton;
+  protected JButton installButton;
+  protected Component installButtonPlaceholder;
+  protected JComboBox downgradeChooser;
+  protected JComboBox versionToInstallChooser;
+  protected JButton downgradeButton;
+  protected JPanel buttonsPanel;
+  protected JPanel inactiveButtonsPanel;
+  protected JLabel statusLabel;
+  protected JTextPane description;
+  protected TitledBorder titledBorder;
   private final String moreInfoLbl = tr("More info");
-
-  public ContributedLibraryTableCellJPanel(JTable parentTable, Object value,
-                                           boolean isSelected) {
-    super();
+  
+  public ContributedLibraryTableCellJPanel() {
+    super() ;
+    initComponents();
+  }
+  
+  public void initComponents() {
     setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
 
     // Actual title set below
@@ -119,6 +122,10 @@ public class ContributedLibraryTableCellJPanel extends JPanel {
 
     add(Box.createVerticalStrut(15));
 
+  }
+  
+public void update(JTable parentTable, Object value, boolean isSelected) {
+    
     ContributedLibraryReleases releases = (ContributedLibraryReleases) value;
 
     // FIXME: happens on macosx, don't know why

--- a/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryTableCellRenderer.java
+++ b/app/src/cc/arduino/contributions/libraries/ui/ContributedLibraryTableCellRenderer.java
@@ -36,14 +36,18 @@ import javax.swing.JTable;
 import javax.swing.table.TableCellRenderer;
 
 @SuppressWarnings("serial")
-public class ContributedLibraryTableCellRenderer implements TableCellRenderer {
+public class ContributedLibraryTableCellRenderer extends ContributedLibraryTableCellJPanel implements TableCellRenderer {
+  
 
   public Component getTableCellRendererComponent(JTable table, Object value,
                                                  boolean isSelected,
                                                  boolean hasFocus, int row,
                                                  int column) {
-    ContributedLibraryTableCellJPanel cell = new ContributedLibraryTableCellJPanel(table,
-        value, isSelected);
+    
+    update(table, value, isSelected);
+    
+    ContributedLibraryTableCellJPanel cell = this;
+    
     cell.setButtonsVisible(false);
 
     cell.setForeground(Color.BLACK);


### PR DESCRIPTION
TableCellRender is designed to be reusable.
Te old implementation
created an instance, every time the mouse was over the line, This can lead to rendering problems, and low responsiveness

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?

### Tests

I made a small benchmark with the results:

First run:
- OLD: 423813 ms
- New: 286341 ms

Second run:
- OLD: 442275 ms
- New: 277634 ms

Test Class..

```
package cc.arduino.test;

import java.awt.Rectangle;
import java.awt.Toolkit;

import javax.swing.JTable;
import javax.swing.SwingUtilities;

public class BenchmarkRenderer {
  static long benchmarkTable(final JTable list, String msg) {
    Runnable doScroll = new Runnable() {
      public void run() {
        int index = list.getSelectedRow();
        list.changeSelection(index + 1, 0, false, false);
        // make visible to trigger render...
        Rectangle cellRect = list.getCellRect(index + 1, 0, false);
        list.scrollRectToVisible(cellRect);
      }
    };

    Runnable doNothing = new Runnable() {
      public void run() {
      }
    };

    long startTime = System.currentTimeMillis();

    list.changeSelection(0, 0, false, false);

    /*
     * Each iteration of this loops queue a request to scroll the list on the
     * event dispatching thread (we're running on the "main" thread) and then
     * waits for all of the paint operations caused by the scroll to finish.
     * Finally we force any output that has been buffered by the AWT
     * implementation to be flushed (with Toolkit.sync()). Then overhead
     * introduced here is the same for each list so the elapsed time numbers can
     * be safely compared.
     */
    for (int i = 0; i < list.getModel().getRowCount(); i++) {
      try {
        SwingUtilities.invokeLater(doScroll);
        Thread.yield();
        SwingUtilities.invokeAndWait(doNothing);
        Toolkit.getDefaultToolkit().sync();
      } catch (Exception e) {
        e.printStackTrace();
      }
    }

    long endTime = System.currentTimeMillis();
    long time =  endTime - startTime;
    System.out.println(">>" + time);
    return time;
  }

  public static void main(String[] args) throws Exception {
   
  }
}
```