### PR TITLE
Update links to troubleshooting guides in error messages

### DIFF
--- a/arduino-core/src/cc/arduino/Compiler.java
+++ b/arduino-core/src/cc/arduino/Compiler.java
@@ -101,8 +101,8 @@ public class Compiler implements MessageConsumer {
     tr("Couldn't determine program size: {0}");
     tr("Global variables use {0} bytes ({2}%%) of dynamic memory, leaving {3} bytes for local variables. Maximum is {1} bytes.");
     tr("Global variables use {0} bytes of dynamic memory.");
-    tr("Sketch too big; see http://www.arduino.cc/en/Guide/Troubleshooting#size for tips on reducing it.");
-    tr("Not enough memory; see http://www.arduino.cc/en/Guide/Troubleshooting#size for tips on reducing your footprint.");
+    tr("Sketch too big; see https://support.arduino.cc/hc/en-us/articles/360013825179 for tips on reducing it.");
+    tr("Not enough memory; see https://support.arduino.cc/hc/en-us/articles/360013825179 for tips on reducing your footprint.");
     tr("Low memory available, stability problems may occur.");
     tr("An error occurred while verifying the sketch");
     tr("An error occurred while verifying/uploading the sketch");

--- a/arduino-core/src/cc/arduino/packages/Uploader.java
+++ b/arduino-core/src/cc/arduino/packages/Uploader.java
@@ -176,7 +176,7 @@ public abstract class Uploader implements MessageConsumer {
       return;
     }
     if (StringUtils.containsAny(s, AVRDUDE_PROBLEMS)) {
-      error = tr("Problem uploading to board.  See http://www.arduino.cc/en/Guide/Troubleshooting#upload for suggestions.");
+      error = tr("Problem uploading to board.  See https://support.arduino.cc/hc/en-us/sections/360003198300 for suggestions.");
       return;
     }
     if (s.contains("Expected signature")) {


### PR DESCRIPTION
When the compiled size of a sketch exceeds the available flash or RAM on the board, the error message includes a link to
a troubleshooting guide:
```
Sketch uses 16110 bytes (112%) of program storage space. Maximum is 14336 bytes.
Global variables use 685 bytes (66%) of dynamic memory, leaving 339 bytes for local variables. Maximum is 1024 bytes.
Sketch too big; see http://www.arduino.cc/en/Guide/Troubleshooting#size for tips on reducing it.
```
Archived copy here: https://web.archive.org/web/20200320112114/https://www.arduino.cc/en/Guide/Troubleshooting#size

When an upload fails, the error message includes a link to a troubleshooting guide:
```
Problem uploading to board.  See http://www.arduino.cc/en/Guide/Troubleshooting#upload for suggestions.
```
Archived copy here: https://web.archive.org/web/20200320112114/https://www.arduino.cc/en/Guide/Troubleshooting#upload

http://www.arduino.cc/en/Guide/Troubleshooting was recently replaced with the Arduino Help Center. Even though that URL
redirects to the Help Center, it only goes to the home page, leaving the user to hunt for the relevant article.

A better user experience is provided by linking directly to the relevant content in the Help Center:
- https://support.arduino.cc/hc/en-us/articles/360013825179
- https://support.arduino.cc/hc/en-us/sections/360003198300

---
Fixes https://github.com/arduino/Arduino/issues/11382
Fixes https://github.com/arduino/Arduino/issues/11140

Related: https://github.com/arduino/arduino-cli/pull/1197