### PR TITLE
Make Custom menus scrollable

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1473,6 +1473,7 @@ public class Base {
           customMenu.putClientProperty("platform", getPlatformUniqueId(targetPlatform));
           customMenu.putClientProperty("removeOnWindowDeactivation", true);
           boardsCustomMenus.add(customMenu);
+          MenuScroller.setScrollerFor(customMenu);
         }
       }
     }

--- a/app/src/processing/app/tools/MenuScroller.java
+++ b/app/src/processing/app/tools/MenuScroller.java
@@ -34,6 +34,7 @@ public class MenuScroller {
 
   private JPopupMenu menu;
   private Component[] menuItems;
+  private Component[] allMenuItems;
   private MenuScrollItem upItem;
   private MenuScrollItem downItem;
   private final MenuScrollListener menuListener = new MenuScrollListener();
@@ -540,7 +541,8 @@ public class MenuScroller {
     }
 
     private void setMenuItems() {
-      menuItems = Arrays.stream(menu.getComponents()).filter(x -> x.isVisible()).toArray(Component[]::new);
+      allMenuItems = menu.getComponents();
+      menuItems = Arrays.stream(allMenuItems).filter(x -> x.isVisible()).toArray(Component[]::new);
       if (keepVisibleIndex >= topFixedCount
         && keepVisibleIndex <= menuItems.length - bottomFixedCount
         && (keepVisibleIndex > firstIndex + scrollCount
@@ -555,7 +557,7 @@ public class MenuScroller {
 
     private void restoreMenuItems() {
       menu.removeAll();
-      for (Component component : menuItems) {
+      for (Component component : allMenuItems) {
         menu.add(component);
       }
     }

--- a/app/src/processing/app/tools/MenuScroller.java
+++ b/app/src/processing/app/tools/MenuScroller.java
@@ -16,6 +16,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
 import java.awt.event.KeyEvent;
+import java.util.Arrays;
 
 /**
  * A class that provides scrolling capabilities to a long menu dropdown or
@@ -539,7 +540,7 @@ public class MenuScroller {
     }
 
     private void setMenuItems() {
-      menuItems = menu.getComponents();
+      menuItems = Arrays.stream(menu.getComponents()).filter(x -> x.isVisible()).toArray(Component[]::new);
       if (keepVisibleIndex >= topFixedCount
         && keepVisibleIndex <= menuItems.length - bottomFixedCount
         && (keepVisibleIndex > firstIndex + scrollCount


### PR DESCRIPTION
Fixes #11416

The patch on MenuScroller.java is needed to avoid a clash between custom menus with the same label.
This behaviour artificially increases the amount of objects that the scroller will calculate.
Eg. if two boards share the same custom menu, that menu will contain the properties for both the boards (since it's parsed twice).

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes
