### PR TITLE
Fix status bar custom board preferences disappearing

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -2587,12 +2587,7 @@ public class Editor extends JFrame implements RunnerListener {
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 
   protected void onBoardOrPortChange() {
-    TargetBoard board = BaseNoGui.getTargetBoard();
-    if (board != null)
-      lineStatus.setBoardName(board.getName());
-    else
-      lineStatus.setBoardName("-");
-    lineStatus.setPort(PreferencesData.get("serial.port"));
+    lineStatus.updateBoardAndPort();
     lineStatus.repaint();
   }
 

--- a/app/src/processing/app/EditorLineStatus.java
+++ b/app/src/processing/app/EditorLineStatus.java
@@ -92,12 +92,7 @@ public class EditorLineStatus extends JComponent {
   public void paintComponent(Graphics graphics) {
     Graphics2D g = Theme.setupGraphics2D(graphics);
     if (name.isEmpty() && port.isEmpty()) {
-      PreferencesMap boardPreferences = BaseNoGui.getBoardPreferences();
-      if (boardPreferences != null)
-        setBoardName(boardPreferences.get("name"));
-      else
-        setBoardName("-");
-      setPort(PreferencesData.get("serial.port"));
+      updateBoardAndPort();
     }
     g.setColor(background);
     Dimension size = getSize();
@@ -145,5 +140,14 @@ public class EditorLineStatus extends JComponent {
 
   public Dimension getMaximumSize() {
     return scale(new Dimension(3000, height));
+  }
+
+  public void updateBoardAndPort() {
+    PreferencesMap boardPreferences = BaseNoGui.getBoardPreferences();
+    if (boardPreferences != null)
+      setBoardName(boardPreferences.get("name"));
+    else
+      setBoardName("-");
+    setPort(PreferencesData.get("serial.port"));
   }
 }


### PR DESCRIPTION
This commit fixes #11164

The cause of the bug was that although EditorLineStatus' "paintComponent" function correctly calls "getBoardPreferences" which accounts for any custom board preferences, Editor's "onBoardOrPortChange" incorrectly calls "getTargetBoard" which only account for the board name.

That's why the board settings appear at first but any change to the board settings makes them disappear.
My fix was to simply call "getBoardPreferences" in Editor's "onBoardOrPortChange" just like the implementation in EditorLineStatus.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes
