### PR TITLE
Added duration variable to Blink.ino

### DIFF
--- a/build/shared/examples/01.Basics/Blink/Blink.ino
+++ b/build/shared/examples/01.Basics/Blink/Blink.ino
@@ -16,6 +16,8 @@
   by Arturo Guadalupi
   modified 8 Sep 2016
   by Colby Newman
+  modified 15 Aug 2020
+  by Jeff Beeghly
 
   This example code is in the public domain.
 
@@ -30,8 +32,9 @@ void setup() {
 
 // the loop function runs over and over again forever
 void loop() {
+  const int duration = 1000;         // delay duration, in milliseconds
   digitalWrite(LED_BUILTIN, HIGH);   // turn the LED on (HIGH is the voltage level)
-  delay(1000);                       // wait for a second
+  delay(duration);                   // wait for a second
   digitalWrite(LED_BUILTIN, LOW);    // turn the LED off by making the voltage LOW
-  delay(1000);                       // wait for a second
+  delay(duration);                   // wait for a second
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

Added duration variable to the Blink.ino sketch. This change has the following benefits:
1) Makes it easier to change the delay time and aids in troubleshooting
2) Demonstrates good programming habits to beginner programmers by not using "magic numbers" or redeclaring the same value multiple times
3) Can be used in a beginner "how to program" tutorial - open Blink,ino, then walk the reader/student through changing the value of duration, compile and run, then change the value again, compile and run, and notice the change, etc...