### PR TITLE
Added basic "deprecation" support for platforms

### DIFF
--- a/app/src/cc/arduino/contributions/packages/ui/ContributedPlatformReleases.java
+++ b/app/src/cc/arduino/contributions/packages/ui/ContributedPlatformReleases.java
@@ -44,12 +44,14 @@ public class ContributedPlatformReleases {
   public final List<ContributedPlatform> releases;
   public final List<String> versions;
   public ContributedPlatform selected = null;
+  public boolean deprecated;
 
   public ContributedPlatformReleases(ContributedPlatform platform) {
     packager = platform.getParentPackage();
     arch = platform.getArchitecture();
     releases = new LinkedList<>();
     versions = new LinkedList<>();
+    deprecated = platform.isDeprecated();
     add(platform);
   }
 
@@ -65,7 +67,9 @@ public class ContributedPlatformReleases {
     if (version != null) {
       versions.add(version);
     }
-    selected = getLatest();
+    ContributedPlatform latest = getLatest();
+    selected = latest;
+    deprecated = latest.isDeprecated();
   }
 
   public ContributedPlatform getInstalled() {
@@ -87,6 +91,10 @@ public class ContributedPlatformReleases {
 
   public ContributedPlatform getSelected() {
     return selected;
+  }
+
+  public boolean isDeprecated() {
+    return deprecated;
   }
 
   public void select(ContributedPlatform value) {

--- a/app/src/cc/arduino/contributions/packages/ui/ContributedPlatformTableCellJPanel.java
+++ b/app/src/cc/arduino/contributions/packages/ui/ContributedPlatformTableCellJPanel.java
@@ -232,6 +232,9 @@ public class ContributedPlatformTableCellJPanel extends JPanel {
               + format(tr("version <b>{0}</b>"), installed.getParsedVersion())
               + " <strong><font color=\"#00979D\">INSTALLED</font></strong>";
     }
+    if (releases.isDeprecated()) {
+      desc += " <strong><font color=\"#C03030\">DEPRECATED</font></strong>";
+    }
     desc += "<br />";
 
     desc += tr("Boards included in this package:") + "<br />";

--- a/app/src/cc/arduino/contributions/packages/ui/ContributionIndexTableModel.java
+++ b/app/src/cc/arduino/contributions/packages/ui/ContributionIndexTableModel.java
@@ -36,6 +36,7 @@ import cc.arduino.contributions.ui.FilteredAbstractTableModel;
 import processing.app.BaseNoGui;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -73,6 +74,18 @@ public class ContributionIndexTableModel
         addContribution(platform);
       }
     }
+    Collections.sort(contributions, (x,y)-> {
+      if (x.isDeprecated() != y.isDeprecated()) {
+        return x.isDeprecated() ? 1 : -1;
+      }
+      ContributedPlatform x1 = x.getLatest();
+      ContributedPlatform y1 = y.getLatest();
+      int category = (x1.getCategory().equals("Arduino") ? -1 : 0) + (y1.getCategory().equals("Arduino") ? 1 : 0);
+      if (category != 0) {
+        return category;
+      }
+      return x1.getName().compareToIgnoreCase(y1.getName());
+    });
     fireTableDataChanged();
   }
 

--- a/arduino-core/src/cc/arduino/contributions/packages/ContributedPlatform.java
+++ b/arduino-core/src/cc/arduino/contributions/packages/ContributedPlatform.java
@@ -29,11 +29,18 @@
 
 package cc.arduino.contributions.packages;
 
-import cc.arduino.contributions.DownloadableContribution;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-import java.io.File;
-import java.util.*;
+import cc.arduino.contributions.DownloadableContribution;
 
 public class ContributedPlatform extends DownloadableContribution {
 
@@ -45,8 +52,8 @@ public class ContributedPlatform extends DownloadableContribution {
   private String category;
   private String architecture;
   private String checksum;
-  private ArrayList<ContributedToolReference> toolsDependencies = new ArrayList<ContributedToolReference>();
-  private ArrayList<ContributedBoard> boards = new ArrayList<ContributedBoard>();
+  private ArrayList<ContributedToolReference> toolsDependencies = new ArrayList<>();
+  private ArrayList<ContributedBoard> boards = new ArrayList<>();
   private ContributedHelp help;
   private boolean installed;
   private File installedFolder;
@@ -54,12 +61,16 @@ public class ContributedPlatform extends DownloadableContribution {
   private Map<ContributedToolReference, ContributedTool> resolvedToolReferences;
   private ContributedPackage parentPackage;
 
+  @Override
   public String getUrl() { return url; }
 
+  @Override
   public String getVersion() { return version; }
 
+  @Override
   public long getSize() { return size; }
 
+  @Override
   public String getArchiveFileName() { return archiveFileName; }
 
   public String getName() { return name; }

--- a/arduino-core/src/cc/arduino/contributions/packages/ContributedPlatform.java
+++ b/arduino-core/src/cc/arduino/contributions/packages/ContributedPlatform.java
@@ -60,6 +60,7 @@ public class ContributedPlatform extends DownloadableContribution {
   private boolean builtIn;
   private Map<ContributedToolReference, ContributedTool> resolvedToolReferences;
   private ContributedPackage parentPackage;
+  private boolean deprecated;
 
   @Override
   public String getUrl() { return url; }
@@ -155,6 +156,14 @@ public class ContributedPlatform extends DownloadableContribution {
 
   public void setParentPackage(ContributedPackage parentPackage) {
     this.parentPackage = parentPackage;
+  }
+
+  public boolean isDeprecated() {
+    return deprecated;
+  }
+
+  public void setDeprecated(boolean deprecated) {
+    this.deprecated = deprecated;
   }
 
   @Override


### PR DESCRIPTION
The IDE now supports a `deprecated` field in the package_index.json at the platform release level:

```
    {
      "name": "arduino",
      "maintainer": "Arduino",
      "websiteURL": "http://www.arduino.cc/",
      "email": "packages@arduino.cc",
      "help": {
        "online": "http://www.arduino.cc/en/Reference/HomePage"
      },
      "platforms": [
        {
          "name": "[DEPRECATED - Please install standalone packages] Arduino Mbed OS Boards",
          "architecture": "mbed",
          "version": "2.0.2",
          "deprecated": true,             <--------
          "category": "Arduino",
          "url": "http://downloads.arduino.cc/cores/staging/ArduinoCore-mbed-2.0.2.tar.bz2",
          "archiveFileName": "ArduinoCore-mbed-2.0.2.tar.bz2",
          "checksum": "SHA-256:51b261ca0b11cd98f6e91d660ef2338e462c45b2ece20b527b74c13b51dbcad2",
```

if the latest version of a platform is marked `deprecated` then the whole platform is labeled as deprecated and moved to the bottom of the list.

![image](https://user-images.githubusercontent.com/423515/117626627-9a20d680-b177-11eb-9d73-bf87e63222bc.png)

this should discourage users from installing it, BTW no other actions are done to prevent it.
