### PR TITLE
Optimize: Improve performance using StringBuilder and reducing map lookups

### DIFF
--- a/app/src/processing/app/tools/FixEncoding.java
+++ b/app/src/processing/app/tools/FixEncoding.java
@@ -84,7 +84,7 @@ public class FixEncoding implements Tool {
     try {
       reader = new BufferedReader(new FileReader(file));
 
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       String line;
       while ((line = reader.readLine()) != null) {
         buffer.append(line);

--- a/arduino-core/src/cc/arduino/contributions/packages/ContributionsIndexer.java
+++ b/arduino-core/src/cc/arduino/contributions/packages/ContributionsIndexer.java
@@ -273,8 +273,9 @@ public class ContributionsIndexer {
         if (!versionsFile.isFile())
           continue;
         PreferencesMap toolsVersion = new PreferencesMap(versionsFile).subTree(pack.getName());
-        for (String name : toolsVersion.keySet()) {
-          String version = toolsVersion.get(name);
+        for (Map.Entry<String, String> toolsVersionEntry : toolsVersion.entrySet()) {
+          String name = toolsVersionEntry.getKey();
+          String version = toolsVersionEntry.getValue();
           ContributedTool tool = syncToolWithFilesystem(pack, toolFolder, name, version);
           if (tool != null)
             tool.setBuiltIn(true);

--- a/arduino-core/src/cc/arduino/packages/BoardPort.java
+++ b/arduino-core/src/cc/arduino/packages/BoardPort.java
@@ -29,6 +29,8 @@
 
 package cc.arduino.packages;
 
+import java.util.Map;
+
 import processing.app.BaseNoGui;
 import processing.app.debug.TargetBoard;
 import processing.app.debug.TargetPackage;
@@ -176,8 +178,9 @@ public class BoardPort {
 
     for (int suffix = 0;; suffix++) {
       boolean found = true;
-      for (String prop : identificationProps.keySet()) {
-        String value = identificationProps.get(prop);
+      for (Map.Entry<String, String> identificationPropsEntry : identificationProps.entrySet()) {
+        String prop = identificationPropsEntry.getKey();
+        String value = identificationPropsEntry.getValue();
         prop += "." + suffix;
         if (!boardProps.containsKey(prop)) {
           return false;

--- a/arduino-core/src/processing/app/BaseNoGui.java
+++ b/arduino-core/src/processing/app/BaseNoGui.java
@@ -849,7 +849,7 @@ public class BaseNoGui {
    */
   static public String sanitizeName(String origName) {
     char c[] = origName.toCharArray();
-    StringBuffer buffer = new StringBuffer();
+    StringBuilder buffer = new StringBuilder();
 
     for (int i = 0; i < c.length; i++) {
       if (((c[i] >= '0') && (c[i] <= '9')) ||

--- a/arduino-core/src/processing/app/legacy/PApplet.java
+++ b/arduino-core/src/processing/app/legacy/PApplet.java
@@ -161,7 +161,7 @@ public class PApplet {
    *      // list is now "apple, bear, cat"</PRE>
    */
   static public String join(String str[], String separator) {
-    StringBuffer buffer = new StringBuffer();
+    StringBuilder buffer = new StringBuilder();
     for (int i = 0; i < str.length; i++) {
       if (i != 0) buffer.append(separator);
       buffer.append(str[i]);


### PR DESCRIPTION
These are performance improvements with no new functionality.   

StringBuilder will perform faster than StringBuffer as synchronization does not need to occur in these locations.  
Iterating over an entrySet rather than a keySet and then looking up the entry will eliminate the need for N lookups.

### All Submissions:

* [X ] Have you followed the guidelines in our Contributing document?
* [X ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X ] Does your submission pass tests?
2. [X ] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [ NA ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ Existing Tests cover ] Have you written new tests for your core changes, as applicable?
* [ Yes ] Have you successfully ran tests with your changes
