### PR TITLE
Fixed case-insensitive name check in checkSketchFile

### DIFF
--- a/arduino-core/src/processing/app/Sketch.java
+++ b/arduino-core/src/processing/app/Sketch.java
@@ -68,10 +68,10 @@ public class Sketch {
     if (pdeName.equals(fileName) || inoName.equals(fileName))
       return file;
 
-    if (altPdeFile.exists())
+    if (FileUtils.fileExistsCaseSensitive(altPdeFile, pdeName))
       return altPdeFile;
 
-    if (altInoFile.exists())
+    if (FileUtils.fileExistsCaseSensitive(altInoFile, inoName))
       return altInoFile;
 
     return null;

--- a/arduino-core/src/processing/app/helpers/FileUtils.java
+++ b/arduino-core/src/processing/app/helpers/FileUtils.java
@@ -309,4 +309,20 @@ public class FileUtils {
     return result;
   }
 
+  /**
+   * Checks for the existence of a file with the given name but accounts
+   * for case-sensitivity on case-insensitive file systems.
+   * https://stackoverflow.com/a/34730781
+   *
+   * @param file The file being checked
+   * @param name The actual name the file is expected to have
+   */
+  public static boolean fileExistsCaseSensitive(File file, String name) {
+    try {
+        return file.exists() && file.getCanonicalFile().getName().equals(name);
+    } catch (IOException e) {
+        return false;
+    }
+  }
+
 }


### PR DESCRIPTION
This commit fixes #8030

It turns out that on case-insensitive file systems, the "file.exists" check will return true even if the file that actually exists differs from the file being checked in the case of the letters. (i.e. "Test.ino" will be considered to exist even if the actual file name is "test.ino").
The proposed solution is to make use of the function getCanonicalFile as suggested in [this StackOverflow answer](https://stackoverflow.com/a/34730781) to get the actual file name and compare it to the expected name.

I decided to implement a function in FileUtils for better code reuse but it could have been inlined as well since this is its only use-case currently.

### All Submissions:

* [ x ] Have you followed the guidelines in our Contributing document?
* [ x ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?

### Changes to Core Features:

* [ x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ x ] Have you successfully ran tests with your changes
