### PR TITLE
Add RGB LED demo example for Arduino Giga R1 WiFi

### DIFF
--- a/hardware/arduino/mbed/variants/GIGA/Examples/GigaWiFi_RGB_LED_Demo/GigaWiFi_RGB_LED_Demo/GigaWiFi_RGB_LED_Demo.ino
+++ b/hardware/arduino/mbed/variants/GIGA/Examples/GigaWiFi_RGB_LED_Demo/GigaWiFi_RGB_LED_Demo/GigaWiFi_RGB_LED_Demo.ino
@@ -1,0 +1,153 @@
+/*
+  Arduino Giga WiFi – RGB LED Demonstration
+
+  This sketch showcases how to control the built-in RGB LED on the Arduino Giga R1 WiFi board. 
+  It demonstrates basic color mixing by setting the Red, Green, and Blue channels independently, allowing you to experiment with various color outputs.
+
+  Designed specifically for the Giga R1 WiFi, this example helps new users understand how to interface with onboard components without needing any external wiring.
+
+  Board Compatibility:
+  * Arduino Giga R1 WiFi (only) connected via USB-C.
+
+  Features Demonstrated:
+  * Direct control of RGB LED pins
+  * Simple timing with delay()
+  * Sequential color transitions
+
+  Available Commands (case-sensitive):
+    BLED   - Switch ON the RED channel of the RGB LED.
+    GLED   - Switch ON the GREEN channel of the RGB LED.
+    RLED   - Switch ON the BLUE channel of the RGB LED.
+    LEDoff - Switch OFF the LED.
+    BlinkB - Blink the LED in the Blue color channel.
+    BlinkG - Blink the LED in the Green color channel.
+    BlinkR - Blink the LED in the Red color channel.
+
+  Usage:
+  1. Upload the sketch to your Arduino Giga R1 WiFi.
+  2. Start the serial montior.
+  3. Interact by typing in any of the previous 7 commands.
+
+  Created:    09 April 2025
+  Author:     Ahmed Sharaf (Tech Forge International LLC)
+  License:    MIT
+*/
+
+// Global variables and constants
+String inputCommand = "";      // Buffer to store incoming Serial data.
+const int commandDelay = 500;  // Delay used for LED blinking in milliseconds (change according to your personal pereference).
+const int blinkCount = 5;      // Number of times to blink the LED (change according to your personal pereference).
+
+// Function declarations
+void processCommand(String command);
+void TurnOn(int led, String ledName);
+void BlinkLED(int led, String ledName);
+void TurnOffLED();
+
+void setup() {
+  // Initialize Serial communication at 115200 baud.
+  Serial.begin(115200);
+
+  // Wait for the serial port to connect (for native USB boards).
+  while (!Serial) {
+    ;  // Do nothing until Serial is ready.
+  }
+
+  // Configure LED pins as outputs.
+  pinMode(LEDB, OUTPUT);
+  pinMode(LEDG, OUTPUT);
+  pinMode(LEDR, OUTPUT);
+
+  // Turn off all LEDs at startup.
+  TurnOffLED();
+
+  // Display welcome message and available commands.
+  Serial.println("=========================================================");
+  Serial.println("           Arduino Giga WiFi | RGB LED Control");
+  Serial.println("=========================================================");
+  Serial.println("Enter one of the following 7 commands (case-sensitive):");
+  Serial.println("---------------------------------------------------------");
+  Serial.println("  RLED    : Switch ON the RED channel of the RGB LED.");
+  Serial.println("  GLED    : Switch ON the GREEN channel of the RGB LED.");
+  Serial.println("  BLED    : Switch ON the BLUE channel of the RGB LED.");
+  Serial.println("  LEDoff  : Switch OFF the RGB LED.");
+  Serial.println("  BlinkR  : Blink the LED in the RED color channel.");
+  Serial.println("  BlinkG  : Blink the LED in the GREEN color channel.");
+  Serial.println("  BlinkB  : Blink the LED in the BLUE color channel.");
+  Serial.println("---------------------------------------------------------");
+}
+
+void loop() {
+  // Read incoming serial data character-by-character.
+  while (Serial.available()) {
+    char c = Serial.read();
+    // Append characters to command buffer; ignore newline and comma delimiters.
+    if (c != '\n' && c != ',') {
+      inputCommand += c;
+    }
+    delay(2);  // Short delay to ensure complete data reception.
+  }
+
+  // If a command was received, process it.
+  if (inputCommand.length() > 0) {
+    inputCommand.trim();  // Remove any leading/trailing whitespace.
+    processCommand(inputCommand);
+    inputCommand = "";  // Clear the command buffer.
+    Serial.flush();     // Clear any leftover data in the Serial buffer.
+  }
+}
+
+// Processes the received command and triggers the corresponding action.
+void processCommand(String command) {
+  // Debug print for testing purposes
+  Serial.print("Received command: ");
+  Serial.println(command);
+
+  if (command == "BLED") {
+    TurnOn(LEDB, "Blue");
+  } else if (command == "GLED") {
+    TurnOn(LEDG, "Green");
+  } else if (command == "RLED") {
+    TurnOn(LEDR, "Red");
+  } else if (command == "LEDoff") {
+    TurnOffLED();
+    Serial.println("Turned off all LEDs.");
+  } else if (command == "BlinkB") {
+    BlinkLED(LEDB, "Blue");
+  } else if (command == "BlinkG") {
+    BlinkLED(LEDG, "Green");
+  } else if (command == "BlinkR") {
+    BlinkLED(LEDR, "Red");
+  } else {
+    Serial.println("Unrecognized command. Please try again using one of the 7 commands avaialble.");
+  }
+}
+
+// Activates the selected color channel of the RGB LED; assumes active LOW.
+void TurnOn(int led, String ledName) {
+  // Ensure the LED is off before switching to the selected color.
+  TurnOffLED();
+  digitalWrite(led, LOW);  // Activate the specified color channel.
+  Serial.println("Turned on the " + ledName + " LED.");
+}
+
+// Blinks the specified color channel of the RGB LED a given number of times.
+void BlinkLED(int led, String colorName) {
+  // Ensure all LEDs are off before blinking.
+  TurnOffLED();
+  Serial.println("Blinking the LED in " + colorName + " " + String(blinkCount) + " times.");
+  for (int i = 0; i < blinkCount; i++) {
+    digitalWrite(led, LOW);  // Turn LED ON with the specified color.
+    delay(commandDelay);
+    digitalWrite(led, HIGH);  // Turn LED OFF.
+    delay(commandDelay);
+  }
+}
+
+// Turns off all color channels of the integrated RGB LED; assumes active LOW.
+void TurnOffLED() {
+  digitalWrite(LEDB, HIGH);
+  digitalWrite(LEDG, HIGH);
+  digitalWrite(LEDR, HIGH);
+  delay(2);  // Short delay to ensure state change is registered.
+}

--- a/hardware/arduino/mbed/variants/GIGA/Examples/GigaWiFi_RGB_LED_Demo/GigaWiFi_RGB_LED_Demo/GigaWiFi_RGB_LED_Demo.ino
+++ b/hardware/arduino/mbed/variants/GIGA/Examples/GigaWiFi_RGB_LED_Demo/GigaWiFi_RGB_LED_Demo/GigaWiFi_RGB_LED_Demo.ino
@@ -1,32 +1,37 @@
 /*
   Arduino Giga WiFi – RGB LED Demonstration
 
-  This sketch showcases how to control the built-in RGB LED on the Arduino Giga R1 WiFi board. 
-  It demonstrates basic color mixing by setting the Red, Green, and Blue channels independently, allowing you to experiment with various color outputs.
+  This sketch showcases how to control the built-in RGB LED connected to the digital pins D86, D87 and D88 (Only RGB, not accessible as GPIO) on the Arduino Giga R1 WiFi board.
 
-  Designed specifically for the Giga R1 WiFi, this example helps new users understand how to interface with onboard components without needing any external wiring.
+  It demonstrates basic color mixing by setting the Red, Green, and Blue channels independently, allowing you to experiment with various color outputs without needing any external wiring.
+
+  Designed specifically for the Giga R1 WiFi, this example helps new users interface with the onboard RGB LED (whose channels are predefined) and understand timing and sequential transitions.
 
   Board Compatibility:
-  * Arduino Giga R1 WiFi (only) connected via USB-C.
+    * Arduino Giga R1 WiFi (only) connected via USB-C.
 
   Features Demonstrated:
-  * Direct control of RGB LED pins
-  * Simple timing with delay()
-  * Sequential color transitions
+    * Direct control of the built-in RGB LED channels
+    * Simple timing with delay()
+    * Sequential color transitions
 
   Available Commands (case-sensitive):
-    BLED   - Switch ON the RED channel of the RGB LED.
-    GLED   - Switch ON the GREEN channel of the RGB LED.
-    RLED   - Switch ON the BLUE channel of the RGB LED.
-    LEDoff - Switch OFF the LED.
-    BlinkB - Blink the LED in the Blue color channel.
-    BlinkG - Blink the LED in the Green color channel.
-    BlinkR - Blink the LED in the Red color channel.
+    RLED       - Turn on the LED in Red color.
+    GLED       - Turn on the LED in Green color.
+    BLED       - Turn on the LED in Blue color.
+    LEDoff     - Turn off the LED.
+    BlinkR     - Blink the LED in the Red channel (default 5 times).
+    BlinkG     - Blink the LED in the Green channel (default 5 times).
+    BlinkB     - Blink the LED in the Blue channel (default 5 times).
+    BlinkR(n)  - Blink the LED in the Red channel n times.
+    BlinkG(n)  - Blink the LED in the Green channel n times.
+    BlinkB(n)  - Blink the LED in the Blue channel n times.
+    ToggleRGB  - Blink the LED in an RGB sequence.
 
   Usage:
-  1. Upload the sketch to your Arduino Giga R1 WiFi.
-  2. Start the serial montior.
-  3. Interact by typing in any of the previous 7 commands.
+    1. Upload the sketch to your Arduino Giga R1 WiFi.
+    2. Open the Serial Monitor.
+    3. Type one of the above commands to control the LED.
 
   Created:    09 April 2025
   Author:     Ahmed Sharaf (Tech Forge International LLC)
@@ -34,120 +39,173 @@
 */
 
 // Global variables and constants
-String inputCommand = "";      // Buffer to store incoming Serial data.
-const int commandDelay = 500;  // Delay used for LED blinking in milliseconds (change according to your personal pereference).
-const int blinkCount = 5;      // Number of times to blink the LED (change according to your personal pereference).
+String inputCommand = "";         // Buffer to store incoming Serial data.
+const int commandDelay = 500;     // Delay for LED blinking in milliseconds.
+const int defaultBlinkCount = 5;  // Default number of blinks if not specified.
 
 // Function declarations
 void processCommand(String command);
-void TurnOn(int led, String ledName);
-void BlinkLED(int led, String ledName);
+void TurnOn(int led, String colorName);
+void BlinkLED(int led, String colorName, int numBlinks);
 void TurnOffLED();
+void ToggleRGB();
 
 void setup() {
   // Initialize Serial communication at 115200 baud.
   Serial.begin(115200);
+  while (!Serial) { /* Wait for Serial to be ready. */ }
 
-  // Wait for the serial port to connect (for native USB boards).
-  while (!Serial) {
-    ;  // Do nothing until Serial is ready.
-  }
+  // The built-in RGB LED channels are predefined—set them as outputs.
+  pinMode(LEDR, OUTPUT);  //Digital Pin D86 (Only RGB, not accessible as GPIO)
+  pinMode(LEDG, OUTPUT);  //Digital Pin D87 (Only RGB, not accessible as GPIO)
+  pinMode(LEDB, OUTPUT);  //Digital Pin D88 (Only RGB, not accessible as GPIO)
 
-  // Configure LED pins as outputs.
-  pinMode(LEDB, OUTPUT);
-  pinMode(LEDG, OUTPUT);
-  pinMode(LEDR, OUTPUT);
-
-  // Turn off all LEDs at startup.
+  // Ensure the LED is off at startup.
   TurnOffLED();
 
-  // Display welcome message and available commands.
-  Serial.println("=========================================================");
-  Serial.println("           Arduino Giga WiFi | RGB LED Control");
-  Serial.println("=========================================================");
-  Serial.println("Enter one of the following 7 commands (case-sensitive):");
-  Serial.println("---------------------------------------------------------");
-  Serial.println("  RLED    : Switch ON the RED channel of the RGB LED.");
-  Serial.println("  GLED    : Switch ON the GREEN channel of the RGB LED.");
-  Serial.println("  BLED    : Switch ON the BLUE channel of the RGB LED.");
-  Serial.println("  LEDoff  : Switch OFF the RGB LED.");
-  Serial.println("  BlinkR  : Blink the LED in the RED color channel.");
-  Serial.println("  BlinkG  : Blink the LED in the GREEN color channel.");
-  Serial.println("  BlinkB  : Blink the LED in the BLUE color channel.");
-  Serial.println("---------------------------------------------------------");
+  // Display the welcome message and available commands.
+  Serial.println("=========================================================================");
+  Serial.println("                  Arduino Giga WiFi | RGB LED Control");
+  Serial.println("=========================================================================");
+  Serial.println("Enter one of the following commands (case-sensitive):");
+  Serial.println("-------------------------------------------------------------------------");
+  Serial.println("  RLED        : Switch ON the LED in RED color.");
+  Serial.println("  GLED        : Switch ON the LED in GREEN color.");
+  Serial.println("  BLED        : Switch ON the LED in BLUE color.");
+  Serial.println("  LEDoff      : Switch OFF the LED.");
+  Serial.println("  BlinkR      : Blink the LED in the RED channel (default 5 times).");
+  Serial.println("  BlinkG      : Blink the LED in the GREEN channel (default 5 times).");
+  Serial.println("  BlinkB      : Blink the LED in the BLUE channel (default 5 times).");
+  Serial.println("  BlinkR(n)   : Blink the LED in RED n times.");
+  Serial.println("  BlinkG(n)   : Blink the LED in GREEN n times.");
+  Serial.println("  BlinkB(n)   : Blink the LED in BLUE n times.");
+  Serial.println("  ToggleRGB   : Blink the LED in an RGB sequence.");
+  Serial.println("-------------------------------------------------------------------------");
 }
 
 void loop() {
-  // Read incoming serial data character-by-character.
+  // Read incoming Serial data character-by-character.
   while (Serial.available()) {
     char c = Serial.read();
-    // Append characters to command buffer; ignore newline and comma delimiters.
+    // Append characters to the command buffer; ignore newline and comma delimiters.
     if (c != '\n' && c != ',') {
       inputCommand += c;
     }
-    delay(2);  // Short delay to ensure complete data reception.
+    delay(2);  // Small delay helps ensure the full command is received.
   }
 
-  // If a command was received, process it.
+  // Process the command if any command has been received.
   if (inputCommand.length() > 0) {
-    inputCommand.trim();  // Remove any leading/trailing whitespace.
+    inputCommand.trim(); // Remove any stray whitespace.
     processCommand(inputCommand);
-    inputCommand = "";  // Clear the command buffer.
-    Serial.flush();     // Clear any leftover data in the Serial buffer.
+    inputCommand = "";   // Clear the command buffer.
+    Serial.flush();      // Clear any leftover Serial data.
   }
 }
 
-// Processes the received command and triggers the corresponding action.
+// Parses and processes incoming commands.
 void processCommand(String command) {
-  // Debug print for testing purposes
-  Serial.print("Received command: ");
-  Serial.println(command);
+  Serial.println("Received command: " + String(command));  
 
-  if (command == "BLED") {
-    TurnOn(LEDB, "Blue");
-  } else if (command == "GLED") {
-    TurnOn(LEDG, "Green");
-  } else if (command == "RLED") {
+  // Parameterized blink commands.
+  if (command.startsWith("BlinkR(") && command.endsWith(")")) {
+    int numBlinks = command.substring(command.indexOf('(') + 1, command.indexOf(')')).toInt();
+    if (numBlinks > 0)
+      BlinkLED(LEDR, "Red", numBlinks);
+    else
+      Serial.println("Invalid number for BlinkR command.");
+  }
+  else if (command.startsWith("BlinkG(") && command.endsWith(")")) {
+    int numBlinks = command.substring(command.indexOf('(') + 1, command.indexOf(')')).toInt();
+    if (numBlinks > 0)
+      BlinkLED(LEDG, "Green", numBlinks);
+    else
+      Serial.println("Invalid number for BlinkG command.");
+  }
+  else if (command.startsWith("BlinkB(") && command.endsWith(")")) {
+    int numBlinks = command.substring(command.indexOf('(') + 1, command.indexOf(')')).toInt();
+    if (numBlinks > 0)
+      BlinkLED(LEDB, "Blue", numBlinks);
+    else
+      Serial.println("Invalid number for BlinkB command.");
+  }
+  // Default commands.
+  else if (command == "RLED") {
     TurnOn(LEDR, "Red");
-  } else if (command == "LEDoff") {
+  }
+  else if (command == "GLED") {
+    TurnOn(LEDG, "Green");
+  }
+  else if (command == "BLED") {
+    TurnOn(LEDB, "Blue");
+  }
+  else if (command == "LEDoff") {
     TurnOffLED();
-    Serial.println("Turned off all LEDs.");
-  } else if (command == "BlinkB") {
-    BlinkLED(LEDB, "Blue");
-  } else if (command == "BlinkG") {
-    BlinkLED(LEDG, "Green");
-  } else if (command == "BlinkR") {
-    BlinkLED(LEDR, "Red");
-  } else {
-    Serial.println("Unrecognized command. Please try again using one of the 7 commands avaialble.");
+    Serial.println("Turned off the LED.");
+  }
+  else if (command == "BlinkR") {
+    BlinkLED(LEDR, "Red", defaultBlinkCount);
+  }
+  else if (command == "BlinkG") {
+    BlinkLED(LEDG, "Green", defaultBlinkCount);
+  }
+  else if (command == "BlinkB") {
+    BlinkLED(LEDB, "Blue", defaultBlinkCount);
+  }
+  else if (command == "ToggleRGB") {
+    ToggleRGB();
+  }
+  else {
+    Serial.println("Unrecognized command. Please try one of the available commands.");
   }
 }
 
-// Activates the selected color channel of the RGB LED; assumes active LOW.
-void TurnOn(int led, String ledName) {
-  // Ensure the LED is off before switching to the selected color.
-  TurnOffLED();
-  digitalWrite(led, LOW);  // Activate the specified color channel.
-  Serial.println("Turned on the " + ledName + " LED.");
+// Turns on a specified LED color channel (active LOW logic).
+void TurnOn(int led, String colorName) {
+  TurnOffLED();                // Ensure only one channel is active.
+  digitalWrite(led, LOW);      // Activate the channel.
+  Serial.println("Turned on the LED in " + colorName + " color.");
 }
 
-// Blinks the specified color channel of the RGB LED a given number of times.
-void BlinkLED(int led, String colorName) {
-  // Ensure all LEDs are off before blinking.
-  TurnOffLED();
-  Serial.println("Blinking the LED in " + colorName + " " + String(blinkCount) + " times.");
-  for (int i = 0; i < blinkCount; i++) {
-    digitalWrite(led, LOW);  // Turn LED ON with the specified color.
+// Blinks the given LED channel a specified number of times.
+void BlinkLED(int led, String colorName, int numBlinks) {
+  TurnOffLED();  // Ensure all channels are off before blinking.
+  Serial.println("Blinking the LED in " + colorName + " " + String(numBlinks) + " times.");
+  for (int i = 0; i < numBlinks; i++) {
+    digitalWrite(led, LOW);    // Turn channel on.
     delay(commandDelay);
-    digitalWrite(led, HIGH);  // Turn LED OFF.
+    digitalWrite(led, HIGH);   // Turn channel off.
     delay(commandDelay);
   }
 }
 
-// Turns off all color channels of the integrated RGB LED; assumes active LOW.
+// Turns off all channels (assumes active LOW logic).
 void TurnOffLED() {
   digitalWrite(LEDB, HIGH);
   digitalWrite(LEDG, HIGH);
   digitalWrite(LEDR, HIGH);
-  delay(2);  // Short delay to ensure state change is registered.
+  delay(2);  // Brief delay to ensure state change.
+}
+
+// Sequentially blinks the RGB LED in a set sequence.
+void ToggleRGB() {
+  Serial.println("Toggling through RGB sequence.");
+  
+  // Blink Red
+  digitalWrite(LEDR, LOW);
+  delay(commandDelay);
+  TurnOffLED();
+  delay(commandDelay);
+  
+  // Blink Green
+  digitalWrite(LEDG, LOW);
+  delay(commandDelay);
+  TurnOffLED();
+  delay(commandDelay);
+  
+  // Blink Blue
+  digitalWrite(LEDB, LOW);
+  delay(commandDelay);
+  TurnOffLED();
+  delay(commandDelay);
 }


### PR DESCRIPTION
### Description

This pull request adds a new example sketch demonstrating how to control the built-in RGB LED on the Arduino Giga R1 WiFi board using Serial commands.

The sketch allows users to:
- Turn on the LED in Red, Green, or Blue colors
- Blink the LED in each color
- Turn off the LED

### File Location

`hardware/arduino/mbed/variants/GIGA/examples/GigaWiFi_RGB_LED_Demo/GigaWiFi_RGB_LED_Demo.ino`

### Why it's useful

This example provides Giga users with an easy, hands-on way to experiment with the built-in RGB LED, using only Serial input — no extra wiring or libraries needed. It’s beginner-friendly and suitable as a built-in reference.

### Tested On

- Arduino Giga R1 WiFi
- Arduino IDE 2.x

### Author

Ahmed Sharaf (Tech Forge International LLC)

🛠️ **Note:** The "Java CI" check is failing due to the use of a deprecated `actions/upload-artifact@v1` in the upstream workflow.  
This is unrelated to the example code in this pull request, which has been tested and works as intended on the Arduino Giga R1 WiFi.
