### PR TITLE
Fix trimming: trim() return value should be used.

### DIFF
--- a/arduino-core/src/processing/app/BaseNoGui.java
+++ b/arduino-core/src/processing/app/BaseNoGui.java
@@ -888,9 +888,7 @@ public class BaseNoGui {
     // then trim any other character (\r) so saveStrings can print it in the correct
     // format for every OS
     String strArray[] = str.split("\n");
-    for (String item : strArray) {
-      item.trim();
-    }
+    Arrays.parallelSetAll(strArray, i -> strArray[i].trim());
     PApplet.saveStrings(temp, strArray);
 
     try {


### PR DESCRIPTION
The trim() method returns a new trimmed string, it does not alter the current string (strings being immutable in Java).

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes
