### PR TITLE
Board Manager: searching returns also near matches

### DIFF
--- a/app/src/cc/arduino/contributions/packages/ui/ContributedPlatformReleases.java
+++ b/app/src/cc/arduino/contributions/packages/ui/ContributedPlatformReleases.java
@@ -59,6 +59,12 @@ public class ContributedPlatformReleases {
     return platform.getArchitecture().equals(arch);
   }
 
+  public boolean contains(ContributedPlatform platform) {
+    return (platform.getParentPackage().equals(packager)
+        && platform.getArchitecture().equals(arch)
+        && versions.contains(platform.getParsedVersion()));
+  }
+
   public void add(ContributedPlatform platform) {
     releases.add(platform);
     String version = platform.getParsedVersion();

--- a/app/src/cc/arduino/contributions/packages/ui/ContributionIndexTableModel.java
+++ b/app/src/cc/arduino/contributions/packages/ui/ContributionIndexTableModel.java
@@ -65,11 +65,21 @@ public class ContributionIndexTableModel
                                           + platform.getBoards().stream()
                                               .map(ContributedBoard::getName)
                                               .collect(Collectors.joining(" "));
+
+        // Add all the versions of the same core, even if there's no match
+        for (ContributedPlatformReleases contribution : contributions) {
+          if (contribution.shouldContain(platform)) {
+            addContribution(platform);
+            continue;
+          }
+        }
+
         if (!filter.test(platform)) {
           continue;
         }
         if (!stringContainsAll(compoundTargetSearchText, filters))
           continue;
+
         addContribution(platform);
       }
     }
@@ -97,12 +107,16 @@ public class ContributionIndexTableModel
 
   private void addContribution(ContributedPlatform platform) {
     for (ContributedPlatformReleases contribution : contributions) {
-      if (!contribution.shouldContain(platform))
+      if (!contribution.shouldContain(platform)) {
         continue;
+      }
+      if (contribution.contains(platform)) {
+        // no duplicates
+        return;
+      }
       contribution.add(platform);
       return;
     }
-
     contributions.add(new ContributedPlatformReleases(platform));
   }
 


### PR DESCRIPTION
The original filter would only populate the contribution list with perfect matches.

Previously, if a core was installed but didn't match the search it wouldn't appear in the results (due to a board being added or the description changed);
the user could then install (not upgrade) the core, triggering a confusing situation.

When moving to arduino-cli backend we should take care of this issue, at least visually (the cli logic would correctly update/downgrade the core)

@per1234 I couldn't find the relevant issues for this fix; I'm quite sure there are a couple :slightly_smiling_face: 
 It would be great you can cross reference them here.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes
