### PR TITLE
Make 20 colors available for line plots

### DIFF
--- a/build/shared/lib/theme/theme.txt
+++ b/build/shared/lib/theme/theme.txt
@@ -41,15 +41,29 @@ plotting.bgcolor = #ffffff
 plotting.color = #ffffff
 plotting.gridcolor = #f0f0f0
 plotting.boundscolor = #000000
-plotting.graphcolor.size = 8
-plotting.graphcolor.00 = #0000FF
-plotting.graphcolor.01 = #FF0000
-plotting.graphcolor.02 = #009900
-plotting.graphcolor.03 = #FF9900
-plotting.graphcolor.04 = #CC00CC
-plotting.graphcolor.05 = #666666
-plotting.graphcolor.06 = #00CCFF
-plotting.graphcolor.07 = #000000
+plotting.graphcolor.size = 20
+# These are the python matplotlib tab20 colors
+# ``` for c in plt.cm.tab20.colors: print(matplotlib.colors.to_hex(c)) ```
+plotting.graphcolor.00 = #1F77B4
+plotting.graphcolor.01 = #AEC7E8
+plotting.graphcolor.02 = #FF7F0E
+plotting.graphcolor.03 = #FFBB78
+plotting.graphcolor.04 = #2CA02C
+plotting.graphcolor.05 = #98DF8A
+plotting.graphcolor.06 = #D62728
+plotting.graphcolor.07 = #FF9896
+plotting.graphcolor.08 = #9467BD
+plotting.graphcolor.09 = #C5B0D5
+plotting.graphcolor.10 = #8C564B
+plotting.graphcolor.11 = #C49C94
+plotting.graphcolor.12 = #E377C2
+plotting.graphcolor.13 = #F7B6D2
+plotting.graphcolor.14 = #7F7F7F
+plotting.graphcolor.15 = #C7C7C7
+plotting.graphcolor.16 = #BCBD22
+plotting.graphcolor.17 = #DBDB8D
+plotting.graphcolor.18 = #17BECF
+plotting.graphcolor.19 = #9EDAE5
 
 # GUI - LINESTATUS   
 linestatus.color = #ffffff


### PR DESCRIPTION
This change modifies `theme.txt` so that there are 20 colors available for Arduino's serial plotter. 

These colors are taken from matplotlib's [tab20 color theme](https://matplotlib.org/stable/tutorials/colors/colormaps.html#qualitative), and can be recreated like:

```sh
$ python3
Python 3.9.13 (main, May 24 2022, 21:13:51)
[Clang 13.1.6 (clang-1316.0.21.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import matplotlib
>>> import matplotlib.pyplot as plt
>>> for c in plt.cm.tab20.colors: print(matplotlib.colors.to_hex(c))
...
#1f77b4
#aec7e8
#ff7f0e
#ffbb78
#2ca02c
#98df8a
#d62728
#ff9896
#9467bd
#c5b0d5
#8c564b
#c49c94
#e377c2
#f7b6d2
#7f7f7f
#c7c7c7
#bcbd22
#dbdb8d
#17becf
#9edae5
```

This means that up to 20 individual time series can be plotted before the colors recycle, and these 20 colors are also reasonably different from each other so that you can tell them apart.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/arduino/Arduino/pulls?q=) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes
