### PR TITLE
Fix built-in examples update during build

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -242,7 +242,8 @@
     <antcall target="unzip">
       <param name="archive_file" value="${BUILT-IN-EXAMPLES-REPOSITORY-NAME}-${BUILT-IN-EXAMPLES-VERSION}.zip" />
       <param name="archive_url" value="https://github.com/${BUILT-IN-EXAMPLES-REPOSITORY-OWNER}/${BUILT-IN-EXAMPLES-REPOSITORY-NAME}/archive/${BUILT-IN-EXAMPLES-VERSION}.zip" />
-      <param name="final_folder" value="${BUILT-IN-EXAMPLES-FINAL-PATH}" />
+      <!-- Because the presence of this folder determines whether the extraction happens, this must point to a version-dependent path, otherwise updates will fail -->
+      <param name="final_folder" value="${BUILT-IN-EXAMPLES-STAGING-PATH}/${BUILT-IN-EXAMPLES-REPOSITORY-NAME}-${BUILT-IN-EXAMPLES-VERSION}/examples" />
       <param name="dest_folder" value="${BUILT-IN-EXAMPLES-STAGING-PATH}" />
     </antcall>
 


### PR DESCRIPTION
Previously, the built-in examples assembly step of the build system set the `final_folder` parameter of the `unzip` target to the true final installation location of the examples.

The behavior of the `unzip` target is to only unzip the archive if `final_folder` doesn't exist. Because that folder will exist any time a previous build has been done and `ant clean` was not run, the archive will not be unzipped. This causes the build to fail after an update to the built-in examples version when it attempts to copy the examples from the
version-dependent extraction staging folder to the final location.

The fix is to set the `final_folder` parameter to the version-dependent staging folder location, which will cause the extraction to happen every time the examples version is updated, but to be skipped when there was no update.

See https://github.com/arduino/Arduino/pull/10734#issuecomment-701523543 for an explanation of the problem, and the steps to reproduce it here: https://github.com/arduino/Arduino/pull/10734#issuecomment-701998801. (Thanks matthijskooijman!)

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes
