### PR TITLE
Make SerialPassthrough example baud-agnostic

### DIFF
--- a/build/shared/examples/04.Communication/SerialPassthrough/SerialPassthrough.ino
+++ b/build/shared/examples/04.Communication/SerialPassthrough/SerialPassthrough.ino
@@ -22,12 +22,24 @@
   by Erik Nyquist
 */
 
+uint32_t currentBaud = 9600;
+
 void setup() {
-  Serial.begin(9600);
-  Serial1.begin(9600);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for native USB
+  }
+  currentBaud = Serial.baud();
+  Serial1.begin(currentBaud);    // Set hardware serial baud rate to USB's desired baud rate
 }
 
 void loop() {
+  // Poll for baud changes on the USB CDC side
+  if (currentBaud != Serial.baud()) {
+    currentBaud = Serial.baud();
+    Serial1.flush();             // Finish sending any pending messages
+    Serial1.begin(currentBaud);  // Set hardware serial baud rate to USB's desired baud rate
+  }
+
   if (Serial.available()) {      // If anything comes in Serial (USB),
     Serial1.write(Serial.read());   // read it and send it out Serial1 (pins 0 & 1)
   }


### PR DESCRIPTION
### All Submissions:

* [Y] Have you followed the guidelines in our Contributing document?
* [Y] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?

The existing SerialPassthrough example is hard-coded to 9600 baud, and since the Serial.baud() method is undocumented it wasn't exactly clear how to extrapolate to situations where the baud rate on the CDC side is changeable (say you want to create an FTDI USB <> UART replacement using an ATmega32u4).

Manually tested by uploading to an Arduino Micro connected to another USB <> UART converter. Able to send text to and from the Arduino Serial Monitor even at different baud rates (the other end was using PuTTY which naturally required creating a new session specifying the baud rate each time).
