### PR TITLE
Fixed NPE in buildProgrammersMenu

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1706,7 +1706,7 @@ public class Base {
     TargetPlatform corePlatform = null;
 
     String core = board.getPreferences().get("build.core");
-    if (core.contains(":")) {
+    if (core != null && core.contains(":")) {
       String[] split = core.split(":", 2);
       corePlatform = BaseNoGui.getCurrentTargetPlatformFromPackage(split[0]);
     }


### PR DESCRIPTION
Some platforms may not define directly `build.core` because it may be defined through a custom menu.

For example, the arduboy platform has in the boards.txt:

```
[...]
menu.core=Core
[...]
# core #
arduboy-homemade.menu.core.arduboy-core=Arduboy optimized core
arduboy-homemade.menu.core.arduboy-core.build.core=arduboy
arduboy-homemade.menu.core.arduino-core=Standard Arduino core
arduboy-homemade.menu.core.arduino-core.build.core=arduino:arduino
[...]
```

the build.core is determined only after applying the submenu options.

Before this patch the IDE would not start due to a NullPointerException, this PR fix the exception by checking if the `build.core` property is directly defined. If it is not the current platform is used instead of an eventual referenced platform.

The proper fix requires to apply all the custom properties and to find the referenced platform, but this is much more involved and requires a much complex PR, the purpose of this PR is to fix the crash and to allow the IDE to start.
