### PR TITLE
Add the ability to find libraries in sketch folder.

### DIFF
--- a/app/src/cc/arduino/view/preferences/Preferences.form
+++ b/app/src/cc/arduino/view/preferences/Preferences.form
@@ -480,6 +480,13 @@
                         </Property>
                       </Properties>
                     </Component>
+                    <Component class="javax.swing.JCheckBox" name="loadSketchLibrariesBox">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                          <Connection code="tr(&quot;Use libraries in sketch folder&quot;)" type="code"/>
+                        </Property>
+                      </Properties>
+                    </Component>
                   </SubComponents>
                 </Container>
                 <Component class="javax.swing.JLabel" name="jLabel1">

--- a/app/src/cc/arduino/view/preferences/Preferences.java
+++ b/app/src/cc/arduino/view/preferences/Preferences.java
@@ -135,6 +135,7 @@ public class Preferences extends javax.swing.JDialog {
     checkUpdatesBox = new javax.swing.JCheckBox();
     saveVerifyUploadBox = new javax.swing.JCheckBox();
     accessibleIDEBox = new javax.swing.JCheckBox();
+    loadSketchLibrariesBox = new javax.swing.JCheckBox();
     jLabel1 = new javax.swing.JLabel();
     jLabel2 = new javax.swing.JLabel();
     scaleSpinner = new javax.swing.JSpinner();
@@ -284,6 +285,9 @@ public class Preferences extends javax.swing.JDialog {
 
     accessibleIDEBox.setText(tr("Use accessibility features"));
     checkboxesContainer.add(accessibleIDEBox);
+
+	loadSketchLibrariesBox.setText(tr("Use libraries in sketch folder"));
+	checkboxesContainer.add(loadSketchLibrariesBox);
 
     jLabel1.setText(tr("Interface scale:"));
 
@@ -718,6 +722,7 @@ public class Preferences extends javax.swing.JDialog {
   private javax.swing.JButton browseButton;
   private javax.swing.JCheckBox checkUpdatesBox;
   private javax.swing.JCheckBox accessibleIDEBox;
+  private javax.swing.JCheckBox loadSketchLibrariesBox;
   private javax.swing.JPanel checkboxesContainer;
   private javax.swing.JComboBox comboLanguage;
   private javax.swing.JLabel comboLanguageLabel;
@@ -833,6 +838,8 @@ public class Preferences extends javax.swing.JDialog {
 
     PreferencesData.setBoolean("ide.accessible", accessibleIDEBox.isSelected());
 
+    PreferencesData.setBoolean("build.load_sketch_libraries",loadSketchLibrariesBox.isSelected());
+
     PreferencesData.set("boardsmanager.additional.urls", additionalBoardsManagerField.getText().replace("\r\n", "\n").replace("\r", "\n").replace("\n", ","));
 
     PreferencesData.set(Constants.PREF_PROXY_TYPE, proxyTypeButtonGroup.getSelection().getActionCommand());
@@ -912,6 +919,8 @@ public class Preferences extends javax.swing.JDialog {
     }
 
     accessibleIDEBox.setSelected(PreferencesData.getBoolean("ide.accessible"));
+
+    loadSketchLibrariesBox.setSelected(PreferencesData.getBoolean("build.load_sketch_libraries"));
 
     saveVerifyUploadBox.setSelected(PreferencesData.getBoolean("editor.save_on_verify"));
 

--- a/arduino-core/src/cc/arduino/Compiler.java
+++ b/arduino-core/src/cc/arduino/Compiler.java
@@ -246,7 +246,13 @@ public class Compiler implements MessageConsumer {
     addPathFlagIfPathExists(cmd, "-tools", Paths.get(BaseNoGui.getHardwarePath(), "tools", "avr").toFile());
     addPathFlagIfPathExists(cmd, "-tools", installedPackagesFolder);
 
+    if(PreferencesData.getBoolean("build.load_sketch_libraries") == true) {
+        addPathFlagIfPathExists(cmd, "-libraries",Paths.get(sketch.getFolder().getAbsolutePath(),"libraries").toFile());
+    }
+
     addPathFlagIfPathExists(cmd, "-built-in-libraries", BaseNoGui.getContentFile("libraries"));
+
+   
     addPathFlagIfPathExists(cmd, "-libraries", BaseNoGui.getSketchbookLibrariesFolder().folder);
 
     String fqbn = Stream.of(aPackage.getId(), platform.getId(), board.getId(), boardOptions(board)).filter(s -> !s.isEmpty()).collect(Collectors.joining(":"));

--- a/build/shared/lib/preferences.txt
+++ b/build/shared/lib/preferences.txt
@@ -269,6 +269,10 @@ programmer = arduino:avrispmkii
 upload.using = bootloader
 upload.verify = true
 
+# This is true if the arduino IDE will try to load libraries from <Sketch>/libraries
+# This is false by default to maintain backwards compatibility 
+build.load_sketch_libraries = false
+
 # default port is not defined to prevent running AVRDUDE before Port selected (issue #7943)
 #serial.port=
 serial.databits=8


### PR DESCRIPTION
### Feature Explaination:

This is a patch to allow the user to search sketches by default in the <Sketch>/libraries folder if it exists.  This feature is referenced and/or requested here:

https://github.com/arduino/arduino-builder/pull/223
https://github.com/arduino/Arduino/issues/4936
https://github.com/arduino/Arduino/issues/4936#issuecomment-436803575
https://github.com/arduino/Arduino/issues/9507
https://github.com/arduino/Arduino/issues/7755
https://github.com/arduino/Arduino/issues/11106

This adds this feature to the Arduino IDE provided that the user has enabled it in their preferences.  This preference is disabled by default in order to avoid breaking past behavior by default (in the exceedingly unlikely case that the user had a libraries directory in their sketch that they did NOT wish to be compiled).

This feature is not needed to be implemented in arduino-cli, because the user of arduino-cli could always manually add "--libraries `pwd`" or similar very easily in their command line build.  However, it may be a good idea to add by default as a potential future feature.


### All Submissions:

* [X ] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Have you lint your code locally prior to submission?

