### PR TITLE
Fix trimming

### DIFF
--- a/arduino-core/src/processing/app/BaseNoGui.java
+++ b/arduino-core/src/processing/app/BaseNoGui.java
@@ -888,8 +888,8 @@ public class BaseNoGui {
     // then trim any other character (\r) so saveStrings can print it in the correct
     // format for every OS
     String strArray[] = str.split("\n");
-    for (String item : strArray) {
-      item.trim();
+    for (int i = 0; i < strArray.length; i++) {
+      strArray[i] = strArray[i].trim();
     }
     PApplet.saveStrings(temp, strArray);
 


### PR DESCRIPTION
The trim() method returns a new trimmed string, it does not alter the current string (strings being immutable in Java).

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes
