### PR TITLE
rebuildProgrammerMenu: Handle no current board

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1702,18 +1702,20 @@ public class Base {
     ButtonGroup group = new ButtonGroup();
 
     TargetBoard board = BaseNoGui.getTargetBoard();
-    TargetPlatform boardPlatform = board.getContainerPlatform();
-    TargetPlatform corePlatform = null;
+    if (board != null) {
+      TargetPlatform boardPlatform = board.getContainerPlatform();
+      TargetPlatform corePlatform = null;
 
-    String core = board.getPreferences().get("build.core");
-    if (core != null && core.contains(":")) {
-      String[] split = core.split(":", 2);
-      corePlatform = BaseNoGui.getCurrentTargetPlatformFromPackage(split[0]);
+      String core = board.getPreferences().get("build.core");
+      if (core != null && core.contains(":")) {
+        String[] split = core.split(":", 2);
+        corePlatform = BaseNoGui.getCurrentTargetPlatformFromPackage(split[0]);
+      }
+
+      addProgrammersForPlatform(boardPlatform, programmerMenus, group);
+      if (corePlatform != null)
+        addProgrammersForPlatform(corePlatform, programmerMenus, group);
     }
-
-    addProgrammersForPlatform(boardPlatform, programmerMenus, group);
-    if (corePlatform != null)
-      addProgrammersForPlatform(corePlatform, programmerMenus, group);
 
     if (programmerMenus.isEmpty()) {
       JMenuItem item = new JMenuItem(tr("No programmers available for this board"));


### PR DESCRIPTION
rebuildProgrammerMenu: Handle no current board

This can happen happen in some unlikely cases (such as when renaming a
platform in a way that breaks the "select a board when none is selected
logic").

Even though a board should always be selected, code should still handle
no selected board gracefully (rather than raising a NullPointerException
like this used to do).

See #10887 for the underlying issue that caused no board to be selected.


### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?
