### PR TITLE
Add Shift+click on serial monitor toolbar button to open serial plotter

### DIFF
--- a/app/src/processing/app/EditorToolbar.java
+++ b/app/src/processing/app/EditorToolbar.java
@@ -62,7 +62,7 @@ public class EditorToolbar extends JComponent implements MouseInputListener, Key
    * Titles for each button when the shift key is pressed.
    */
   private static final String[] titleShift = {
-    tr("Verify"), tr("Upload Using Programmer"), tr("New"), tr("Open"), tr("Save As..."), tr("Serial Monitor")
+    tr("Verify"), tr("Upload Using Programmer"), tr("New"), tr("Open"), tr("Save As..."), tr("Serial Plotter")
   };
 
   private static final int BUTTON_COUNT = title.length;
@@ -500,7 +500,11 @@ public class EditorToolbar extends JComponent implements MouseInputListener, Key
         break;
 
       case SERIAL:
-        editor.handleSerial();
+        if (isShiftDown) {
+          editor.handlePlotter();
+        } else {
+          editor.handleSerial();
+        }
         break;
 
       default:


### PR DESCRIPTION
## Feature
The change involves the _Serial Monitor button_ on the toolbar.
- **Before**: click to open Serial Monitor, shift+click to open Serial Monitor
- **After**: click to open Serial Monitor, shift+click to open Serial Plotter

<img src="https://user-images.githubusercontent.com/62206011/101081071-de48f300-35a9-11eb-80d1-7882c4c4a431.png" height="130">

## Changed files
- app/src/processing/app/EditorToolbar.java

## Details
I added the `if(isShiftDown)` check on the Serial Monitor button, too. In case of Shift being pressed down, `editor.handlePlotter()` is invoked. I changed the title of the button accordingly to this.
As you can see in the picture, works fine on Windows.

