### PR TITLE
Fixed Boards and Libraries Manager "filters" persistence

### DIFF
--- a/app/src/cc/arduino/contributions/libraries/ui/LibraryManagerUI.java
+++ b/app/src/cc/arduino/contributions/libraries/ui/LibraryManagerUI.java
@@ -197,8 +197,11 @@ public class LibraryManagerUI extends InstallerJDialog<ContributedLibraryRelease
       try {
         setProgressVisible(true, "");
         installer.updateIndex(this::setProgress);
-        ((LibrariesIndexTableModel) contribModel).update();
         onIndexesUpdated();
+        if (contribTable.getCellEditor() != null) {
+          contribTable.getCellEditor().stopCellEditing();
+        }
+        ((LibrariesIndexTableModel) contribModel).update();
       } catch (Exception e) {
         throw new RuntimeException(e);
       } finally {
@@ -234,12 +237,11 @@ public class LibraryManagerUI extends InstallerJDialog<ContributedLibraryRelease
         } else {
           installer.install(lib, this::setProgress);
         }
-        // TODO: Do a better job in refreshing only the needed element
+        onIndexesUpdated();
         if (contribTable.getCellEditor() != null) {
           contribTable.getCellEditor().stopCellEditing();
         }
         ((LibrariesIndexTableModel) contribModel).update();
-        onIndexesUpdated();
       } catch (Exception e) {
         throw new RuntimeException(e);
       } finally {
@@ -266,12 +268,11 @@ public class LibraryManagerUI extends InstallerJDialog<ContributedLibraryRelease
       try {
         setProgressVisible(true, tr("Removing..."));
         installer.remove(lib, this::setProgress);
-        // TODO: Do a better job in refreshing only the needed element
+        onIndexesUpdated();
         if (contribTable.getCellEditor() != null) {
           contribTable.getCellEditor().stopCellEditing();
         }
         ((LibrariesIndexTableModel) contribModel).update();
-        onIndexesUpdated();
       } catch (Exception e) {
         throw new RuntimeException(e);
       } finally {

--- a/app/src/cc/arduino/contributions/libraries/ui/LibraryManagerUI.java
+++ b/app/src/cc/arduino/contributions/libraries/ui/LibraryManagerUI.java
@@ -72,6 +72,10 @@ public class LibraryManagerUI extends InstallerJDialog<ContributedLibraryRelease
     return new LibrariesIndexTableModel();
   }
 
+  private LibrariesIndexTableModel getContribModel() {
+    return (LibrariesIndexTableModel) contribModel;
+  }
+
   @Override
   protected TableCellRenderer createCellRenderer() {
     return new ContributedLibraryTableCellRenderer();
@@ -201,7 +205,7 @@ public class LibraryManagerUI extends InstallerJDialog<ContributedLibraryRelease
         if (contribTable.getCellEditor() != null) {
           contribTable.getCellEditor().stopCellEditing();
         }
-        ((LibrariesIndexTableModel) contribModel).update();
+        getContribModel().update();
       } catch (Exception e) {
         throw new RuntimeException(e);
       } finally {
@@ -241,7 +245,7 @@ public class LibraryManagerUI extends InstallerJDialog<ContributedLibraryRelease
         if (contribTable.getCellEditor() != null) {
           contribTable.getCellEditor().stopCellEditing();
         }
-        ((LibrariesIndexTableModel) contribModel).update();
+        getContribModel().update();
       } catch (Exception e) {
         throw new RuntimeException(e);
       } finally {
@@ -272,7 +276,7 @@ public class LibraryManagerUI extends InstallerJDialog<ContributedLibraryRelease
         if (contribTable.getCellEditor() != null) {
           contribTable.getCellEditor().stopCellEditing();
         }
-        ((LibrariesIndexTableModel) contribModel).update();
+        getContribModel().update();
       } catch (Exception e) {
         throw new RuntimeException(e);
       } finally {

--- a/app/src/cc/arduino/contributions/packages/ui/ContributionIndexTableModel.java
+++ b/app/src/cc/arduino/contributions/packages/ui/ContributionIndexTableModel.java
@@ -47,9 +47,17 @@ public class ContributionIndexTableModel
   private final List<ContributedPlatformReleases> contributions = new ArrayList<>();
   private final String[] columnNames = { "Description" };
   private final Class<?>[] columnTypes = { ContributedPlatform.class };
+  private Predicate<ContributedPlatform> filter;
+  private String[] filters;
 
   public void updateIndexFilter(String[] filters,
                                 Predicate<ContributedPlatform> filter) {
+    this.filter = filter;
+    this.filters = filters;
+    updateContributions();
+  }
+
+  private void updateContributions() {
     contributions.clear();
     for (ContributedPackage pack : BaseNoGui.indexer.getPackages()) {
       for (ContributedPlatform platform : pack.getPlatforms()) {
@@ -146,6 +154,7 @@ public class ContributionIndexTableModel
   }
 
   public void update() {
+    updateContributions();
     fireTableDataChanged();
   }
 

--- a/app/src/cc/arduino/contributions/packages/ui/ContributionManagerUI.java
+++ b/app/src/cc/arduino/contributions/packages/ui/ContributionManagerUI.java
@@ -29,7 +29,6 @@
 
 package cc.arduino.contributions.packages.ui;
 
-import cc.arduino.contributions.DownloadableContribution;
 import cc.arduino.contributions.packages.ContributedPlatform;
 import cc.arduino.contributions.packages.ContributionInstaller;
 import cc.arduino.contributions.ui.*;
@@ -41,6 +40,7 @@ import javax.swing.*;
 import javax.swing.table.TableCellRenderer;
 
 import java.awt.*;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -92,30 +92,28 @@ public class ContributionManagerUI extends InstallerJDialog {
     this.installer = installer;
   }
 
+  private Collection<String> oldCategories = new ArrayList<>();
+
   public void updateUI() {
-    DropdownItem<DownloadableContribution> previouslySelectedCategory = (DropdownItem<DownloadableContribution>) categoryChooser
-        .getSelectedItem();
+    // Check if categories have changed
+    Collection<String> categories = BaseNoGui.indexer.getCategories();
+    if (categories.equals(oldCategories)) {
+      return;
+    }
+    oldCategories = categories;
 
     categoryChooser.removeActionListener(categoryChooserActionListener);
-
-    filterField.setEnabled(getContribModel().getRowCount() > 0);
-
-    categoryChooser.addActionListener(categoryChooserActionListener);
-
     // Enable categories combo only if there are two or more choices
+    filterField.setEnabled(getContribModel().getRowCount() > 0);
     categoryFilter = x -> true;
     categoryChooser.removeAllItems();
     categoryChooser.addItem(new DropdownAllCoresItem());
     categoryChooser.addItem(new DropdownUpdatableCoresItem());
-    Collection<String> categories = BaseNoGui.indexer.getCategories();
     for (String s : categories) {
       categoryChooser.addItem(new DropdownCoreOfCategoryItem(s));
     }
-    if (previouslySelectedCategory != null) {
-      categoryChooser.setSelectedItem(previouslySelectedCategory);
-    } else {
-      categoryChooser.setSelectedIndex(0);
-    }
+    categoryChooser.addActionListener(categoryChooserActionListener);
+    categoryChooser.setSelectedIndex(0);
   }
 
   public void setProgress(Progress progress) {

--- a/app/src/cc/arduino/contributions/packages/ui/ContributionManagerUI.java
+++ b/app/src/cc/arduino/contributions/packages/ui/ContributionManagerUI.java
@@ -144,6 +144,10 @@ public class ContributionManagerUI extends InstallerJDialog {
             .updateIndex(this::setProgress);
         installer.deleteUnknownFiles(downloadedPackageIndexFiles);
         onIndexesUpdated();
+        if (contribTable.getCellEditor() != null) {
+          contribTable.getCellEditor().stopCellEditing();
+        }
+        getContribModel().update();
       } catch (Exception e) {
         throw new RuntimeException(e);
       } finally {
@@ -169,6 +173,10 @@ public class ContributionManagerUI extends InstallerJDialog {
         }
         errors.addAll(installer.install(platformToInstall, this::setProgress));
         onIndexesUpdated();
+        if (contribTable.getCellEditor() != null) {
+          contribTable.getCellEditor().stopCellEditing();
+        }
+        getContribModel().update();
       } catch (Exception e) {
         throw new RuntimeException(e);
       } finally {
@@ -207,6 +215,10 @@ public class ContributionManagerUI extends InstallerJDialog {
         setProgressVisible(true, tr("Removing..."));
         installer.remove(platform);
         onIndexesUpdated();
+        if (contribTable.getCellEditor() != null) {
+          contribTable.getCellEditor().stopCellEditing();
+        }
+        getContribModel().update();
       } catch (Exception e) {
         throw new RuntimeException(e);
       } finally {


### PR DESCRIPTION
This PR allows to keep the filter of the libraries and board manager unchanged after install, update or delete.
The PR completes the work done in #10440.

- Applied the same fix for Lib Manager in #10440 to the Board Manager.
- Fixed the dialog update logic in both lib and board managers