### PR TITLE
Fixed invalid http accept header

### DIFF
--- a/arduino-core/src/cc/arduino/utils/network/HttpConnectionManager.java
+++ b/arduino-core/src/cc/arduino/utils/network/HttpConnectionManager.java
@@ -128,6 +128,11 @@ public class HttpConnectionManager {
       .toUpperCase().replace("-", "").substring(0, 16);
     HttpURLConnection connection = (HttpURLConnection) requestURL
       .openConnection(proxy);
+
+    // see https://github.com/arduino/Arduino/issues/10264
+    // Workaround for https://bugs.openjdk.java.net/browse/JDK-8163921
+    connection.setRequestProperty("Accept", "*/*");
+
     connection.setRequestProperty("User-agent", userAgent);
     connection.setRequestProperty("X-Request-ID", requestId);
     if (id != null) {


### PR DESCRIPTION
This patch overrides the default JDK accept header that happens to be
invalid, as per RFC 7231.

Real issue: https://bugs.openjdk.java.net/browse/JDK-8163921

Fix https://github.com/arduino/Arduino/issues/10264

@DataGhost @matthijskooijman 