### PR TITLE
Lib manager filters fix

### DIFF
--- a/app/src/cc/arduino/contributions/libraries/ui/LibraryManagerUI.java
+++ b/app/src/cc/arduino/contributions/libraries/ui/LibraryManagerUI.java
@@ -41,7 +41,6 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Predicate;
 
 import javax.swing.Box;
 import javax.swing.JComboBox;
@@ -67,7 +66,6 @@ public class LibraryManagerUI extends InstallerJDialog<ContributedLibraryRelease
 
   private final JComboBox typeChooser;
   private final LibraryInstaller installer;
-  private Predicate<ContributedLibraryReleases> typeFilter;
 
   @Override
   protected FilteredAbstractTableModel createContribModel() {
@@ -116,17 +114,16 @@ public class LibraryManagerUI extends InstallerJDialog<ContributedLibraryRelease
   }
 
   protected final ActionListener typeChooserActionListener = new ActionListener() {
-
     @Override
     public void actionPerformed(ActionEvent event) {
       DropdownItem<ContributedLibraryReleases> selected = (DropdownItem<ContributedLibraryReleases>) typeChooser.getSelectedItem();
       previousRowAtPoint = -1;
-      if (selected != null && typeFilter != selected.getFilterPredicate()) {
-        typeFilter = selected.getFilterPredicate();
+      if (selected != null && extraFilter != selected.getFilterPredicate()) {
+        extraFilter = selected.getFilterPredicate();
         if (contribTable.getCellEditor() != null) {
           contribTable.getCellEditor().stopCellEditing();
         }
-        updateIndexFilter(filters, categoryFilter.and(typeFilter));
+        updateIndexFilter(filters, categoryFilter.and(extraFilter));
       }
     }
   };
@@ -159,7 +156,7 @@ public class LibraryManagerUI extends InstallerJDialog<ContributedLibraryRelease
     categoryChooser.setSelectedIndex(0);
 
     // Load types
-    typeFilter = x -> true;
+    extraFilter = x -> true;
     typeChooser.removeActionListener(typeChooserActionListener);
     typeChooser.removeAllItems();
     typeChooser.addItem(new DropdownAllLibraries());

--- a/app/src/cc/arduino/contributions/libraries/ui/LibraryManagerUI.java
+++ b/app/src/cc/arduino/contributions/libraries/ui/LibraryManagerUI.java
@@ -35,6 +35,7 @@ import java.awt.Dialog;
 import java.awt.Frame;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -130,48 +131,46 @@ public class LibraryManagerUI extends InstallerJDialog<ContributedLibraryRelease
     }
   };
 
-  public void updateUI() {
-    DropdownItem<ContributedLibraryReleases> previouslySelectedCategory = (DropdownItem<ContributedLibraryReleases>) categoryChooser.getSelectedItem();
-    DropdownItem<ContributedLibraryReleases> previouslySelectedType = (DropdownItem<ContributedLibraryReleases>) typeChooser.getSelectedItem();
+  private Collection<String> oldCategories = new ArrayList<>();
+  private Collection<String> oldTypes = new ArrayList<>();
 
-    categoryChooser.removeActionListener(categoryChooserActionListener);
-    typeChooser.removeActionListener(typeChooserActionListener);
+  public void updateUI() {
+    // Check if categories or types have changed
+    Collection<String> categories = BaseNoGui.librariesIndexer.getIndex().getCategories();
+    List<String> types = new LinkedList<>(BaseNoGui.librariesIndexer.getIndex().getTypes());
+    Collections.sort(types, new LibraryTypeComparator());
+
+    if (categories.equals(oldCategories) && types.equals(oldTypes)) {
+      return;
+    }
+    oldCategories = categories;
+    oldTypes = types;
 
     // Load categories
     categoryFilter = x -> true;
+    categoryChooser.removeActionListener(categoryChooserActionListener);
     categoryChooser.removeAllItems();
     categoryChooser.addItem(new DropdownAllLibraries());
-    Collection<String> categories = BaseNoGui.librariesIndexer.getIndex().getCategories();
     for (String category : categories) {
       categoryChooser.addItem(new DropdownLibraryOfCategoryItem(category));
     }
-
     categoryChooser.setEnabled(categoryChooser.getItemCount() > 1);
-
     categoryChooser.addActionListener(categoryChooserActionListener);
-    if (previouslySelectedCategory != null) {
-      categoryChooser.setSelectedItem(previouslySelectedCategory);
-    } else {
-      categoryChooser.setSelectedIndex(0);
-    }
+    categoryChooser.setSelectedIndex(0);
 
+    // Load types
     typeFilter = x -> true;
+    typeChooser.removeActionListener(typeChooserActionListener);
     typeChooser.removeAllItems();
     typeChooser.addItem(new DropdownAllLibraries());
     typeChooser.addItem(new DropdownUpdatableLibrariesItem());
     typeChooser.addItem(new DropdownInstalledLibraryItem());
-    List<String> types = new LinkedList<>(BaseNoGui.librariesIndexer.getIndex().getTypes());
-    Collections.sort(types, new LibraryTypeComparator());
     for (String type : types) {
       typeChooser.addItem(new DropdownLibraryOfTypeItem(type));
     }
     typeChooser.setEnabled(typeChooser.getItemCount() > 1);
     typeChooser.addActionListener(typeChooserActionListener);
-    if (previouslySelectedType != null) {
-      typeChooser.setSelectedItem(previouslySelectedType);
-    } else {
-      typeChooser.setSelectedIndex(0);
-    }
+    typeChooser.setSelectedIndex(0);
 
     filterField.setEnabled(contribModel.getRowCount() > 0);
   }

--- a/app/src/cc/arduino/contributions/ui/InstallerJDialog.java
+++ b/app/src/cc/arduino/contributions/ui/InstallerJDialog.java
@@ -81,6 +81,7 @@ public abstract class InstallerJDialog<T> extends JDialog {
   protected final FilterJTextField filterField;
   protected final JPanel filtersContainer;
   // Currently selected category and filters
+  protected Predicate<T> extraFilter = x -> true;
   protected Predicate<T> categoryFilter;
   protected String[] filters;
   protected final String noConnectionErrorMessage;
@@ -337,7 +338,7 @@ public abstract class InstallerJDialog<T> extends JDialog {
         if (contribTable.getCellEditor() != null) {
           contribTable.getCellEditor().stopCellEditing();
         }
-        updateIndexFilter(filters, categoryFilter);
+        updateIndexFilter(filters, categoryFilter.and(extraFilter));
       }
     }
   };

--- a/app/src/cc/arduino/contributions/ui/InstallerJDialog.java
+++ b/app/src/cc/arduino/contributions/ui/InstallerJDialog.java
@@ -71,7 +71,6 @@ import javax.swing.text.DefaultEditorKit;
 
 import cc.arduino.contributions.ui.listeners.AbstractKeyListener;
 import processing.app.Base;
-import processing.app.Theme;
 
 public abstract class InstallerJDialog<T> extends JDialog {
 
@@ -329,7 +328,6 @@ public abstract class InstallerJDialog<T> extends JDialog {
   }
 
   protected final ActionListener categoryChooserActionListener = new ActionListener() {
-
     @Override
     public void actionPerformed(ActionEvent event) {
       DropdownItem<T> selected = (DropdownItem<T>) categoryChooser.getSelectedItem();


### PR DESCRIPTION
This PR fixes two bugs in library manager combo-box Type and Category filters:

- The filters are both reset to "All" after an install/update operation
- Changing the Category will show the *all* the libraries belonging to that category regardless of the "Type" selection (for example if you selected "Installed" or "Upgradable" before changing the category)
