### PR TITLE
Use file passed on command line when using --upload or --verify

### DIFF
--- a/arduino-core/src/processing/app/Sketch.java
+++ b/arduino-core/src/processing/app/Sketch.java
@@ -22,6 +22,8 @@ public class Sketch {
   public static final List<String> OTHER_ALLOWED_EXTENSIONS = Arrays.asList("c", "cpp", "h", "hh", "hpp", "s");
   public static final List<String> EXTENSIONS = Stream.concat(SKETCH_EXTENSIONS.stream(), OTHER_ALLOWED_EXTENSIONS.stream()).collect(Collectors.toList());
 
+  private final File initialFile;
+
   /**
    * folder that contains this sketch
    */
@@ -50,6 +52,7 @@ public class Sketch {
    *          Any file inside the sketch directory.
    */
   Sketch(File file) throws IOException {
+    initialFile = file;
     folder = file.getParentFile();
     files = listSketchFiles(true);
   }
@@ -141,6 +144,13 @@ public class Sketch {
 
   public int getCodeCount() {
     return files.size();
+  }
+
+  /**
+   * Returns the initial File used to initialize this Sketch
+   */
+  public File getInitialFile() {
+    return initialFile;
   }
 
   public SketchFile[] getFiles() {

--- a/arduino-core/src/processing/app/SketchFile.java
+++ b/arduino-core/src/processing/app/SketchFile.java
@@ -95,7 +95,8 @@ public class SketchFile {
     this.sketch = sketch;
     this.file = file;
     FileUtils.SplitFile split = FileUtils.splitFilename(file);
-    this.primary = split.basename.equals(sketch.getFolder().getName())
+    this.primary = (file.equals(sketch.getInitialFile())
+        || split.basename.equals(sketch.getFolder().getName()))
         && Sketch.SKETCH_EXTENSIONS.contains(split.extension);
   }
 


### PR DESCRIPTION
This removes the requirement for .ino files to match their folder name when the Compiler is invoked via the command line with an explicit .ino file path. Fixes #10755 which in turn fixes microsoft/vscode-arduino#1100. When invoking compiler via `--upload` or `--verify`, it doesn't make sense to require the `.ino` sketch name to match the containing folder name, as other IDEs do not have a reason to enforce this requirement. This should allow tools like `microsoft/vscode-arduino` to eventually support multiple `.ino` files per project more gracefully as well.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?
